### PR TITLE
added the setup files for a pip install

### DIFF
--- a/project.toml
+++ b/project.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = [
+    "setuptools >= 45",
+    "wheel",
+    "setuptools_scm[toml] >= 6.2",
+    "setuptools_scm_git_archive",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "FESTIM/_version.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,33 @@
+
+
+[metadata]
+name = FESTIM
+author = Remi Delaporte-Mathurin
+author_email = rdelaportemathurin@gmail.com
+description = Finite element simulations of hydrogen transport
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/RemDelaporteMathurin/FESTIM
+license = None
+license_file = LICENSE
+classifiers =
+    Natural Language :: English
+    Topic :: Scientific/Engineering
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+project_urls =
+    Source = https://github.com/RemDelaporteMathurin/FESTIM
+    Tracker = https://github.com/RemDelaporteMathurin/FESTIM/issues
+
+[options]
+packages = find:
+python_requires= >=3.6
+
+[options.extras_require]
+tests = 
+    pytest >= 5.4.3

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup()


### PR DESCRIPTION
## Proposed changes

This PR fixes #366 by added a bunch of setup files.

Users will now be able to locally install FESTIM by

1. Cloning the repo
2. `cd FESTIM`
3. `python3 setup.py` or installing in develop mode `python3 setup.py develop`

after that, FESTIM can be accessed from anywhere.

This is the foundation of a pip distribution...


## Types of changes

What types of changes does your code introduce to FESTIM?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
