### PR TITLE
Fix bug is_steady_state with TemperatureFromXDMF

### DIFF
--- a/festim/temperature/temperature_from_xdmf.py
+++ b/festim/temperature/temperature_from_xdmf.py
@@ -46,3 +46,7 @@ class TemperatureFromXDMF(Temperature):
         refer to issue #499
         """
         pass
+
+    def is_steady_state(self):
+        # TemperatureFromXDMF is always steady state
+        return True

--- a/test/unit/test_temperature.py
+++ b/test/unit/test_temperature.py
@@ -203,3 +203,23 @@ def test_temperature_from_xdmf_transient_case(tmpdir):
     my_model.settings.final_time = 10
     my_model.initialise()
     my_model.run()
+
+
+def test_temperature_from_xdmf(tmpdir):
+    """
+    Tests that .is_steady_state() can be run for
+    a TemperatureFromXDMF object
+    """
+    mesh = fenics.UnitSquareMesh(10, 10)
+    V = fenics.FunctionSpace(mesh, "CG", 1)
+    expr = fenics.Expression("1 + x[0] + 2*x[1]", degree=2)
+    T = fenics.interpolate(expr, V)
+    # write function to temporary file
+    T_file = str(tmpdir.join("T.xdmf"))
+    fenics.XDMFFile(T_file).write_checkpoint(
+        T, "T", 0, fenics.XDMFFile.Encoding.HDF5, append=False
+    )
+
+    temperature = festim.TemperatureFromXDMF(T_file, "T")
+
+    assert temperature.is_steady_state()


### PR DESCRIPTION
## Proposed changes

This PR fixes the bug reported on [the Discourse](https://festim.discourse.group/t/temperaturefromxdmf-work-in-a-conda-environment).
This is fixed by overriding the `is_steady_state` method

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
