### PR TITLE
Radioactive decay

### DIFF
--- a/docs/source/api/sources.rst
+++ b/docs/source/api/sources.rst
@@ -10,3 +10,7 @@ Sources
 .. autoclass:: ImplantationFlux
     :members:
     :show-inheritance:
+
+.. autoclass:: RadioactiveDecay
+    :members:
+    :show-inheritance:

--- a/festim/__init__.py
+++ b/festim/__init__.py
@@ -90,6 +90,7 @@ from .stepsize import Stepsize
 
 from .sources.source import Source
 from .sources.source_implantation_flux import ImplantationFlux
+from .sources.radioactive_decay import RadioactiveDecay
 
 from .materials.material import Material
 from .materials.materials import Materials

--- a/festim/concentration/mobile.py
+++ b/festim/concentration/mobile.py
@@ -106,38 +106,37 @@ class Mobile(Concentration):
 
         # add the trapping terms
         F_trapping = 0
-        if dt is not None:
-            if traps is not None:
-                for trap in traps.traps:
-                    for i, mat in enumerate(trap.materials):
-                        if type(trap.k_0) is list:
-                            k_0 = trap.k_0[i]
-                            E_k = trap.E_k[i]
-                            p_0 = trap.p_0[i]
-                            E_p = trap.E_p[i]
-                            density = trap.density[i]
-                        else:
-                            k_0 = trap.k_0
-                            E_k = trap.E_k
-                            p_0 = trap.p_0
-                            E_p = trap.E_p
-                            density = trap.density[0]
-                        c_m, _ = self.get_concentration_for_a_given_material(mat, T)
-                        F_trapping += (
-                            -k_0
-                            * exp(-E_k / k_B / T.T)
-                            * c_m
-                            * (density - trap.solution)
-                            * self.test_function
-                            * dx(mat.id)
-                        )
-                        F_trapping += (
-                            p_0
-                            * exp(-E_p / k_B / T.T)
-                            * trap.solution
-                            * self.test_function
-                            * dx(mat.id)
-                        )
+        if traps is not None:
+            for trap in traps.traps:
+                for i, mat in enumerate(trap.materials):
+                    if type(trap.k_0) is list:
+                        k_0 = trap.k_0[i]
+                        E_k = trap.E_k[i]
+                        p_0 = trap.p_0[i]
+                        E_p = trap.E_p[i]
+                        density = trap.density[i]
+                    else:
+                        k_0 = trap.k_0
+                        E_k = trap.E_k
+                        p_0 = trap.p_0
+                        E_p = trap.E_p
+                        density = trap.density[0]
+                    c_m, _ = self.get_concentration_for_a_given_material(mat, T)
+                    F_trapping += (
+                        -k_0
+                        * exp(-E_k / k_B / T.T)
+                        * c_m
+                        * (density - trap.solution)
+                        * self.test_function
+                        * dx(mat.id)
+                    )
+                    F_trapping += (
+                        p_0
+                        * exp(-E_p / k_B / T.T)
+                        * trap.solution
+                        * self.test_function
+                        * dx(mat.id)
+                    )
         F += -F_trapping
 
         self.F_diffusion = F

--- a/festim/concentration/mobile.py
+++ b/festim/concentration/mobile.py
@@ -133,7 +133,7 @@ class Mobile(Concentration):
             else:
                 volumes = [source.volume]
             if isinstance(source, RadioactiveDecay):
-                source.value = -source.form(self.mobile_concentration())
+                source.value = source.form(self.mobile_concentration())
 
             for volume in volumes:
                 F_source += -source.value * self.test_function * dx(volume)

--- a/festim/concentration/mobile.py
+++ b/festim/concentration/mobile.py
@@ -105,15 +105,42 @@ class Mobile(Concentration):
                         * dx
                     )
 
-        # add the traps transient terms
+        # add the trapping terms
+        F_trapping = 0
         if dt is not None:
             if traps is not None:
                 for trap in traps.traps:
-                    F += (
-                        ((trap.solution - trap.previous_solution) / dt.value)
-                        * self.test_function
-                        * mesh.dx
-                    )
+                    for i, mat in enumerate(trap.materials):
+                        if type(trap.k_0) is list:
+                            k_0 = trap.k_0[i]
+                            E_k = trap.E_k[i]
+                            p_0 = trap.p_0[i]
+                            E_p = trap.E_p[i]
+                            density = trap.density[i]
+                        else:
+                            k_0 = trap.k_0
+                            E_k = trap.E_k
+                            p_0 = trap.p_0
+                            E_p = trap.E_p
+                            density = trap.density[0]
+                        c_m, _ = self.get_concentration_for_a_given_material(mat, T)
+                        F_trapping += (
+                            -k_0
+                            * exp(-E_k / k_B / T.T)
+                            * c_m
+                            * (density - trap.solution)
+                            * self.test_function
+                            * dx(mat.id)
+                        )
+                        F_trapping += (
+                            p_0
+                            * exp(-E_p / k_B / T.T)
+                            * trap.solution
+                            * self.test_function
+                            * dx(mat.id)
+                        )
+        F += -F_trapping
+
         self.F_diffusion = F
         self.F += F
 

--- a/festim/concentration/mobile.py
+++ b/festim/concentration/mobile.py
@@ -1,6 +1,5 @@
 from festim import Concentration, FluxBC, k_B, R, RadioactiveDecay
 from fenics import *
-import sympy as sp
 
 
 class Mobile(Concentration):

--- a/festim/concentration/mobile.py
+++ b/festim/concentration/mobile.py
@@ -1,4 +1,4 @@
-from festim import Concentration, FluxBC, k_B, R
+from festim import Concentration, FluxBC, k_B, R, RadioactiveDecay
 from fenics import *
 import sympy as sp
 
@@ -132,6 +132,9 @@ class Mobile(Concentration):
                 volumes = source.volume
             else:
                 volumes = [source.volume]
+            if isinstance(source, RadioactiveDecay):
+                source.value = -source.form(self.mobile_concentration())
+
             for volume in volumes:
                 F_source += -source.value * self.test_function * dx(volume)
             if isinstance(source.value, (Expression, UserExpression)):

--- a/festim/concentration/traps/trap.py
+++ b/festim/concentration/traps/trap.py
@@ -205,7 +205,8 @@ class Trap(Concentration):
         """
         for source in self.sources:
             if isinstance(source, RadioactiveDecay):
-                source.value = -source.form(self.solution)
+                source.value = source.form(self.solution)
             self.F_source = -source.value * self.test_function * dx(source.volume)
             self.F += self.F_source
-            self.sub_expressions.append(source.value)
+            if isinstance(source.value, (Expression, UserExpression)):
+                self.sub_expressions.append(source.value)

--- a/festim/concentration/traps/trap.py
+++ b/festim/concentration/traps/trap.py
@@ -1,4 +1,4 @@
-from festim import Concentration, k_B, Material, Theta
+from festim import Concentration, k_B, Material, Theta, RadioactiveDecay
 from fenics import *
 import sympy as sp
 import numpy as np
@@ -204,6 +204,8 @@ class Trap(Concentration):
             dx (fenics.Measure): the dx measure of the sim
         """
         for source in self.sources:
+            if isinstance(source, RadioactiveDecay):
+                source.value = -source.form(self.solution)
             self.F_source = -source.value * self.test_function * dx(source.volume)
             self.F += self.F_source
             self.sub_expressions.append(source.value)

--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -188,7 +188,19 @@ class Simulation:
 
         # set sources
         for source in self.sources:
-            field_to_object[source.field].sources.append(source)
+            if isinstance(source, festim.RadioactiveDecay) and source.field == "all":
+                # this could be refactored if sources accept several fields
+                # (e.g. festim.Source(field=["0", "T"]))
+                # for field in source.field:
+                #    field_to_object[field].sources.append(source)
+
+                # create list of all unique festim.Concentration objects in field_to_object
+                # and assign source to each of them
+                for obj in set(field_to_object.values()):
+                    if isinstance(obj, festim.Concentration):
+                        obj.sources.append(source)
+            else:
+                field_to_object[source.field].sources.append(source)
 
     def attribute_boundary_conditions(self):
         """Assigns boundary_conditions to mobile and T"""

--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -189,13 +189,8 @@ class Simulation:
         # set sources
         for source in self.sources:
             if isinstance(source, festim.RadioactiveDecay) and source.field == "all":
-                # this could be refactored if sources accept several fields
-                # (e.g. festim.Source(field=["0", "T"]))
-                # for field in source.field:
-                #    field_to_object[field].sources.append(source)
-
-                # create list of all unique festim.Concentration objects in field_to_object
-                # and assign source to each of them
+                # assign source to each of the unique festim.Concentration
+                # objects in field_to_object
                 for obj in set(field_to_object.values()):
                     if isinstance(obj, festim.Concentration):
                         obj.sources.append(source)

--- a/festim/sources/radioactive_decay.py
+++ b/festim/sources/radioactive_decay.py
@@ -6,5 +6,17 @@ class RadioactiveDecay(Source):
         self.decay_constant = decay_constant
         super().__init__(value=None, volume=volume, field=field)
 
+    @property
+    def decay_constant(self):
+        return self._decay_constant
+
+    @decay_constant.setter
+    def decay_constant(self, value):
+        if not isinstance(value, (float, int)):
+            raise TypeError("decay_constant must be a float or an int")
+        if value <= 0:
+            raise ValueError("decay_constant must be positive")
+        self._decay_constant = value
+
     def form(self, concentration):
         return self.decay_constant * concentration

--- a/festim/sources/radioactive_decay.py
+++ b/festim/sources/radioactive_decay.py
@@ -2,6 +2,19 @@ from festim import Source
 
 
 class RadioactiveDecay(Source):
+    """
+    A radioactive decay source.
+    dc/dt = ... - lambda * c
+    where lambda is the decay constant in 1/s.
+
+    Args:
+        decay_constant (float): The decay constant of the source in 1/s.
+        volume (int): The volume of the source.
+        field (str, optional): The field to which the source is
+            applied. If "all" the decay will be applied to all
+            concentrations. Defaults to "all".
+    """
+
     def __init__(self, decay_constant, volume, field="all") -> None:
         self.decay_constant = decay_constant
         super().__init__(value=None, volume=volume, field=field)

--- a/festim/sources/radioactive_decay.py
+++ b/festim/sources/radioactive_decay.py
@@ -1,0 +1,10 @@
+from festim import Source
+
+
+class RadioactiveDecay(Source):
+    def __init__(self, decay_constant, volume, field="all") -> None:
+        self.decay_constant = decay_constant
+        super().__init__(value=None, volume=volume, field=field)
+
+    def form(self, concentration):
+        return self.decay_constant * concentration

--- a/festim/sources/radioactive_decay.py
+++ b/festim/sources/radioactive_decay.py
@@ -19,4 +19,4 @@ class RadioactiveDecay(Source):
         self._decay_constant = value
 
     def form(self, concentration):
-        return self.decay_constant * concentration
+        return -self.decay_constant * concentration

--- a/test/system/test_system.py
+++ b/test/system/test_system.py
@@ -181,7 +181,6 @@ def test_run_MMS(tmpdir):
 
     f = (
         sp.diff(u, festim.t)
-        # + sp.diff(v, festim.t)
         - p * v
         + k * u * (n_trap - v)
         - D * sp.diff(u, festim.x, 2)

--- a/test/system/test_system.py
+++ b/test/system/test_system.py
@@ -591,12 +591,11 @@ def test_run_MMS_steady_state(tmpdir):
     k = k_0 * sp.exp(-E_k / k_B / T)
 
     f = (
-        sp.diff(u, festim.t)
-        + sp.diff(v, festim.t)
-        - D * sp.diff(u, festim.x, 2)
+        -D * sp.diff(u, festim.x, 2)
         - sp.diff(D, festim.x) * sp.diff(u, festim.x)
+        - (p * v - k * u * (n_trap - v))
     )
-    g = sp.diff(v, festim.t) + p * v - k * u * (n_trap - v)
+    g = p * v - k * u * (n_trap - v)
 
     def run(h):
         my_materials = festim.Materials(

--- a/test/system/test_system.py
+++ b/test/system/test_system.py
@@ -1102,3 +1102,101 @@ def test_mms_radioactive_decay():
     msg = f"Maximum error on u is: {error_max_u}"
     print(msg)
     assert error_max_u < tol_u
+
+
+def test_MMS_decay_with_trap():
+    """MMS test for radioactive decay
+    Steady state, solute and trap
+    """
+    u = 1 + festim.x
+    v = 1 + festim.x * 2
+    size = 1
+    k_0 = 2
+    E_k = 1.5
+    p_0 = 0.2
+    E_p = 0.1
+    T = 700 + 30 * festim.x
+    decay_constant = 0.1
+    n_trap = 1
+    E_D = 0.1
+    D_0 = 2
+    k_B = festim.k_B
+    D = D_0 * sp.exp(-E_D / k_B / T)
+    p = p_0 * sp.exp(-E_p / k_B / T)
+    k = k_0 * sp.exp(-E_k / k_B / T)
+
+    f = (
+        -p * v
+        + k * u * (n_trap - v)
+        - D * sp.diff(u, festim.x, 2)
+        - sp.diff(D, festim.x) * sp.diff(u, festim.x)
+        + decay_constant * u
+    )
+    g = p * v - k * u * (n_trap - v) + decay_constant * v
+
+    my_materials = festim.Materials(
+        [festim.Material(name="mat", id=1, D_0=D_0, E_D=E_D)]
+    )
+
+    my_trap = festim.Trap(k_0, E_k, p_0, E_p, ["mat"], n_trap)
+
+    size = 0.1
+    my_mesh = festim.MeshFromVertices(np.linspace(0, size, 1600))
+
+    my_sources = [
+        festim.Source(f, 1, "solute"),
+        festim.Source(g, 1, "1"),
+        festim.RadioactiveDecay(decay_constant=decay_constant, volume=1),
+    ]
+
+    my_temp = festim.Temperature(T)
+
+    my_bcs = [
+        festim.DirichletBC(surfaces=[1, 2], value=u, field=0),
+        festim.DirichletBC(surfaces=[1, 2], value=v, field=1),
+    ]
+
+    my_settings = festim.Settings(
+        absolute_tolerance=1e-10,
+        relative_tolerance=1e-9,
+        maximum_iterations=50,
+        transient=False,
+        traps_element_type="DG",
+    )
+
+    my_sim = festim.Simulation(
+        mesh=my_mesh,
+        materials=my_materials,
+        traps=my_trap,
+        boundary_conditions=my_bcs,
+        sources=my_sources,
+        temperature=my_temp,
+        settings=my_settings,
+    )
+
+    my_sim.initialise()
+    my_sim.run()
+    error_max_u = compute_error(
+        u,
+        computed=my_sim.mobile.post_processing_solution,
+        t=my_sim.t,
+        norm="error_max",
+    )
+    error_max_v = compute_error(
+        v,
+        computed=my_sim.traps.traps[0].post_processing_solution,
+        t=my_sim.t,
+        norm="error_max",
+    )
+
+    tol_u = 1e-10
+    tol_v = 1e-7
+    msg = (
+        "Maximum error on u is:"
+        + str(error_max_u)
+        + "\n \
+        Maximum error on v is:"
+        + str(error_max_v)
+    )
+    print(msg)
+    assert error_max_u < tol_u and error_max_v < tol_v

--- a/test/system/test_system.py
+++ b/test/system/test_system.py
@@ -1095,7 +1095,7 @@ def test_mms_radioactive_decay():
     error_max_u = compute_error(
         u,
         computed=my_sim.mobile.post_processing_solution,
-        t=my_sim.t,
+        t=0,
         norm="error_max",
     )
 

--- a/test/system/test_system.py
+++ b/test/system/test_system.py
@@ -181,7 +181,9 @@ def test_run_MMS(tmpdir):
 
     f = (
         sp.diff(u, festim.t)
-        + sp.diff(v, festim.t)
+        # + sp.diff(v, festim.t)
+        - p * v
+        + k * u * (n_trap - v)
         - D * sp.diff(u, festim.x, 2)
         - sp.diff(D, festim.x) * sp.diff(u, festim.x)
     )
@@ -303,7 +305,8 @@ def test_run_MMS_chemical_pot(tmpdir):
 
     f = (
         sp.diff(u, festim.t)
-        + sp.diff(v, festim.t)
+        - p * v
+        + k * u * (n_trap - v)
         - D * sp.diff(u, festim.x, 2)
         - sp.diff(D, festim.x) * sp.diff(u, festim.x)
     )

--- a/test/system/test_system.py
+++ b/test/system/test_system.py
@@ -1101,7 +1101,6 @@ def test_mms_radioactive_decay():
     )
 
     tol_u = 1e-7
-    dt = 0.1 / 50
     msg = f"Maximum error on u is: {error_max_u}"
     print(msg)
     assert error_max_u < tol_u

--- a/test/unit/test_mobile.py
+++ b/test/unit/test_mobile.py
@@ -159,13 +159,26 @@ class TestCreateDiffusionForm:
         c_0_n = my_mobile.previous_solution
         expected_form = ((c_0 - c_0_n) / self.dt.value) * v * self.my_mesh.dx(1)
         expected_form += f.dot(D * f.grad(c_0), f.grad(v)) * self.my_mesh.dx(1)
+        form_trapping_expected = 0
         for trap in my_traps.traps:
-            expected_form += (
-                ((trap.solution - trap.previous_solution) / self.dt.value)
+            form_trapping_expected += (
+                (
+                    -trap.k_0
+                    * f.exp(-trap.E_k / festim.k_B / self.my_temp.T)
+                    * c_0
+                    * (trap.density[0] - trap.solution)
+                )
                 * v
-                * self.my_mesh.dx
+                * self.my_mesh.dx(1)
             )
-
+            form_trapping_expected += (
+                trap.p_0
+                * f.exp(-trap.E_p / festim.k_B / self.my_temp.T)
+                * trap.solution
+                * v
+                * self.my_mesh.dx(1)
+            )
+        expected_form += -form_trapping_expected
         print("expected F:")
         print(expected_form)
         print("produced F:")

--- a/test/unit/test_radioactive_decay.py
+++ b/test/unit/test_radioactive_decay.py
@@ -1,0 +1,31 @@
+from festim import RadioactiveDecay
+import pytest
+
+
+def test_init():
+    rd = RadioactiveDecay(0.5, 100)
+    assert rd.decay_constant == 0.5
+    assert rd.volume == 100
+
+
+def test_decay_constant_setter():
+    rd = RadioactiveDecay(0.5, 100)
+    rd.decay_constant = 0.7
+    assert rd.decay_constant == 0.7
+
+
+def test_decay_constant_setter_invalid_type():
+    rd = RadioactiveDecay(0.5, 100)
+    with pytest.raises(TypeError):
+        rd.decay_constant = "invalid"
+
+
+def test_decay_constant_setter_negative_value():
+    rd = RadioactiveDecay(0.5, 100)
+    with pytest.raises(ValueError):
+        rd.decay_constant = -0.5
+
+
+def test_form():
+    rd = RadioactiveDecay(0.5, 100)
+    assert rd.form(200) == -100


### PR DESCRIPTION
## Proposed changes

This PR implements radioactive decay (fixes #488).

The new formulation is:

$$
    \frac{\partial c_m}{\partial t} =  \nabla \cdot (D \nabla c_m)  - \lambda c_m - \sum \left( -k_i \ c_m \ (n_i - c_{t,i}) + p_i \ c_{t,i} \right)
$$

$$
    \frac{\partial c_{t,i}}{\partial t}=k_i \ c_m \ (n_i - c_{t,i})- p_i \ c_{t,i} - \lambda c_{t,i}
$$

where $\lambda$ is the decay constant (expressed in s^-1).

It is implemented as a volumetric source object inheriting from `F.Source`.
It takes a decay constant parameter.

**Usage**:

```python
import festim as F
import numpy as np


my_model = F.Simulation()

my_model.traps = [
    F.Trap(0, 1, 0, 3, materials=my_model.materials.materials[0], density=100)
]

half_life = 50  # seconds
decay_constant = np.log(2) / half_life

my_model.sources = [
    F.RadioactiveDecay(decay_constant=decay_constant, volume=1, field="solute"),
    F.RadioactiveDecay(decay_constant=decay_constant, volume=1, field="1"),
]
```

Alternatively, a single decay source can be applied to all concentrations (default behaviour):
```python
import festim as F
import numpy as np


my_model = F.Simulation()

my_model.traps = [
    F.Trap(0, 1, 0, 3, materials=my_model.materials.materials[0], density=100)
]

half_life = 50  # seconds
decay_constant = np.log(2) / half_life

my_model.sources = [
    F.RadioactiveDecay(decay_constant=decay_constant, volume=1, field="all"),
]
```

On a simple simulation with no BCs, no trapping/detrapping, but initial conditions (200 for mobile and 100 for trapped concentration), a half-life of 50 s, things work as expected:

![image](https://github.com/festim-dev/FESTIM/assets/40028739/2d066452-c9d0-4fc5-a606-897e6f63b70b)


## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

@jhdark I had to modify the formulation in order to make this work. Before, we had:

$$
\frac{\partial c_m}{\partial t} =  \nabla \cdot (D \nabla c_m )  + S - \sum \frac{\partial c_{t,i}}{\partial t}
$$

This trapping term wouldn't work when adding decay. Since:

$$
    \frac{\partial c_{t,i}}{\partial t}=k_i \ c_m \ (n_i - c_{t,i})- p_i \ c_{t,i} - \lambda c_{t,i}
$$

then the decay of trapped particles would create mobile particles!

I therefore had to:
- modify the formulation
- modify the MMS tests
- modify some other units tests

I'm happy to break this PR down and open a smaller PR that just does this

Also, it might be interesting to allow several materials per source!

