### PR TITLE
Adding a checkpoint key to disable the write_checkpoint method

### DIFF
--- a/FESTIM/export.py
+++ b/FESTIM/export.py
@@ -189,8 +189,19 @@ def export_xdmf(res, exports, files, t, append):
             raise TypeError('Unexpected' + str(type(fun)) + 'type')
 
         solution.rename(label, "label")
-        files[i].write_checkpoint(
-            solution, label, t, XDMFFile.Encoding.HDF5, append=append)
+        checkpoint = True  # Default value
+        if "checkpoint" in exports["xdmf"].keys():
+            if type(exports["xdmf"]["checkpoint"]) != bool:
+                raise TypeError(
+                    "Unknown value for XDMF checkpoint (True or False)")
+            if exports["xdmf"]["checkpoint"] is False:
+                checkpoint = False
+
+        if checkpoint:
+            files[i].write_checkpoint(
+                solution, label, t, XDMFFile.Encoding.HDF5, append=append)
+        else:
+            files[i].write(solution, t)
     return
 
 


### PR DESCRIPTION
This PR includes a workaround for issue #134 
If need be, the checkpointing can be disabled by assigning the optional `"checkpoint"` key in `parameters["exports"]["xdmf"]`. The default value is `True`. 
However, this will disable the future importation of the exported file.
```python
exports["xdmf"] =  {
        "functions": ['solute'],
        "labels":  ['1'],
        "folder": "Solution",
        "checkpoint": False,
}
```