### PR TITLE
XDMF checkpoint 1D warning

### DIFF
--- a/FESTIM/exports/xdmf_export.py
+++ b/FESTIM/exports/xdmf_export.py
@@ -1,7 +1,6 @@
 import warnings
 from FESTIM import Export
 import fenics as f
-warnings.simplefilter('always', DeprecationWarning)
 
 
 class XDMFExport(Export):
@@ -76,6 +75,15 @@ class XDMFExport(Export):
         self.function.rename(self.label, "label")
 
         if self.checkpoint:
+
+            # warn users if checkpoint is True and 1D
+            dimension = self.function.function_space().mesh().topology().dim()
+            if dimension == 1:
+                msg = "in 1D, checkpointing is needed to visualise the XDMF "
+                msg += "file in Paraview (see issue "
+                msg += "https://github.com/RemDelaporteMathurin/FESTIM/issues/134)"
+                warnings.warn(msg)
+
             self.file.write_checkpoint(
                 self.function, self.label, t, f.XDMFFile.Encoding.HDF5,
                 append=self.append)


### PR DESCRIPTION
## Proposed changes

This PR linked to #134 adds a warning to users when trying to export an XDMF file with checkpointing in 1D.

## Types of changes

What types of changes does your code introduce to FESTIM?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
