### PR TITLE
Fix codecov upload

### DIFF
--- a/.github/workflows/ci_conda.yml
+++ b/.github/workflows/ci_conda.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Echo secret
-      run: echo ${{ secrets.TEST_SECRET }}
+      run: echo $TEST_SECRET
 
     - name: Set up Conda
       uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/ci_conda.yml
+++ b/.github/workflows/ci_conda.yml
@@ -1,9 +1,6 @@
 name: Conda CI
 on: [pull_request, push]
 
-env:
-  CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
-
 jobs:
   run-tests:
     runs-on: ubuntu-latest
@@ -37,6 +34,8 @@ jobs:
     
     - name: Upload to codecov
       uses: codecov/codecov-action@v3
+      env:
+        CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
       with:
         files: ./coverage.xml
         verbose: true

--- a/.github/workflows/ci_conda.yml
+++ b/.github/workflows/ci_conda.yml
@@ -37,3 +37,4 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml
+        verbose: true

--- a/.github/workflows/ci_conda.yml
+++ b/.github/workflows/ci_conda.yml
@@ -4,6 +4,8 @@ on: [pull_request, push]
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
 
     steps:
     - name: Checkout code
@@ -34,8 +36,6 @@ jobs:
     
     - name: Upload to codecov
       uses: codecov/codecov-action@v3
-      env:
-        CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
       with:
         files: ./coverage.xml
         verbose: true

--- a/.github/workflows/ci_conda.yml
+++ b/.github/workflows/ci_conda.yml
@@ -38,4 +38,3 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml
-        verbose: true

--- a/.github/workflows/ci_conda.yml
+++ b/.github/workflows/ci_conda.yml
@@ -9,9 +9,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Echo secret
-      run: echo $TEST_SECRET
-
     - name: Set up Conda
       uses: conda-incubator/setup-miniconda@v2
       with:

--- a/.github/workflows/ci_conda.yml
+++ b/.github/workflows/ci_conda.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Upload to codecov
       uses: codecov/codecov-action@v3
       env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        CODECOV_TOKEN: "blablablabla"
       with:
         files: ./coverage.xml
         verbose: true

--- a/.github/workflows/ci_conda.yml
+++ b/.github/workflows/ci_conda.yml
@@ -9,6 +9,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
+    - name: Echo secret
+      run: echo ${{ secrets.TEST_SECRET }}
+
     - name: Set up Conda
       uses: conda-incubator/setup-miniconda@v2
       with:

--- a/.github/workflows/ci_conda.yml
+++ b/.github/workflows/ci_conda.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - name: Echo secret
-      run: echo $CODECOV_TOKEN
+      run: echo "this is the codecov token $CODECOV_TOKEN"
 
     - name: Echo other secret
-      run: echo $TESTBLABLA
+      run: echo "$TESTBLABLA"
 
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/ci_conda.yml
+++ b/.github/workflows/ci_conda.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Echo secret
-      run: echo "this is the codecov token $CODECOV_TOKEN"
+      run: echo "this is the codecov token $CODECOV_TOKEN over"
 
     - name: Echo other secret
       run: echo "$TESTBLABLA"

--- a/.github/workflows/ci_conda.yml
+++ b/.github/workflows/ci_conda.yml
@@ -1,6 +1,9 @@
 name: Conda CI
 on: [pull_request, push]
 
+env:
+  CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest
@@ -34,8 +37,6 @@ jobs:
     
     - name: Upload to codecov
       uses: codecov/codecov-action@v3
-      env:
-        CODECOV_TOKEN: "blablablabla"
       with:
         files: ./coverage.xml
         verbose: true

--- a/.github/workflows/ci_conda.yml
+++ b/.github/workflows/ci_conda.yml
@@ -8,6 +8,12 @@ jobs:
       CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
 
     steps:
+    - name: Echo secret
+      run: echo $CODECOV_TOKEN
+
+    - name: Echo other secret
+      run: echo $TESTBLABLA
+
     - name: Checkout code
       uses: actions/checkout@v2
 

--- a/.github/workflows/ci_conda.yml
+++ b/.github/workflows/ci_conda.yml
@@ -34,7 +34,8 @@ jobs:
     
     - name: Upload to codecov
       uses: codecov/codecov-action@v3
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml
         verbose: true

--- a/.github/workflows/ci_conda.yml
+++ b/.github/workflows/ci_conda.yml
@@ -12,7 +12,7 @@ jobs:
       run: echo "this is the codecov token $CODECOV_TOKEN over"
 
     - name: Echo other secret
-      run: echo "$TESTBLABLA"
+      run: echo "this is my test secret $TEST_SECRET"
 
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -4,7 +4,7 @@ on: [pull_request, push]
 jobs:
   run-tests:
       env:
-      CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
+        CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
       runs-on: ubuntu-latest
       container: dolfinx/dolfinx:v0.7.0
       steps:

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -3,6 +3,8 @@ on: [pull_request, push]
 
 jobs:
   run-tests:
+      env:
+      CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
       runs-on: ubuntu-latest
       container: dolfinx/dolfinx:v0.7.0
       steps:

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -8,6 +8,9 @@ jobs:
       runs-on: ubuntu-latest
       container: dolfinx/dolfinx:v0.7.0
       steps:
+        - name: Echo secret
+          run: echo $CODECOV_TOKEN
+
         - name: Checkout code
           uses: actions/checkout@v2
       

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,4 @@
+codecov:
+  token: "blablablablablabla"
 ignore:
   - "festim/_version.py"  # ignore version file

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,2 @@
-codecov:
-  token: "blablablablablabla"
 ignore:
   - "festim/_version.py"  # ignore version file


### PR DESCRIPTION
This PR fixes the upload to codecov which randomely failed.
After a long discussion with the codecov team https://github.com/codecov/feedback/issues/180 we found out that the problem was that [the CODECOV_TOKEN secret wasn't passed correctly](https://github.com/festim-dev/FESTIM/actions/runs/7182795041/job/19560097608#step:7:59).

The solution was to define the secret at the job level and not at the step level.

I reported this bug to Github https://github.com/orgs/community/discussions/78847

NOTE: a similar change will have to be done on the main branch