### PR TITLE
Mesh from XDMF files

### DIFF
--- a/examples/tds_example.py
+++ b/examples/tds_example.py
@@ -55,6 +55,7 @@ my_model.reactions = [
         reactant1=mobile_H,
         reactant2=empty_trap1,
         product=trapped_H1,
+        volume=my_subdomain,
     ),
     F.Reaction(
         k_0=4.1e-7 / (1.1e-10**2 * 6 * w_atom_density),
@@ -64,6 +65,7 @@ my_model.reactions = [
         reactant1=mobile_H,
         reactant2=empty_trap2,
         product=trapped_H2,
+        volume=my_subdomain,
     ),
 ]
 

--- a/festim/__init__.py
+++ b/festim/__init__.py
@@ -36,8 +36,10 @@ from .source import Source
 
 from .species import Species, Trap, ImplicitSpecies, find_species_from_name
 
-from .subdomain.surface_subdomain import SurfaceSubdomain1D
-from .subdomain.volume_subdomain import VolumeSubdomain1D, find_volume_from_id
+from .subdomain.surface_subdomain import SurfaceSubdomain, find_surface_from_id
+from .subdomain.surface_subdomain_1d import SurfaceSubdomain1D
+from .subdomain.volume_subdomain import VolumeSubdomain, find_volume_from_id
+from .subdomain.volume_subdomain_1d import VolumeSubdomain1D
 
 from .stepsize import Stepsize
 

--- a/festim/__init__.py
+++ b/festim/__init__.py
@@ -26,6 +26,7 @@ from .material import Material
 
 from .mesh.mesh import Mesh
 from .mesh.mesh_1d import Mesh1D
+from .mesh.mesh_from_xdmf import MeshFromXDMF
 
 from .hydrogen_transport_problem import HydrogenTransportProblem
 

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -172,6 +172,10 @@ class HydrogenTransportProblem:
         return [s for s in self.subdomains if isinstance(s, F.VolumeSubdomain)]
 
     @property
+    def surface_subdomains(self):
+        return [s for s in self.subdomains if isinstance(s, F.SurfaceSubdomain)]
+
+    @property
     def species(self):
         return self._species
 
@@ -403,7 +407,8 @@ class HydrogenTransportProblem:
 
         elif isinstance(self.mesh, F.Mesh1D):
             self.facet_meshtags, self.volume_meshtags = self.mesh.define_meshtags(
-                subdomains=self.subdomains,
+                surface_subdomains=self.surface_subdomains,
+                volume_subdomains=self.volume_subdomains,
             )
         elif isinstance(self.mesh, F.Mesh):
             # FIXME # refer to issue #647

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -172,10 +172,6 @@ class HydrogenTransportProblem:
         return [s for s in self.subdomains if isinstance(s, F.VolumeSubdomain)]
 
     @property
-    def surface_subdomains(self):
-        return [s for s in self.subdomains if isinstance(s, F.SurfaceSubdomain)]
-
-    @property
     def species(self):
         return self._species
 
@@ -408,7 +404,6 @@ class HydrogenTransportProblem:
         elif isinstance(self.mesh, F.Mesh1D):
             self.facet_meshtags, self.volume_meshtags = self.mesh.define_meshtags(
                 subdomains=self.subdomains,
-                volume_subdomains=self.volume_subdomains,
             )
         elif isinstance(self.mesh, F.Mesh):
             # FIXME # refer to issue #647

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -40,10 +40,8 @@ class HydrogenTransportProblem:
         ds (dolfinx.fem.ds): the surface measure of the model
         function_space (dolfinx.fem.FunctionSpace): the function space of the
             model
-        facet_meshtags (dolfinx.mesh.MeshTags): the facet tags of the model
+        facet_meshtags (dolfinx.mesh.MeshTags): the facet meshtags of the model
         volume_meshtags (dolfinx.mesh.MeshTags): the volume meshtags of the
-            model
-        surface_meshtags (dolfinx.mesh.MeshTags): the surface meshtags of the
             model
         formulation (ufl.form.Form): the formulation of the model
         solver (dolfinx.nls.newton.NewtonSolver): the solver of the model
@@ -59,6 +57,10 @@ class HydrogenTransportProblem:
             over domain
         V_DG_1 (dolfinx.fem.FunctionSpace): A DG function space of degree 1
             over domain
+        volume_subdomains (list of festim.VolumeSubdomain): the volume subdomains
+            of the model
+        surface_subdomains (list of festim.SurfaceSubdomain): the surface subdomains
+            of the model
 
 
     Usage:

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -109,8 +109,6 @@ class HydrogenTransportProblem:
         self.formulation = None
         self.bc_forms = []
         self.temperature_fenics = None
-        # self.surface_subdomains = []
-        # self.volume_subdomains = []
 
     @property
     def temperature(self):
@@ -160,19 +158,11 @@ class HydrogenTransportProblem:
 
     @property
     def volume_subdomains(self):
-        values = []
-        for subdom in self.subdomains:
-            if isinstance(subdom, F.VolumeSubdomain):
-                values.append(subdom)
-        return values
+        return [s for s in self.subdomains if isinstance(s, F.VolumeSubdomain)]
 
     @property
     def surface_subdomains(self):
-        values = []
-        for subdom in self.subdomains:
-            if isinstance(subdom, F.SurfaceSubdomain):
-                values.append(subdom)
-        return values
+        return [s for s in self.subdomains if isinstance(s, F.SurfaceSubdomain)]
 
     def initialise(self):
         self.define_function_spaces()

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -175,6 +175,7 @@ class HydrogenTransportProblem:
     def surface_subdomains(self):
         return [s for s in self.subdomains if isinstance(s, F.SurfaceSubdomain)]
 
+    @property
     def species(self):
         return self._species
 

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -41,7 +41,9 @@ class HydrogenTransportProblem:
         function_space (dolfinx.fem.FunctionSpace): the function space of the
             model
         facet_meshtags (dolfinx.mesh.MeshTags): the facet tags of the model
-        volume_meshtags (dolfinx.mesh.MeshTags): the volume tags of the
+        volume_meshtags (dolfinx.mesh.MeshTags): the volume meshtags of the
+            model
+        surface_meshtags (dolfinx.mesh.MeshTags): the surface meshtags of the
             model
         formulation (ufl.form.Form): the formulation of the model
         solver (dolfinx.nls.newton.NewtonSolver): the solver of the model
@@ -166,7 +168,7 @@ class HydrogenTransportProblem:
 
     def initialise(self):
         self.define_function_spaces()
-        self.define_markers_and_measures()
+        self.define_meshtags_and_measures()
         self.assign_functions_to_species()
 
         self.t = fem.Constant(self.mesh.mesh, 0.0)
@@ -372,12 +374,13 @@ class HydrogenTransportProblem:
             spe.prev_solution = sub_prev_solution[idx]
             spe.test_function = sub_test_functions[idx]
 
-    def define_markers_and_measures(self):
-        """Defines the markers and measures of the model"""
+    def define_meshtags_and_measures(self):
+        """Defines the facet and volume meshtags of the model which are used
+        to define the measures fo the model, dx and ds"""
 
         if isinstance(self.mesh, F.MeshFromXDMF):
-            self.facet_meshtags = self.mesh.define_surface_markers()
-            self.volume_meshtags = self.mesh.define_volume_markers()
+            self.facet_meshtags = self.mesh.define_surface_meshtags()
+            self.volume_meshtags = self.mesh.define_volume_meshtags()
 
         else:
             facet_indices, tags_facets = [], []

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -109,8 +109,8 @@ class HydrogenTransportProblem:
         self.formulation = None
         self.bc_forms = []
         self.temperature_fenics = None
-        self.surface_subdomains = []
-        self.volume_subdomains = []
+        # self.surface_subdomains = []
+        # self.volume_subdomains = []
 
     @property
     def temperature(self):
@@ -157,6 +157,22 @@ class HydrogenTransportProblem:
     @property
     def multispecies(self):
         return len(self.species) > 1
+
+    @property
+    def volume_subdomains(self):
+        values = []
+        for subdom in self.subdomains:
+            if isinstance(subdom, F.VolumeSubdomain):
+                values.append(subdom)
+        return values
+
+    @property
+    def surface_subdomains(self):
+        values = []
+        for subdom in self.subdomains:
+            if isinstance(subdom, F.SurfaceSubdomain):
+                values.append(subdom)
+        return values
 
     def initialise(self):
         self.define_function_spaces()
@@ -382,11 +398,6 @@ class HydrogenTransportProblem:
             tags_volumes = np.full(num_cells, 0, dtype=np.int32)
 
             for sub_dom in self.subdomains:
-                if isinstance(sub_dom, F.SurfaceSubdomain):
-                    self.surface_subdomains.append(sub_dom)
-                if isinstance(sub_dom, F.VolumeSubdomain):
-                    self.volume_subdomains.append(sub_dom)
-
                 if isinstance(sub_dom, F.SurfaceSubdomain1D):
                     facet_index = sub_dom.locate_boundary_facet_indices(
                         self.mesh.mesh, self.mesh.fdim

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -430,11 +430,6 @@ class HydrogenTransportProblem:
             if isinstance(self.mesh, F.Mesh1D):
                 self.mesh.check_borders(self.volume_subdomains)
 
-            # check volume ids are unique
-            vol_ids = [vol.id for vol in self.volume_subdomains]
-            if len(vol_ids) != len(np.unique(vol_ids)):
-                raise ValueError("Volume ids are not unique")
-
             # dofs and tags need to be in np.in32 format for meshtags
             facet_indices = np.array(facet_indices, dtype=np.int32)
             tags_facets = np.array(tags_facets, dtype=np.int32)
@@ -446,6 +441,11 @@ class HydrogenTransportProblem:
             self.volume_meshtags = meshtags(
                 self.mesh.mesh, self.mesh.vdim, mesh_cell_indices, tags_volumes
             )
+
+        # check volume ids are unique
+        vol_ids = [vol.id for vol in self.volume_subdomains]
+        if len(vol_ids) != len(np.unique(vol_ids)):
+            raise ValueError("Volume ids are not unique")
 
         # define measures
         self.ds = ufl.Measure(

--- a/festim/mesh/mesh_1d.py
+++ b/festim/mesh/mesh_1d.py
@@ -82,16 +82,14 @@ class Mesh1D(F.Mesh):
         tags_volumes = np.full(num_cells, 0, dtype=np.int32)
 
         for surf in surface_subdomains:
-            if isinstance(surf, F.SurfaceSubdomain1D):
-                facet_index = surf.locate_boundary_facet_indices(self.mesh, self.fdim)
-                facet_indices.append(facet_index)
-                tags_facets.append(surf.id)
+            facet_index = surf.locate_boundary_facet_indices(self.mesh, self.fdim)
+            facet_indices.append(facet_index)
+            tags_facets.append(surf.id)
 
         for vol in volume_subdomains:
-            if isinstance(vol, F.VolumeSubdomain1D):
-                # find all cells in subdomain and mark them as sub_dom.id
-                entities = vol.locate_subdomain_entities(self.mesh, self.vdim)
-                tags_volumes[entities] = vol.id
+            # find all cells in subdomain and mark them as sub_dom.id
+            entities = vol.locate_subdomain_entities(self.mesh, self.vdim)
+            tags_volumes[entities] = vol.id
 
         # check if all borders are defined
         self.check_borders(volume_subdomains)

--- a/festim/mesh/mesh_1d.py
+++ b/festim/mesh/mesh_1d.py
@@ -20,8 +20,8 @@ class Mesh1D(F.Mesh):
     def __init__(self, vertices, **kwargs) -> None:
         self.vertices = vertices
 
-        self.mesh = self.generate_mesh()
-        super().__init__(mesh=self.mesh, **kwargs)
+        mesh = self.generate_mesh()
+        super().__init__(mesh=mesh, **kwargs)
 
     def generate_mesh(self):
         """Generates a 1D mesh"""
@@ -63,18 +63,18 @@ class Mesh1D(F.Mesh):
         ):
             raise ValueError("borders dont match domain borders")
 
-    def define_meshtags(self, subdomains, volume_subdomains):
+    def define_meshtags(self, subdomains):
         """Defines the facet and volume meshtags of the mesh
 
         Args:
             subdomains (list of festim.SufaceSubdomains and/or festim.VolumeSubdomains): the subdomains of the model
-            volume_subdomains (list of festim.VolumeSubdomains): the volume subdomains of the model
 
         Returns:
             dolfinx.mesh.MeshTags: the facet meshtags
             dolfinx.mesh.MeshTags: the volume meshtags
         """
         facet_indices, tags_facets = [], []
+        volume_subdomains = []
 
         # find all cells in domain and mark them as 0
         num_cells = self.mesh.topology.index_map(self.vdim).size_local
@@ -90,6 +90,7 @@ class Mesh1D(F.Mesh):
                 tags_facets.append(sub_dom.id)
             if isinstance(sub_dom, F.VolumeSubdomain1D):
                 # find all cells in subdomain and mark them as sub_dom.id
+                volume_subdomains.append(sub_dom)
                 entities = sub_dom.locate_subdomain_entities(self.mesh, self.vdim)
                 tags_volumes[entities] = sub_dom.id
 

--- a/festim/mesh/mesh_from_xdmf.py
+++ b/festim/mesh/mesh_from_xdmf.py
@@ -1,0 +1,62 @@
+from dolfinx.io import XDMFFile
+from mpi4py import MPI
+import festim as F
+
+
+class MeshFromXDMF(F.Mesh):
+    """
+    Mesh read from the XDMF files
+
+    Args:
+        volume_file (str): path to the volume file
+        facet_file (str): path to the facet file
+        mesh_name (str, optional): name of the mesh in the XDMF file. Defaults to "Grid".
+        meshtags_name (str, optional): name of the meshtags in the XDMF file. Defaults to "Grid".
+
+    Attributes:
+        volume_file (str): path to the volume file
+        facet_file (str): path to the facet file
+        mesh_name (str, optional): name of the mesh in the XDMF file. Defaults to "Grid".
+        meshtags_name (str, optional): name of the meshtags in the XDMF file. Defaults to "Grid".
+        mesh (fenics.mesh.Mesh): the mesh
+    """
+
+    def __init__(
+        self, volume_file, facet_file, mesh_name="Grid", meshtags_name="Grid"
+    ) -> None:
+        self.volume_file = volume_file
+        self.facet_file = facet_file
+        self.mesh_name = mesh_name
+        self.meshtags_name = meshtags_name
+
+        volumes_file = XDMFFile(MPI.COMM_WORLD, self.volume_file, "r")
+        mesh = volumes_file.read_mesh(name=f"{self.mesh_name}")
+
+        super().__init__(mesh=mesh)
+
+    def define_surface_markers(self):
+        """Creates the facet meshtags
+
+        Returns:
+            dolfinx.MeshTags: the facet meshtags
+        """
+        facets_file = XDMFFile(MPI.COMM_WORLD, self.facet_file, "r")
+        facet_meshtags = facets_file.read_meshtags(
+            self.mesh, name=f"{self.meshtags_name}"
+        )
+
+        return facet_meshtags
+
+    def define_volume_markers(self):
+        """Creates the volume meshtags
+
+        Returns:
+            dolfinx.MeshTags: the volume meshtags
+        """
+        volume_file = XDMFFile(MPI.COMM_WORLD, self.volume_file, "r")
+
+        volume_meshtags = volume_file.read_meshtags(
+            self.mesh, name=f"{self.meshtags_name}"
+        )
+
+        return volume_meshtags

--- a/festim/mesh/mesh_from_xdmf.py
+++ b/festim/mesh/mesh_from_xdmf.py
@@ -18,7 +18,7 @@ class MeshFromXDMF(F.Mesh):
         facet_file (str): path to the facet file
         mesh_name (str, optional): name of the mesh in the XDMF file. Defaults to "Grid".
         meshtags_name (str, optional): name of the meshtags in the XDMF file. Defaults to "Grid".
-        mesh (fenics.mesh.Mesh): the mesh
+        mesh (fenics.mesh.Mesh): the fenics mesh
     """
 
     def __init__(

--- a/festim/mesh/mesh_from_xdmf.py
+++ b/festim/mesh/mesh_from_xdmf.py
@@ -16,25 +16,31 @@ class MeshFromXDMF(F.Mesh):
     Attributes:
         volume_file (str): path to the volume file
         facet_file (str): path to the facet file
-        mesh_name (str, optional): name of the mesh in the XDMF file. Defaults to "Grid".
-        meshtags_name (str, optional): name of the meshtags in the XDMF file. Defaults to "Grid".
+        mesh_name (str): name of the mesh in the XDMF file. Defaults to "Grid".
+        meshtags_name (str): name of the meshtags in the XDMF file. Defaults to "Grid".
         mesh (fenics.mesh.Mesh): the fenics mesh
     """
 
     def __init__(
-        self, volume_file, facet_file, mesh_name="Grid", meshtags_name="Grid"
+        self,
+        volume_file,
+        facet_file,
+        mesh_name="Grid",
+        surface_meshtags_name="Grid",
+        volume_meshtags_name="Grid",
     ) -> None:
         self.volume_file = volume_file
         self.facet_file = facet_file
         self.mesh_name = mesh_name
-        self.meshtags_name = meshtags_name
+        self.surface_meshtags_name = surface_meshtags_name
+        self.volume_meshtags_name = volume_meshtags_name
 
         volumes_file = XDMFFile(MPI.COMM_WORLD, self.volume_file, "r")
         mesh = volumes_file.read_mesh(name=f"{self.mesh_name}")
 
         super().__init__(mesh=mesh)
 
-    def define_surface_markers(self):
+    def define_surface_meshtags(self):
         """Creates the facet meshtags
 
         Returns:
@@ -42,12 +48,12 @@ class MeshFromXDMF(F.Mesh):
         """
         facets_file = XDMFFile(MPI.COMM_WORLD, self.facet_file, "r")
         facet_meshtags = facets_file.read_meshtags(
-            self.mesh, name=f"{self.meshtags_name}"
+            self.mesh, name=f"{self.surface_meshtags_name}"
         )
 
         return facet_meshtags
 
-    def define_volume_markers(self):
+    def define_volume_meshtags(self):
         """Creates the volume meshtags
 
         Returns:
@@ -56,7 +62,7 @@ class MeshFromXDMF(F.Mesh):
         volume_file = XDMFFile(MPI.COMM_WORLD, self.volume_file, "r")
 
         volume_meshtags = volume_file.read_meshtags(
-            self.mesh, name=f"{self.meshtags_name}"
+            self.mesh, name=f"{self.volume_meshtags_name}"
         )
 
         return volume_meshtags

--- a/festim/mesh/mesh_from_xdmf.py
+++ b/festim/mesh/mesh_from_xdmf.py
@@ -10,14 +10,19 @@ class MeshFromXDMF(F.Mesh):
     Args:
         volume_file (str): path to the volume file
         facet_file (str): path to the facet file
-        mesh_name (str, optional): name of the mesh in the XDMF file. Defaults to "Grid".
-        meshtags_name (str, optional): name of the meshtags in the XDMF file. Defaults to "Grid".
+        mesh_name (str, optional): name of the mesh in the volume XDMF file.
+            Defaults to "Grid".
+        surface_meshtags_name (str, optional): name of the surface meshtags in the
+            facet XDMF file. Defaults to "Grid".
+        volume_meshtags_name (str, optional): name of the volume meshtags in the
+            volume XDMF file. Defaults to "Grid".
 
     Attributes:
         volume_file (str): path to the volume file
         facet_file (str): path to the facet file
-        mesh_name (str): name of the mesh in the XDMF file. Defaults to "Grid".
-        meshtags_name (str): name of the meshtags in the XDMF file. Defaults to "Grid".
+        mesh_name (str): name of the mesh in the volume XDMF file.
+        surface_meshtags_name (str): name of the surface meshtags in the facet XDMF file.
+        volume_meshtags_name (str): name of the volume meshtags in the volume XDMF file
         mesh (fenics.mesh.Mesh): the fenics mesh
     """
 

--- a/festim/subdomain/surface_subdomain.py
+++ b/festim/subdomain/surface_subdomain.py
@@ -1,40 +1,31 @@
-import dolfinx.mesh
-import numpy as np
-
-
-class SurfaceSubdomain1D:
+class SurfaceSubdomain:
     """
-    Surface subdomain class for 1D cases
+    Surface subdomain class
 
     Args:
         id (int): the id of the surface subdomain
-        x (float): the x coordinate of the surface subdomain
-
-    Attributes:
-        id (int): the id of the surface subdomain
-        x (float): the x coordinate of the surface subdomain
-
-    Usage:
-        >>> surf_subdomain = F.SurfaceSubdomain1D(id=1, x=1)
     """
 
-    def __init__(self, id, x) -> None:
+    def __init__(self, id):
         self.id = id
-        self.x = x
 
-    def locate_boundary_facet_indices(self, mesh, fdim):
-        """Locates the dof of the surface subdomain within the function space
-        and return the index of the dof
 
-        Args:
-            mesh (dolfinx.mesh.Mesh): the mesh of the simulation
-            fdim (int): the dimension of the model facets
+def find_surface_from_id(id: int, surfaces: list):
+    """Returns the correct surface subdomain object from a list of surface ids
+    based on an int
 
-        Returns:
-            index (np.array): the first value in the list of surface facet
-                indices of the subdomain
-        """
-        indices = dolfinx.mesh.locate_entities_boundary(
-            mesh, fdim, lambda x: np.isclose(x[0], self.x)
-        )
-        return indices[0]
+    Args:
+        id (int): the id of the surface subdomain
+        surfaces (list of F.SurfaceSubdomain): the list of surfaces
+
+    Returns:
+        festim.SurfaceSubdomain: the surface subdomain object with the correct id
+
+    Raises:
+        ValueError: if the surface name is not found in the list of surfaces
+
+    """
+    for surf in surfaces:
+        if surf.id == id:
+            return surf
+    raise ValueError(f"id {id} not found in list of surfaces")

--- a/festim/subdomain/surface_subdomain_1d.py
+++ b/festim/subdomain/surface_subdomain_1d.py
@@ -1,0 +1,41 @@
+import dolfinx.mesh
+import numpy as np
+import festim as F
+
+
+class SurfaceSubdomain1D(F.SurfaceSubdomain):
+    """
+    Surface subdomain class for 1D cases
+
+    Args:
+        id (int): the id of the surface subdomain
+        x (float): the x coordinate of the surface subdomain
+
+    Attributes:
+        id (int): the id of the surface subdomain
+        x (float): the x coordinate of the surface subdomain
+
+    Usage:
+        >>> surf_subdomain = F.SurfaceSubdomain1D(id=1, x=1)
+    """
+
+    def __init__(self, id, x) -> None:
+        super().__init__(id)
+        self.x = x
+
+    def locate_boundary_facet_indices(self, mesh, fdim):
+        """Locates the dof of the surface subdomain within the function space
+        and return the index of the dof
+
+        Args:
+            mesh (dolfinx.mesh.Mesh): the mesh of the simulation
+            fdim (int): the dimension of the model facets
+
+        Returns:
+            index (np.array): the first value in the list of surface facet
+                indices of the subdomain
+        """
+        indices = dolfinx.mesh.locate_entities_boundary(
+            mesh, fdim, lambda x: np.isclose(x[0], self.x)
+        )
+        return indices[0]

--- a/festim/subdomain/volume_subdomain.py
+++ b/festim/subdomain/volume_subdomain.py
@@ -6,8 +6,9 @@ class VolumeSubdomain:
         id (int): the id of the volume subdomain
     """
 
-    def __init__(self, id):
+    def __init__(self, id, material):
         self.id = id
+        self.material = material
 
 
 def find_volume_from_id(id: int, volumes: list):

--- a/festim/subdomain/volume_subdomain.py
+++ b/festim/subdomain/volume_subdomain.py
@@ -1,48 +1,13 @@
-from dolfinx.mesh import locate_entities
-import numpy as np
-
-
-class VolumeSubdomain1D:
+class VolumeSubdomain:
     """
-    Volume subdomain class for 1D cases
+    Volume subdomain class
 
     Args:
         id (int): the id of the volume subdomain
-        borders (list of float): the borders of the volume subdomain
-        material (festim.Material): the material of the volume subdomain
-
-    Attributes:
-        id (int): the id of the volume subdomain
-        borders (list of float): the borders of the volume subdomain
-        material (festim.Material): the material of the volume subdomain
-
-    Usage:
-        >>> vol_subdomain = F.VolumeSubdomain1D(id=1, borders=[0, 1],
-        ...     material=F.Material(...))
     """
 
-    def __init__(self, id, borders, material) -> None:
-        self.borders = borders
-        self.material = material
+    def __init__(self, id):
         self.id = id
-
-    def locate_subdomain_entities(self, mesh, vdim):
-        """Locates all cells in subdomain borders within domain
-
-        Args:
-            mesh (dolfinx.mesh.Mesh): the mesh of the model
-            vdim (int): the dimension of the volumes of the mesh,
-                for 1D this is always 1
-
-        Returns:
-            entities (np.array): the entities of the subdomain
-        """
-        entities = locate_entities(
-            mesh,
-            vdim,
-            lambda x: np.logical_and(x[0] >= self.borders[0], x[0] <= self.borders[1]),
-        )
-        return entities
 
 
 def find_volume_from_id(id: int, volumes: list):
@@ -54,7 +19,7 @@ def find_volume_from_id(id: int, volumes: list):
         volumes (list): the list of volumes
 
     Returns:
-        volume (festim.VolumeSubdomain1D): the volume subdomain object with the correct id
+        festim.VolumeSubdomain: the volume subdomain object with the correct id
 
     Raises:
         ValueError: if the volume name is not found in the list of volumes

--- a/festim/subdomain/volume_subdomain_1d.py
+++ b/festim/subdomain/volume_subdomain_1d.py
@@ -23,9 +23,8 @@ class VolumeSubdomain1D(F.VolumeSubdomain):
     """
 
     def __init__(self, id, borders, material) -> None:
-        super().__init__(id)
+        super().__init__(id, material)
         self.borders = borders
-        self.material = material
 
     def locate_subdomain_entities(self, mesh, vdim):
         """Locates all cells in subdomain borders within domain

--- a/festim/subdomain/volume_subdomain_1d.py
+++ b/festim/subdomain/volume_subdomain_1d.py
@@ -1,0 +1,46 @@
+from dolfinx.mesh import locate_entities
+import numpy as np
+import festim as F
+
+
+class VolumeSubdomain1D(F.VolumeSubdomain):
+    """
+    Volume subdomain class for 1D cases
+
+    Args:
+        id (int): the id of the volume subdomain
+        borders (list of float): the borders of the volume subdomain
+        material (festim.Material): the material of the volume subdomain
+
+    Attributes:
+        id (int): the id of the volume subdomain
+        borders (list of float): the borders of the volume subdomain
+        material (festim.Material): the material of the volume subdomain
+
+    Usage:
+        >>> vol_subdomain = F.VolumeSubdomain1D(id=1, borders=[0, 1],
+        ...     material=F.Material(...))
+    """
+
+    def __init__(self, id, borders, material) -> None:
+        super().__init__(id)
+        self.borders = borders
+        self.material = material
+
+    def locate_subdomain_entities(self, mesh, vdim):
+        """Locates all cells in subdomain borders within domain
+
+        Args:
+            mesh (dolfinx.mesh.Mesh): the mesh of the model
+            vdim (int): the dimension of the volumes of the mesh,
+                for 1D this is always 1
+
+        Returns:
+            entities (np.array): the entities of the subdomain
+        """
+        entities = locate_entities(
+            mesh,
+            vdim,
+            lambda x: np.logical_and(x[0] >= self.borders[0], x[0] <= self.borders[1]),
+        )
+        return entities

--- a/test/test_dirichlet_bc.py
+++ b/test/test_dirichlet_bc.py
@@ -66,7 +66,7 @@ def test_callable_for_value():
     )
 
     my_model.define_function_spaces()
-    my_model.define_markers_and_measures()
+    my_model.define_meshtags_and_measures()
 
     T = fem.Constant(my_model.mesh.mesh, 550.0)
     t = fem.Constant(my_model.mesh.mesh, 0.0)
@@ -104,7 +104,7 @@ def test_value_callable_x_t_T():
     )
 
     my_model.define_function_spaces()
-    my_model.define_markers_and_measures()
+    my_model.define_meshtags_and_measures()
 
     T = fem.Constant(my_model.mesh.mesh, 550.0)
     t = fem.Constant(my_model.mesh.mesh, 0.0)
@@ -147,7 +147,7 @@ def test_callable_t_only(value):
     )
 
     my_model.define_function_spaces()
-    my_model.define_markers_and_measures()
+    my_model.define_meshtags_and_measures()
 
     T = fem.Constant(my_model.mesh.mesh, 550.0)
     t = fem.Constant(my_model.mesh.mesh, 0.0)
@@ -190,7 +190,7 @@ def test_callable_x_only():
     )
 
     my_model.define_function_spaces()
-    my_model.define_markers_and_measures()
+    my_model.define_meshtags_and_measures()
 
     T = fem.Constant(my_model.mesh.mesh, 550.0)
     t = fem.Constant(my_model.mesh.mesh, 0.0)

--- a/test/test_h_transport_problem.py
+++ b/test/test_h_transport_problem.py
@@ -245,7 +245,7 @@ def test_define_D_global_different_temperatures():
     )
 
     my_model.define_function_spaces()
-    my_model.define_markers_and_measures()
+    my_model.define_meshtags_and_measures()
     my_model.define_temperature()
 
     D_computed, D_expr = my_model.define_D_global(H)
@@ -280,7 +280,7 @@ def test_define_D_global_different_materials():
     )
 
     my_model.define_function_spaces()
-    my_model.define_markers_and_measures()
+    my_model.define_meshtags_and_measures()
     my_model.define_temperature()
 
     D_computed, D_expr = my_model.define_D_global(H)
@@ -327,7 +327,7 @@ def test_initialise_exports_multiple_exports_same_species():
     )
 
     my_model.define_function_spaces()
-    my_model.define_markers_and_measures()
+    my_model.define_meshtags_and_measures()
     my_model.define_temperature()
     my_model.initialise_exports()
 
@@ -360,7 +360,7 @@ def test_define_D_global_multispecies():
     )
 
     my_model.define_function_spaces()
-    my_model.define_markers_and_measures()
+    my_model.define_meshtags_and_measures()
     my_model.define_temperature()
 
     D_A_computed, D_A_expr = my_model.define_D_global(A)
@@ -405,7 +405,7 @@ def test_post_processing_update_D_global():
     )
 
     my_model.define_function_spaces()
-    my_model.define_markers_and_measures()
+    my_model.define_meshtags_and_measures()
     my_model.t = fem.Constant(my_model.mesh.mesh, 1.0)
     my_model.define_temperature()
     my_model.initialise_exports()
@@ -460,7 +460,7 @@ def test_update_time_dependent_bcs_with_time_dependent_temperature(
     my_model.define_temperature()
     my_model.define_function_spaces()
     my_model.assign_functions_to_species()
-    my_model.define_markers_and_measures()
+    my_model.define_meshtags_and_measures()
     my_model.create_dirichletbc_form(my_bc)
 
     for i in range(3):
@@ -507,7 +507,7 @@ def test_update_time_dependent_values_source(source_value, expected_values):
     my_model.sources = [my_source]
 
     my_model.define_function_spaces()
-    my_model.define_markers_and_measures()
+    my_model.define_meshtags_and_measures()
     my_model.assign_functions_to_species()
     my_model.define_temperature()
     my_model.create_source_values_fenics()
@@ -565,7 +565,7 @@ def test_update_sources_with_time_dependent_temperature(
     my_model.define_temperature()
     my_model.define_function_spaces()
     my_model.assign_functions_to_species()
-    my_model.define_markers_and_measures()
+    my_model.define_meshtags_and_measures()
     my_model.create_source_values_fenics()
 
     for i in range(3):
@@ -600,7 +600,7 @@ def test_create_source_values_fenics_multispecies():
     my_model.sources = [my_source_1, my_source_2]
 
     my_model.define_function_spaces()
-    my_model.define_markers_and_measures()
+    my_model.define_meshtags_and_measures()
     my_model.assign_functions_to_species()
     my_model.define_temperature()
 

--- a/test/test_mesh.py
+++ b/test/test_mesh.py
@@ -50,7 +50,7 @@ def test_meshtags_from_xdmf(tmp_path, mesh):
 
     # create facet meshtags
     facet_indices = []
-    for i in range(1):
+    for i in range(vdim):
         facet_indices.append(
             fenics_mesh.locate_entities_boundary(
                 mesh, fdim, lambda x: np.isclose(x[i], 0)
@@ -62,7 +62,7 @@ def test_meshtags_from_xdmf(tmp_path, mesh):
             )
         )
     facet_tags = []
-    for i in range(2):
+    for i in range(len(facet_indices)):
         facet_tags.append(np.full(len(facet_indices[0]), i + 1, dtype=np.int32))
 
     facet_meshtags = fenics_mesh.meshtags(mesh, fdim, facet_indices, facet_tags)
@@ -107,12 +107,13 @@ def test_meshtags_from_xdmf(tmp_path, mesh):
             volume_file=os.path.join(tmp_path, "volumes_file.xdmf"),
             facet_file=os.path.join(tmp_path, "facets_file.xdmf"),
             mesh_name="mesh",
-            meshtags_name="mesh_tags",
+            surface_meshtags_name="mesh_tags",
+            volume_meshtags_name="mesh_tags",
         )
     )
-    my_model.define_markers_and_measures()
+    my_model.define_meshtags_and_measures()
 
-    # # TEST
+    # TEST
     assert volume_meshtags.dim == my_model.volume_meshtags.dim
     assert volume_meshtags.values.all() == my_model.volume_meshtags.values.all()
     assert facet_meshtags.dim == my_model.facet_meshtags.dim

--- a/test/test_mesh.py
+++ b/test/test_mesh.py
@@ -51,6 +51,7 @@ def test_meshtags_from_xdmf(tmp_path, mesh):
     # create facet meshtags
     facet_indices = []
     for i in range(vdim):
+        # add the boundary entities at 0 and 1 in each dimension
         facet_indices.append(
             fenics_mesh.locate_entities_boundary(
                 mesh, fdim, lambda x: np.isclose(x[i], 0)
@@ -63,14 +64,19 @@ def test_meshtags_from_xdmf(tmp_path, mesh):
         )
     facet_tags = []
     for i in range(len(facet_indices)):
+        # add tags for each boundary
         facet_tags.append(np.full(len(facet_indices[0]), i + 1, dtype=np.int32))
+
+    print(facet_tags)
 
     facet_meshtags = fenics_mesh.meshtags(mesh, fdim, facet_indices, facet_tags)
 
     # create volume meshtags
     num_cells = mesh.topology.index_map(vdim).size_local
     mesh_cell_indices = np.arange(num_cells, dtype=np.int32)
+    # tag all volumes with 0
     tags_volumes = np.full(num_cells, 0, dtype=np.int32)
+    # create 2 volumes for x<0.5 and x>0.5
     volume_indices_left = fenics_mesh.locate_entities(
         mesh,
         vdim,
@@ -82,7 +88,6 @@ def test_meshtags_from_xdmf(tmp_path, mesh):
         vdim,
         lambda x: x[0] >= 0.5,
     )
-
     tags_volumes[volume_indices_left] = 2
     tags_volumes[volume_indices_right] = 3
 

--- a/test/test_mesh.py
+++ b/test/test_mesh.py
@@ -102,17 +102,18 @@ def test_meshtags_from_xdmf(tmp_path, mesh):
     volume_file.write_meshtags(volume_meshtags, mesh.geometry)
 
     # read files
-    my_mesh = F.MeshFromXDMF(
-        volume_file=os.path.join(tmp_path, "volumes_file.xdmf"),
-        facet_file=os.path.join(tmp_path, "facets_file.xdmf"),
-        mesh_name="mesh",
-        meshtags_name="mesh_tags",
+    my_model = F.HydrogenTransportProblem(
+        mesh=F.MeshFromXDMF(
+            volume_file=os.path.join(tmp_path, "volumes_file.xdmf"),
+            facet_file=os.path.join(tmp_path, "facets_file.xdmf"),
+            mesh_name="mesh",
+            meshtags_name="mesh_tags",
+        )
     )
-    facet_meshtags_2 = my_mesh.define_surface_markers()
-    volume_meshtags_2 = my_mesh.define_volume_markers()
+    my_model.define_markers_and_measures()
 
     # # TEST
-    assert volume_meshtags.dim == volume_meshtags_2.dim
-    assert volume_meshtags.values.all() == volume_meshtags_2.values.all()
-    assert facet_meshtags.dim == facet_meshtags_2.dim
-    assert facet_meshtags.values.all() == facet_meshtags_2.values.all()
+    assert volume_meshtags.dim == my_model.volume_meshtags.dim
+    assert volume_meshtags.values.all() == my_model.volume_meshtags.values.all()
+    assert facet_meshtags.dim == my_model.facet_meshtags.dim
+    assert facet_meshtags.values.all() == my_model.facet_meshtags.values.all()

--- a/test/test_mesh.py
+++ b/test/test_mesh.py
@@ -2,6 +2,9 @@ import festim as F
 from dolfinx import mesh as fenics_mesh
 from mpi4py import MPI
 import pytest
+import numpy as np
+import os
+from dolfinx.io import XDMFFile
 
 mesh_1D = fenics_mesh.create_unit_interval(MPI.COMM_WORLD, 10)
 mesh_2D = fenics_mesh.create_unit_square(MPI.COMM_WORLD, 10, 10)
@@ -36,3 +39,80 @@ def test_vdim_changes_when_mesh_changes():
     for mesh in [mesh_1D, mesh_2D, mesh_3D]:
         my_mesh.mesh = mesh
         assert my_mesh.vdim == mesh.topology.dim
+
+
+@pytest.mark.parametrize("mesh", [mesh_1D, mesh_2D, mesh_3D])
+def test_meshtags_from_xdmf(tmp_path, mesh):
+    """Test that the facet and volume meshtags are read correctly from the mesh XDMF files"""
+    # create mesh functions
+    fdim = mesh.topology.dim - 1
+    vdim = mesh.topology.dim
+
+    # create facet meshtags
+    facet_indices = []
+    for i in range(1):
+        facet_indices.append(
+            fenics_mesh.locate_entities_boundary(
+                mesh, fdim, lambda x: np.isclose(x[i], 0)
+            )
+        )
+        facet_indices.append(
+            fenics_mesh.locate_entities_boundary(
+                mesh, fdim, lambda x: np.isclose(x[i], 1)
+            )
+        )
+    facet_tags = []
+    for i in range(2):
+        facet_tags.append(np.full(len(facet_indices[0]), i + 1, dtype=np.int32))
+
+    facet_meshtags = fenics_mesh.meshtags(mesh, fdim, facet_indices, facet_tags)
+
+    # create volume meshtags
+    num_cells = mesh.topology.index_map(vdim).size_local
+    mesh_cell_indices = np.arange(num_cells, dtype=np.int32)
+    tags_volumes = np.full(num_cells, 0, dtype=np.int32)
+    volume_indices_left = fenics_mesh.locate_entities(
+        mesh,
+        vdim,
+        lambda x: x[0] <= 0.5,
+    )
+
+    volume_indices_right = fenics_mesh.locate_entities(
+        mesh,
+        vdim,
+        lambda x: x[0] >= 0.5,
+    )
+
+    tags_volumes[volume_indices_left] = 2
+    tags_volumes[volume_indices_right] = 3
+
+    volume_meshtags = fenics_mesh.meshtags(mesh, vdim, mesh_cell_indices, tags_volumes)
+
+    # write files
+    surface_file = XDMFFile(
+        MPI.COMM_WORLD, os.path.join(tmp_path, "facets_file.xdmf"), "w"
+    )
+    surface_file.write_mesh(mesh)
+    surface_file.write_meshtags(facet_meshtags, mesh.geometry)
+
+    volume_file = XDMFFile(
+        MPI.COMM_WORLD, os.path.join(tmp_path, "volumes_file.xdmf"), "w"
+    )
+    volume_file.write_mesh(mesh)
+    volume_file.write_meshtags(volume_meshtags, mesh.geometry)
+
+    # read files
+    my_mesh = F.MeshFromXDMF(
+        volume_file=os.path.join(tmp_path, "volumes_file.xdmf"),
+        facet_file=os.path.join(tmp_path, "facets_file.xdmf"),
+        mesh_name="mesh",
+        meshtags_name="mesh_tags",
+    )
+    facet_meshtags_2 = my_mesh.define_surface_markers()
+    volume_meshtags_2 = my_mesh.define_volume_markers()
+
+    # # TEST
+    assert volume_meshtags.dim == volume_meshtags_2.dim
+    assert volume_meshtags.values.all() == volume_meshtags_2.values.all()
+    assert facet_meshtags.dim == facet_meshtags_2.dim
+    assert facet_meshtags.values.all() == facet_meshtags_2.values.all()

--- a/test/test_subdomains.py
+++ b/test/test_subdomains.py
@@ -21,7 +21,7 @@ def test_different_surface_ids():
     ]
 
     my_test_model.define_function_spaces()
-    my_test_model.define_markers_and_measures()
+    my_test_model.define_meshtags_and_measures()
 
     for surf_id in surface_subdomains_ids:
         assert surf_id in np.array(my_test_model.facet_meshtags.values)
@@ -43,7 +43,7 @@ def test_different_volume_ids():
     )
     my_model.subdomains = [vol_subdomain_1, vol_subdomain_2, vol_subdomain_3]
 
-    my_model.define_markers_and_measures()
+    my_model.define_meshtags_and_measures()
 
     for vol_id in vol_subdom_ids:
         assert vol_id in np.array(my_model.volume_meshtags.values)
@@ -134,7 +134,7 @@ def test_ValueError_rasied_when_volume_ids_are_not_unique():
     my_test_model.define_function_spaces()
 
     with pytest.raises(ValueError, match="Volume ids are not unique"):
-        my_test_model.define_markers_and_measures()
+        my_test_model.define_meshtags_and_measures()
 
 
 def test_ValueError_raised_when_id_not_found_in_surface_subdomains():
@@ -146,15 +146,15 @@ def test_ValueError_raised_when_id_not_found_in_surface_subdomains():
         F.find_surface_from_id(3, surfaces)
 
 
-@pytest.mark.parametrize("input", [1, 2, 3, 4])
-def test_find_surface_from_id(input):
+@pytest.mark.parametrize("input_id, output_index", [(1, 2), (4, 0), (7, 1), (9, 3)])
+def test_find_surface_from_id(input_id, output_index):
     """test that the correct surface is returned when input is an int"""
 
-    surf_1 = F.SurfaceSubdomain(id=1)
-    surf_2 = F.SurfaceSubdomain(id=2)
-    surf_3 = F.SurfaceSubdomain(id=3)
-    surf_4 = F.SurfaceSubdomain(id=4)
+    surf_1 = F.SurfaceSubdomain(id=7)
+    surf_2 = F.SurfaceSubdomain1D(id=4, x=0)
+    surf_3 = F.SurfaceSubdomain1D(id=9, x=1)
+    surf_4 = F.SurfaceSubdomain(id=1)
 
-    surfaces = [surf_1, surf_2, surf_3, surf_4]
+    surfaces = [surf_2, surf_1, surf_4, surf_3]
 
-    assert F.find_volume_from_id(input, surfaces) == surfaces[input - 1]
+    assert F.find_surface_from_id(input_id, surfaces) == surfaces[output_index]

--- a/test/test_subdomains.py
+++ b/test/test_subdomains.py
@@ -176,3 +176,7 @@ def test_volume_subdomain_properties():
     assert len(my_model.volume_subdomains) == 2
     for subdomain in my_model.volume_subdomains:
         assert isinstance(subdomain, F.VolumeSubdomain)
+
+    assert len(my_model.surface_subdomains) == 3
+    for subdomain in my_model.surface_subdomains:
+        assert isinstance(subdomain, F.SurfaceSubdomain)

--- a/test/test_subdomains.py
+++ b/test/test_subdomains.py
@@ -160,8 +160,8 @@ def test_find_surface_from_id(input_id, output_index):
     assert F.find_surface_from_id(input_id, surfaces) == surfaces[output_index]
 
 
-def test_surface_and_volume_subdomain_properties():
-    """Tests that the volume and surface subdomain properies obtain the correct
+def test_volume_subdomain_properties():
+    """Tests that the volume subdomain property obtains the correct
     subdomains from the the model subdomains list"""
 
     my_model = F.HydrogenTransportProblem()
@@ -176,7 +176,3 @@ def test_surface_and_volume_subdomain_properties():
     assert len(my_model.volume_subdomains) == 2
     for subdomain in my_model.volume_subdomains:
         assert isinstance(subdomain, F.VolumeSubdomain)
-
-    assert len(my_model.surface_subdomains) == 3
-    for subdomain in my_model.surface_subdomains:
-        assert isinstance(subdomain, F.SurfaceSubdomain)

--- a/test/test_subdomains.py
+++ b/test/test_subdomains.py
@@ -144,3 +144,17 @@ def test_ValueError_raised_when_id_not_found_in_surface_subdomains():
 
     with pytest.raises(ValueError, match="id 3 not found in list of surfaces"):
         F.find_surface_from_id(3, surfaces)
+
+
+@pytest.mark.parametrize("input", [1, 2, 3, 4])
+def test_find_surface_from_id(input):
+    """test that the correct surface is returned when input is an int"""
+
+    surf_1 = F.SurfaceSubdomain(id=1)
+    surf_2 = F.SurfaceSubdomain(id=2)
+    surf_3 = F.SurfaceSubdomain(id=3)
+    surf_4 = F.SurfaceSubdomain(id=4)
+
+    surfaces = [surf_1, surf_2, surf_3, surf_4]
+
+    assert F.find_volume_from_id(input, surfaces) == surfaces[input - 1]

--- a/test/test_subdomains.py
+++ b/test/test_subdomains.py
@@ -158,3 +158,25 @@ def test_find_surface_from_id(input_id, output_index):
     surfaces = [surf_2, surf_1, surf_4, surf_3]
 
     assert F.find_surface_from_id(input_id, surfaces) == surfaces[output_index]
+
+
+def test_surface_and_volume_subdomain_properties():
+    """Tests that the volume and surface subdomain properies obtain the correct
+    subdomains from the the model subdomains list"""
+
+    my_model = F.HydrogenTransportProblem()
+    my_model.subdomains = [
+        F.SurfaceSubdomain(id=7),
+        F.SurfaceSubdomain1D(id=4, x=0),
+        F.SurfaceSubdomain(id=2),
+        F.VolumeSubdomain(id=1),
+        F.VolumeSubdomain1D(id=9, borders=[0, 1], material=None),
+    ]
+
+    assert len(my_model.volume_subdomains) == 2
+    for subdomain in my_model.volume_subdomains:
+        assert isinstance(subdomain, F.VolumeSubdomain)
+
+    assert len(my_model.surface_subdomains) == 3
+    for subdomain in my_model.surface_subdomains:
+        assert isinstance(subdomain, F.SurfaceSubdomain)

--- a/test/test_subdomains.py
+++ b/test/test_subdomains.py
@@ -109,8 +109,8 @@ def test_find_volume_from_int(input):
     assert F.find_volume_from_id(input, volumes) == volumes[input - 1]
 
 
-def test_ValueError_raised_when_id_not_found_in_volumes():
-    """test that a ValueError is raised when the id is not found in the list of volumes"""
+def test_ValueError_raised_when_id_not_found_in_volumes_subdomains():
+    """test that a ValueError is raised when an id is not found in the list of volume subdomains"""
 
     volumes = [F.VolumeSubdomain1D(id=1, borders=[0, 1], material=None)]
 
@@ -135,3 +135,12 @@ def test_ValueError_rasied_when_volume_ids_are_not_unique():
 
     with pytest.raises(ValueError, match="Volume ids are not unique"):
         my_test_model.define_markers_and_measures()
+
+
+def test_ValueError_raised_when_id_not_found_in_surface_subdomains():
+    """test that a ValueError is raised when an id is not found in the list of surface subdomains"""
+
+    surfaces = [F.SurfaceSubdomain(id=1)]
+
+    with pytest.raises(ValueError, match="id 3 not found in list of surfaces"):
+        F.find_surface_from_id(3, surfaces)

--- a/test/test_subdomains.py
+++ b/test/test_subdomains.py
@@ -169,7 +169,7 @@ def test_surface_and_volume_subdomain_properties():
         F.SurfaceSubdomain(id=7),
         F.SurfaceSubdomain1D(id=4, x=0),
         F.SurfaceSubdomain(id=2),
-        F.VolumeSubdomain(id=1),
+        F.VolumeSubdomain(id=1, material=None),
         F.VolumeSubdomain1D(id=9, borders=[0, 1], material=None),
     ]
 


### PR DESCRIPTION
## Proposed changes

With this change, users can use meshes made in external software as long as they are converted to XDMF, this can be done using [Meshio](https://github.com/nschloe/meshio). @RemDelaporteMathurin perhaps we could add example conversion scripts to the docs.

Usage:
```python 
mesh=F.MeshFromXDMF(
    volume_file="volumes_file.xdmf",
    facet_file="facets_file.xdmf",
)
```

Additional note, the class takes 2 further arguments: `mesh_name` and `meshtags_name`, these are here as the default name for meshes created in dolfinx is "mesh" and "mesh_tags" for meshtags, where as meshes created by meshio puts everything in something called "Grid". 

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
