### PR TITLE
Trap convenience class

### DIFF
--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -197,10 +197,7 @@ class HydrogenTransportProblem:
         self._species = value
 
     def initialise(self):
-        # if traps are given, create the necessary objects
-        if len(self.traps) > 0:
-            self.create_species_from_trap()
-
+        self.create_species_from_traps()
         self.define_function_spaces()
         self.define_meshtags_and_measures()
         self.assign_functions_to_species()
@@ -216,13 +213,13 @@ class HydrogenTransportProblem:
         self.create_solver()
         self.initialise_exports()
 
-    def create_species_from_trap(self):
+    def create_species_from_traps(self):
         """Generate a species and reaction per trap defined in self.traps"""
 
         for trap in self.traps:
             trap.create_species_and_reaction()
             self.species.append(trap.trapped_concentration)
-            self.reactions.append(trap.trap_reaction)
+            self.reactions.append(trap.reaction)
 
     def define_temperature(self):
         """Sets the value of temperature_fenics_value. The type depends on

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -26,6 +26,7 @@ class HydrogenTransportProblem:
             conditions of the model
         solver_parameters (dict): the solver parameters of the model
         exports (list of festim.Export): the exports of the model
+        traps (list of F.Trap): the traps of the model
 
     Attributes:
         mesh (festim.Mesh): the mesh of the model
@@ -38,6 +39,7 @@ class HydrogenTransportProblem:
             conditions of the model
         solver_parameters (dict): the solver parameters of the model
         exports (list of festim.Export): the exports of the model
+        traps (list of F.Trap): the traps of the model
         dx (dolfinx.fem.dx): the volume measure of the model
         ds (dolfinx.fem.ds): the surface measure of the model
         function_space (dolfinx.fem.FunctionSpace): the function space of the
@@ -94,6 +96,7 @@ class HydrogenTransportProblem:
         boundary_conditions=[],
         settings=None,
         exports=[],
+        traps=[],
     ) -> None:
         self.mesh = mesh
         self.subdomains = subdomains
@@ -104,6 +107,7 @@ class HydrogenTransportProblem:
         self.boundary_conditions = boundary_conditions
         self.settings = settings
         self.exports = exports
+        self.traps = traps
 
         self.dx = None
         self.ds = None
@@ -179,6 +183,10 @@ class HydrogenTransportProblem:
         self._species = value
 
     def initialise(self):
+        # smth to do with traps here
+        if len(self.traps) >= 1:
+            self.create_species_from_trap()
+
         self.define_function_spaces()
         self.define_markers_and_measures()
         self.assign_functions_to_species()
@@ -193,6 +201,14 @@ class HydrogenTransportProblem:
         self.create_formulation()
         self.create_solver()
         self.initialise_exports()
+
+    def create_species_from_trap(self):
+        """Generate a species and reaction per trap defined in self.traps"""
+
+        for trap in self.traps:
+            trap.create_species_and_reaction()
+            self.species.append(trap.trapped_concentration)
+            self.reactions.append(trap.trap_reaction)
 
     def define_temperature(self):
         """Sets the value of temperature_fenics_value. The type depends on

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -195,7 +195,7 @@ class HydrogenTransportProblem:
 
     def initialise(self):
         # if traps are given, create the necessary objects
-        if len(self.traps) >0:
+        if len(self.traps) > 0:
             self.create_species_from_trap()
 
         self.define_function_spaces()

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -183,7 +183,7 @@ class HydrogenTransportProblem:
         self._species = value
 
     def initialise(self):
-        # smth to do with traps here
+        # if traps are given, create the necessary objects
         if len(self.traps) >= 1:
             self.create_species_from_trap()
 

--- a/festim/species.py
+++ b/festim/species.py
@@ -144,12 +144,15 @@ class Trap(Species):
         self.n = n
         self.volume = volume
 
+        self.trapped_concentration = None
+        self.reaction = None
+
     def create_species_and_reaction(self):
         """create the immobile trapped species object and the reaction for trapping"""
         self.trapped_concentration = F.Species(name=self.name, mobile=False)
         trap_site = F.ImplicitSpecies(n=self.n, others=[self.trapped_concentration])
 
-        self.trap_reaction = F.Reaction(
+        self.reaction = F.Reaction(
             reactant1=self.mobile_species,
             reactant2=trap_site,
             product=self.trapped_concentration,

--- a/festim/species.py
+++ b/festim/species.py
@@ -1,4 +1,5 @@
 from typing import List
+import festim as F
 
 
 class Species:
@@ -62,23 +63,60 @@ class Trap(Species):
 
     Args:
         name (str, optional): a name given to the trap. Defaults to None.
+        species (F.Species): the mobile species to be trapped
+        k_0 (float): the trapping rate constant pre-exponential factor.
+        E_k (float): the trapping rate constant activation energy.
+        p_0 (float): the detrapping rate constant pre-exponential factor.
+        E_p (float): the detrapping rate constant activation energy.
+        volume (F.VolumeSubdomain1D): The volume subdomain where the trap is.
+
 
     Attributes:
-        name (str): a name given to the trap.
-        attributes of Species class
+        name (str, optional): a name given to the trap. Defaults to None.
+        species (F.Species): the mobile species to be trapped
+        k_0 (float): the trapping rate constant pre-exponential factor.
+        E_k (float): the trapping rate constant activation energy.
+        p_0 (float): the detrapping rate constant pre-exponential factor.
+        E_p (float): the detrapping rate constant activation energy.
+        volume (F.VolumeSubdomain1D): The volume subdomain where the trap is.
+        trapped_concentration (F.Species): The immobile trapped concentration
+        trap_reaction (F.Reaction): The reaction for trapping the mobile conc.
 
     Usage:
-        >>> from festim import Trap, HTransportProblem
-        >>> trap = Trap(name="Trap")
+        >>> import festim as F
+        >>> trap = F.Trap(name="Trap", species=H, k_0=1.0, E_k=0.2, p_0=0.1, E_p=0.3, volume=my_vol)
         >>> trap.name
         'Trap'
-        >>> my_model = HTransportProblem()
-        >>> my_model.species.append(trap)
+        >>> my_model = F.HydorgenTransportProblem()
+        >>> my_model.traps = [trap]
 
     """
 
-    def __init__(self, name: str = None) -> None:
+    def __init__(self, name: str, species, k_0, E_k, p_0, E_p, n, volume) -> None:
         super().__init__(name)
+        self.species = species
+        self.k_0 = k_0
+        self.E_k = E_k
+        self.p_0 = p_0
+        self.E_p = E_p
+        self.n = n
+        self.volume = volume
+
+    def create_species_and_reaction(self):
+        """create the immobile trapped species object and the reaction for trapping"""
+        self.trapped_concentration = F.Species(name=self.name, mobile=False)
+        trap_site = F.ImplicitSpecies(n=self.n, others=[self.trapped_concentration])
+
+        self.trap_reaction = F.Reaction(
+            reactant1=self.species,
+            reactant2=trap_site,
+            product=self.trapped_concentration,
+            k_0=self.k_0,
+            E_k=self.E_k,
+            p_0=self.p_0,
+            E_p=self.E_p,
+            volume=self.volume,
+        )
 
 
 class ImplicitSpecies:

--- a/test/test_h_transport_problem.py
+++ b/test/test_h_transport_problem.py
@@ -645,3 +645,25 @@ def test_species_setter():
         match="elements of species must be of type festim.Species not <class 'int'>",
     ):
         my_model.species = [1, 2, 3]
+
+
+def test_create_species_from_trap():
+    "Test that a new species and reaction is created when a trap is given"
+    my_model = F.HydrogenTransportProblem()
+    my_mobile_species = F.Species("test_mobile")
+    my_vol = F.VolumeSubdomain1D(id=1, borders=[0, 1], material=None)
+    my_trap = F.Trap(
+        name="test",
+        species=my_mobile_species,
+        k_0=1,
+        E_k=1,
+        p_0=1,
+        E_p=1,
+        n=1,
+        volume=my_vol,
+    )
+    my_model.traps = [my_trap]
+    my_model.create_species_from_trap()
+
+    assert len(my_model.species) == 1
+    assert len(my_model.reactions) == 1

--- a/test/test_h_transport_problem.py
+++ b/test/test_h_transport_problem.py
@@ -654,7 +654,7 @@ def test_create_species_from_trap():
     my_vol = F.VolumeSubdomain1D(id=1, borders=[0, 1], material=None)
     my_trap = F.Trap(
         name="test",
-        species=my_mobile_species,
+        mobile_species=my_mobile_species,
         k_0=1,
         E_k=1,
         p_0=1,
@@ -666,4 +666,7 @@ def test_create_species_from_trap():
     my_model.create_species_from_trap()
 
     assert len(my_model.species) == 1
+    assert isinstance(my_model.species[0], F.Species)
+    
     assert len(my_model.reactions) == 1
+    assert isinstance(my_model.reactions[0], F.Reaction)

--- a/test/test_h_transport_problem.py
+++ b/test/test_h_transport_problem.py
@@ -667,6 +667,6 @@ def test_create_species_from_trap():
 
     assert len(my_model.species) == 1
     assert isinstance(my_model.species[0], F.Species)
-    
+
     assert len(my_model.reactions) == 1
     assert isinstance(my_model.reactions[0], F.Reaction)

--- a/test/test_species.py
+++ b/test/test_species.py
@@ -135,23 +135,6 @@ def test_create_species_and_reaction():
         volume=my_vol,
     )
 
-    cm = F.Species("mobile")
-    ct = F.Species("trapped")
-    trap_sites = F.ImplicitSpecies(n=1, others=[ct])
-    my_model.species = [cm, ct]
-
-    trap_reaction = F.Reaction(
-        reactant1=cm,
-        reactant2=trap_sites,
-        product=ct,
-        k_0=1,
-        E_k=1,
-        p_0=1,
-        E_p=1,
-        volume=my_vol,
-    )
-    my_model.reactions = [trap_reaction]
-
     # RUN
     my_trap.create_species_and_reaction()
 

--- a/test/test_species.py
+++ b/test/test_species.py
@@ -115,3 +115,29 @@ def test_implicit_species_concentration_with_no_solution():
     # test that a ValueError is raised when the second species has no solution
     with pytest.raises(ValueError):
         implicit_species.concentration
+
+
+def test_create_species_and_reaction():
+    """test that the trapped_concentration and trap_reaction attribites
+    are correctly set"""
+
+    # BUILD
+    my_mobile_species = F.Species("test_mobile")
+    my_vol = F.VolumeSubdomain1D(id=1, borders=[0, 1], material=None)
+    my_trap = F.Trap(
+        name="test",
+        species=my_mobile_species,
+        k_0=1,
+        E_k=1,
+        p_0=1,
+        E_p=1,
+        n=1,
+        volume=my_vol,
+    )
+
+    # RUN
+    my_trap.create_species_and_reaction()
+
+    # TEST
+    assert isinstance(my_trap.trapped_concentration, F.Species)
+    assert isinstance(my_trap.trap_reaction, F.Reaction)

--- a/test/test_species.py
+++ b/test/test_species.py
@@ -126,7 +126,7 @@ def test_create_species_and_reaction():
     my_vol = F.VolumeSubdomain1D(id=1, borders=[0, 1], material=None)
     my_trap = F.Trap(
         name="test",
-        species=my_mobile_species,
+        mobile_species=my_mobile_species,
         k_0=1,
         E_k=1,
         p_0=1,
@@ -134,6 +134,23 @@ def test_create_species_and_reaction():
         n=1,
         volume=my_vol,
     )
+
+    cm = F.Species("mobile")
+    ct = F.Species("trapped")
+    trap_sites = F.ImplicitSpecies(n=1, others=[ct])
+    my_model.species = [cm, ct]
+
+    trap_reaction = F.Reaction(
+        reactant1=cm,
+        reactant2=trap_sites,
+        product=ct,
+        k_0=1,
+        E_k=1,
+        p_0=1,
+        E_p=1,
+        volume=my_vol,
+    )
+    my_model.reactions = [trap_reaction]
 
     # RUN
     my_trap.create_species_and_reaction()

--- a/test/test_species.py
+++ b/test/test_species.py
@@ -140,4 +140,4 @@ def test_create_species_and_reaction():
 
     # TEST
     assert isinstance(my_trap.trapped_concentration, F.Species)
-    assert isinstance(my_trap.trap_reaction, F.Reaction)
+    assert isinstance(my_trap.reaction, F.Reaction)


### PR DESCRIPTION
## Proposed changes

With this update users will be able to give a trap object without having to define a 2 species (immobile and implicit) and a reaction, instead just having a `F.Trap()` object instead and passing it to the new attribute of `F.HydrogenTransporModel`, `traps`. Traps needs to be given as a list like so:

```python
my_trap = F.Trap(
    name="test",
    species=my_mobile_species,
    k_0=1,
    E_k=1,
    p_0=1,
    E_p=1,
    n=1,
    volume=my_vol,
)
my_model.traps = [my_trap]
```

This convenience class should make some simpler hydrogen trapping cases easier for users

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
