### PR TITLE
Deprecation of "table" type

### DIFF
--- a/FESTIM/helpers.py
+++ b/FESTIM/helpers.py
@@ -26,7 +26,7 @@ def update_expressions(expressions, t):
 
 
 bc_types = {
-    "dc": ["dc", "solubility", "table"],
+    "dc": ["dc", "solubility"],
     "neumann": ["flux"],
     "robin": ["recomb"]
 }


### PR DESCRIPTION
This PR is related to #231.

The type `"table"` for dirichlet BCs is now deprecated for code simplification. The exact same behaviour can be obtained by defining a time dependent sympy expression in `"dc"` type.