### PR TITLE
Adaptive stepsize

### DIFF
--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -185,7 +185,9 @@ class HydrogenTransportProblem:
 
         self.t = fem.Constant(self.mesh.mesh, 0.0)
         if self.settings.transient:
-            self.dt = self.settings.stepsize.get_dt(self.mesh.mesh)
+            self.dt = F.as_fenics_constant(
+                self.settings.stepsize.initial_value, self.mesh.mesh
+            )
 
         self.define_temperature()
         self.define_boundary_conditions()

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -185,6 +185,7 @@ class HydrogenTransportProblem:
 
         self.t = fem.Constant(self.mesh.mesh, 0.0)
         if self.settings.transient:
+            # TODO should raise error if no stepsize is provided
             # TODO Should this be an attribute of festim.Stepsize?
             self.dt = F.as_fenics_constant(
                 self.settings.stepsize.initial_value, self.mesh.mesh

--- a/festim/stepsize.py
+++ b/festim/stepsize.py
@@ -40,8 +40,9 @@ class Stepsize:
 
     @growth_factor.setter
     def growth_factor(self, value):
-        if value < 1:
-            raise ValueError("growth factor should be greater than one")
+        if value is not None:
+            if value < 1:
+                raise ValueError("growth factor should be greater than one")
 
         self._growth_factor = value
 
@@ -51,8 +52,9 @@ class Stepsize:
 
     @cutback_factor.setter
     def cutback_factor(self, value):
-        if value > 1:
-            raise ValueError("cutback factor should be smaller than one")
+        if value is not None:
+            if value > 1:
+                raise ValueError("cutback factor should be smaller than one")
 
         self._cutback_factor = value
 

--- a/festim/stepsize.py
+++ b/festim/stepsize.py
@@ -24,11 +24,15 @@ class Stepsize:
         initial_value,
     ) -> None:
         self.initial_value = initial_value
-        self.growth_factor = 1.2
-        self.cutback_factor = 0.8
-        self.target_nb_iterations = 4
+        self.growth_factor = None
+        self.cutback_factor = None
+        self.target_nb_iterations = None
 
         # TODO should this class hold the dt object used in the formulation
+
+    @property
+    def adaptive(self):
+        return self.growth_factor or self.cutback_factor or self.target_nb_iterations
 
     def modify_value(self, value, nb_iterations, t=None):
         if not self.is_adapt(t):

--- a/festim/stepsize.py
+++ b/festim/stepsize.py
@@ -7,6 +7,14 @@ class Stepsize:
 
     Args:
         initial_value (float, int): initial stepsize.
+        grwoth_factor (float, optional): factor by which the stepsize is
+            increased when adapting
+        cutback_factor (float, optional): factor by which the stepsize is
+            decreased when adapting
+        target_nb_iterations (int, optional): number of Newton iterations
+            over (resp. under) which the stepsize is increased
+            (resp. decreased)
+
 
     Attributes:
         initial_value (float, int): initial stepsize.
@@ -22,11 +30,14 @@ class Stepsize:
     def __init__(
         self,
         initial_value,
+        growth_factor=None,
+        cutback_factor=None,
+        target_nb_iterations=None,
     ) -> None:
         self.initial_value = initial_value
-        self.growth_factor = None
-        self.cutback_factor = None
-        self.target_nb_iterations = None
+        self.growth_factor = growth_factor
+        self.cutback_factor = cutback_factor
+        self.target_nb_iterations = target_nb_iterations
 
         # TODO should this class hold the dt object used in the formulation
 

--- a/festim/stepsize.py
+++ b/festim/stepsize.py
@@ -34,6 +34,28 @@ class Stepsize:
     def adaptive(self):
         return self.growth_factor or self.cutback_factor or self.target_nb_iterations
 
+    @property
+    def growth_factor(self):
+        return self._growth_factor
+
+    @growth_factor.setter
+    def growth_factor(self, value):
+        if value < 1:
+            raise ValueError("growth factor should be greater than one")
+
+        self._growth_factor = value
+
+    @property
+    def cutback_factor(self):
+        return self._cutback_factor
+
+    @cutback_factor.setter
+    def cutback_factor(self, value):
+        if value > 1:
+            raise ValueError("cutback factor should be smaller than one")
+
+        self._cutback_factor = value
+
     def modify_value(self, value, nb_iterations, t=None):
         if not self.is_adapt(t):
             return value

--- a/festim/stepsize.py
+++ b/festim/stepsize.py
@@ -28,16 +28,18 @@ class Stepsize:
         self.cutback_factor = 0.8
         self.target_nb_iterations = 4
 
+        # TODO should this class hold the dt object used in the formulation
+
     def modify_value(self, value, nb_iterations, t=None):
         if not self.is_adapt(t):
             return value
 
         if nb_iterations < self.target_nb_iterations:
-            new_value = value * self.growth_factor
+            return value * self.growth_factor
         elif nb_iterations > self.target_nb_iterations:
-            new_value = value * self.cutback_factor
-
-        return new_value
+            return value * self.cutback_factor
+        else:
+            return value
 
     def is_adapt(self, t):
         """

--- a/festim/stepsize.py
+++ b/festim/stepsize.py
@@ -17,12 +17,3 @@ class Stepsize:
         initial_value,
     ) -> None:
         self.initial_value = initial_value
-
-    def get_dt(self, mesh):
-        """Defines the dt value
-        Args:
-            mesh (dolfinx.mesh.Mesh): the domain mesh
-        Returns:
-            fem.Constant: the dt value
-        """
-        return F.as_fenics_constant(self.initial_value, mesh)

--- a/festim/stepsize.py
+++ b/festim/stepsize.py
@@ -17,3 +17,15 @@ class Stepsize:
         initial_value,
     ) -> None:
         self.initial_value = initial_value
+        self.growth_factor = 1.2
+        self.cutback_factor = 0.8
+        self.target_nb_iterations = 4
+
+    def adapt(self, value, nb_iterations):
+        new_value = value
+        if nb_iterations < self.target_nb_iterations:
+            new_value = value * self.growth_factor
+        elif nb_iterations > self.target_nb_iterations:
+            new_value = value * self.cutback_factor
+
+        return new_value

--- a/festim/stepsize.py
+++ b/festim/stepsize.py
@@ -10,6 +10,13 @@ class Stepsize:
 
     Attributes:
         initial_value (float, int): initial stepsize.
+        growth_factor (float): factor by which the stepsize is
+            increased when adapting
+        cutback_factor (float): factor by which the stepsize is
+            decreased when adapting
+        target_nb_iterations (int): number of Newton iterations
+            over (resp. under) which the stepsize is increased
+            (resp. decreased)
     """
 
     def __init__(
@@ -21,11 +28,26 @@ class Stepsize:
         self.cutback_factor = 0.8
         self.target_nb_iterations = 4
 
-    def adapt(self, value, nb_iterations):
-        new_value = value
+    def modify_value(self, value, nb_iterations, t=None):
+        if not self.is_adapt(t):
+            return value
+
         if nb_iterations < self.target_nb_iterations:
             new_value = value * self.growth_factor
         elif nb_iterations > self.target_nb_iterations:
             new_value = value * self.cutback_factor
 
         return new_value
+
+    def is_adapt(self, t):
+        """
+        Methods that defines if the stepsize should be
+        adapted or not
+
+        Args:
+            t (float): the current time
+
+        Returns:
+            bool: True if needs to adapt, False otherwise.
+        """
+        return True

--- a/festim/stepsize.py
+++ b/festim/stepsize.py
@@ -7,7 +7,7 @@ class Stepsize:
 
     Args:
         initial_value (float, int): initial stepsize.
-        grwoth_factor (float, optional): factor by which the stepsize is
+        growth_factor (float, optional): factor by which the stepsize is
             increased when adapting
         cutback_factor (float, optional): factor by which the stepsize is
             decreased when adapting

--- a/festim/stepsize.py
+++ b/festim/stepsize.py
@@ -25,6 +25,7 @@ class Stepsize:
         target_nb_iterations (int): number of Newton iterations
             over (resp. under) which the stepsize is increased
             (resp. decreased)
+        adaptive (bool): True if the stepsize is adaptive, False otherwise.
     """
 
     def __init__(

--- a/test/test_h_transport_problem.py
+++ b/test/test_h_transport_problem.py
@@ -127,6 +127,7 @@ def test_iterate():
     my_model = F.HydrogenTransportProblem()
 
     my_model.settings = F.Settings(atol=1e-6, rtol=1e-6, final_time=10)
+    my_model.settings.stepsize = 2.0
 
     my_model.progress = tqdm.autonotebook.tqdm(
         desc="Solving H transport problem",

--- a/test/test_h_transport_problem.py
+++ b/test/test_h_transport_problem.py
@@ -646,3 +646,75 @@ def test_species_setter():
         match="elements of species must be of type festim.Species not <class 'int'>",
     ):
         my_model.species = [1, 2, 3]
+
+
+def test_adaptive_timestepping_grows():
+    """Tests that the stepsize grows"""
+    # BUILD
+    my_vol = F.VolumeSubdomain1D(id=1, borders=[0, 4], material=dummy_mat)
+    my_model = F.HydrogenTransportProblem(
+        mesh=test_mesh,
+        temperature=500,
+        settings=F.Settings(atol=1e-10, rtol=1e-10, transient=True, final_time=10),
+        subdomains=[my_vol],
+        species=[F.Species("H")],
+    )
+
+    stepsize = F.Stepsize(initial_value=1)
+    stepsize.growth_factor = 1.2
+    stepsize.target_nb_iterations = 100  # force it to always grow
+    my_model.settings.stepsize = stepsize
+
+    my_model.initialise()
+
+    my_model.progress = tqdm.autonotebook.tqdm(
+        desc="Solving H transport problem",
+        total=my_model.settings.final_time,
+        unit_scale=True,
+    )
+
+    # RUN & TEST
+    previous_value = stepsize.initial_value
+    for i in range(10):
+        my_model.iterate()
+
+        # check that the current value is greater than the previous one
+        assert my_model.dt.value > previous_value
+
+        previous_value = float(my_model.dt)
+
+
+def test_adaptive_timestepping_shrinks():
+    """Tests that the stepsize shrinks"""
+    # BUILD
+    my_vol = F.VolumeSubdomain1D(id=1, borders=[0, 4], material=dummy_mat)
+    my_model = F.HydrogenTransportProblem(
+        mesh=test_mesh,
+        temperature=500,
+        settings=F.Settings(atol=1e-10, rtol=1e-10, transient=True, final_time=10),
+        subdomains=[my_vol],
+        species=[F.Species("H")],
+    )
+
+    stepsize = F.Stepsize(initial_value=1)
+    stepsize.cutback_factor = 0.8
+    stepsize.target_nb_iterations = -1  # force it to always shrink
+    my_model.settings.stepsize = stepsize
+
+    my_model.initialise()
+
+    my_model.progress = tqdm.autonotebook.tqdm(
+        desc="Solving H transport problem",
+        total=my_model.settings.final_time,
+        unit_scale=True,
+    )
+
+    # RUN & TEST
+    previous_value = stepsize.initial_value
+    for i in range(10):
+        my_model.iterate()
+
+        # check that the current value is smaller than the previous one
+        assert my_model.dt.value < previous_value
+
+        previous_value = float(my_model.dt)

--- a/test/test_stepsize.py
+++ b/test/test_stepsize.py
@@ -1,0 +1,61 @@
+import festim as F
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize("growth_factor, target", [(10, 5), (1.2, 2), (1, 1)])
+def test_adaptive_stepsize_grows(growth_factor, target):
+    """Checks that the stepsize is increased correctly
+
+    Args:
+        growth_factor (float): the growth factor
+        target (int): the target number of iterations
+    """
+    my_stepsize = F.Stepsize(initial_value=2)
+    my_stepsize.growth_factor = growth_factor
+    my_stepsize.target_nb_iterations = target
+
+    current_value = 2
+    new_value = my_stepsize.modify_value(
+        value=current_value,
+        nb_iterations=my_stepsize.target_nb_iterations - 1,
+    )
+
+    expected_value = current_value * my_stepsize.growth_factor
+    assert np.isclose(new_value, expected_value)
+
+
+@pytest.mark.parametrize("cutback_factor, target", [(10, 5), (1.2, 2), (1, 1)])
+def test_adaptive_stepsize_shrinks(cutback_factor, target):
+    """Checks that the stepsize is shrinks correctly
+
+    Args:
+        cutback_factor (float): the cutback factor
+        target (int): the target number of iterations
+    """
+    my_stepsize = F.Stepsize(initial_value=2)
+    my_stepsize.cutback_factor = cutback_factor
+    my_stepsize.target_nb_iterations = target
+
+    current_value = 2
+    new_value = my_stepsize.modify_value(
+        value=current_value,
+        nb_iterations=my_stepsize.target_nb_iterations + 1,
+    )
+
+    expected_value = current_value * my_stepsize.cutback_factor
+    assert np.isclose(new_value, expected_value)
+
+
+def test_stepsize_is_unchanged():
+    """
+    Checks that the stepsize is unchanged when reaches
+    the target nb iterations
+    """
+    my_stepsize = F.Stepsize(initial_value=2)
+    my_stepsize.target_nb_iterations = 5
+
+    current_value = 2
+    new_value = my_stepsize.modify_value(value=current_value, nb_iterations=5)
+
+    assert np.isclose(new_value, current_value)

--- a/test/test_stepsize.py
+++ b/test/test_stepsize.py
@@ -61,6 +61,20 @@ def test_stepsize_is_unchanged():
     assert np.isclose(new_value, current_value)
 
 
+def test_custom_stepsize_not_adaptive():
+    """Checks that a custom stepsize that isn't adaptive is unchanged"""
+
+    class CustomStepsize(F.Stepsize):
+        def is_adapt(self, t):
+            return False
+
+    my_stepsize = CustomStepsize(initial_value=2)
+    current_value = 2
+    new_value = my_stepsize.modify_value(value=current_value, nb_iterations=5)
+
+    assert np.isclose(new_value, current_value)
+
+
 def test_growth_factor_setter():
     """Checks that the growth factor setter works correctly"""
     stepsize = F.Stepsize(1)

--- a/test/test_stepsize.py
+++ b/test/test_stepsize.py
@@ -59,3 +59,29 @@ def test_stepsize_is_unchanged():
     new_value = my_stepsize.modify_value(value=current_value, nb_iterations=5)
 
     assert np.isclose(new_value, current_value)
+
+
+def test_growth_factor_setter():
+    """Checks that the growth factor setter works correctly"""
+    stepsize = F.Stepsize(1)
+
+    # Test that setting a growth factor less than 1 raises a ValueError
+    with pytest.raises(ValueError, match="growth factor should be greater than one"):
+        stepsize.growth_factor = 0.5
+
+    # Test that setting growth factor to None works
+    stepsize.growth_factor = None
+    assert stepsize.growth_factor is None
+
+
+def test_cutback_factor_setter():
+    """Checks that the cutback factor setter works correctly"""
+    stepsize = F.Stepsize(1)
+
+    # Test that setting a cutback factor greater than 1 raises a ValueError
+    with pytest.raises(ValueError, match="cutback factor should be smaller than one"):
+        stepsize.cutback_factor = 1.5
+
+    # Test that setting cutback factor to None works
+    stepsize.cutback_factor = None
+    assert stepsize.cutback_factor is None

--- a/test/test_stepsize.py
+++ b/test/test_stepsize.py
@@ -25,7 +25,7 @@ def test_adaptive_stepsize_grows(growth_factor, target):
     assert np.isclose(new_value, expected_value)
 
 
-@pytest.mark.parametrize("cutback_factor, target", [(10, 5), (1.2, 2), (1, 1)])
+@pytest.mark.parametrize("cutback_factor, target", [(0.8, 5), (0.5, 2), (1, 1)])
 def test_adaptive_stepsize_shrinks(cutback_factor, target):
     """Checks that the stepsize is shrinks correctly
 


### PR DESCRIPTION
## Proposed changes

This is an attempt at adding adaptive timestepping.

I've taken a [similar approach to MOOSE](https://mooseframework.inl.gov/source/timesteppers/IterationAdaptiveDT.html) where the users give a target number of iterations and a growth factor and a cutback factor.

If the number of newton iterations is larger than the target number, the stepsize is reduced (multiplied by cutback factor). Inversely when it's lower than the target, the stepsize is increased (growth factor).

@jhdark I've noticed we have the concept of the stepsize living in different places.
First we have `HTransportProblem.settings.stepsize` AND `HTransportProblem.dt` (which is just the `fenicsx.Constant` object).
I feel like we should remove this redundancy to improve clarity. Doesn't have to be in this PR but I felt like we could kick off the discussion now

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

