### PR TITLE
Fix bug with calculations on small timescales

### DIFF
--- a/festim/exports/derived_quantities/derived_quantities.py
+++ b/festim/exports/derived_quantities/derived_quantities.py
@@ -123,7 +123,7 @@ class DerivedQuantities:
             nb_its_between_exports = self.nb_iterations_between_exports
             if nb_its_between_exports is None:
                 # export at the end
-                return np.isclose(t, final_time)
+                return np.isclose(t, final_time, atol=0)
             else:
                 # export every N iterations
                 return nb_iterations % nb_its_between_exports == 0

--- a/festim/exports/txt_export.py
+++ b/festim/exports/txt_export.py
@@ -47,7 +47,7 @@ class TXTExport(festim.Export):
         if self.times is None:
             return True
         for time in self.times:
-            if np.isclose(time, current_time):
+            if np.isclose(time, current_time, atol=0):
                 return True
         return False
 

--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -320,7 +320,7 @@ class Simulation:
         #  Time-stepping
         print("Time stepping...")
         while self.t < self.settings.final_time and not np.isclose(
-            self.t, self.settings.final_time
+            self.t, self.settings.final_time, atol=0
         ):
             self.iterate()
 
@@ -370,7 +370,10 @@ class Simulation:
         msg = "{:.1f} %        ".format(simulation_percentage)
         msg += "{:.1e} s".format(self.t)
         msg += "    Ellapsed time so far: {:.1f} s".format(elapsed_time)
-        if not np.isclose(self.t, self.settings.final_time) and self.log_level == 40:
+        if (
+            not np.isclose(self.t, self.settings.final_time, atol=0)
+            and self.log_level == 40
+        ):
             print(msg, end="\r")
         else:
             print(msg)

--- a/festim/stepsize.py
+++ b/festim/stepsize.py
@@ -95,7 +95,7 @@ class Stepsize:
         next_milestone = self.next_milestone(t)
         if next_milestone is not None:
             if t + float(self.value) > next_milestone and not np.isclose(
-                t, next_milestone
+                t, next_milestone, atol=0
             ):
                 self.value.assign((next_milestone - t))
 

--- a/test/system/test_misc.py
+++ b/test/system/test_misc.py
@@ -124,17 +124,18 @@ def test_wrong_value_for_bc_field(field):
 def test_txt_export_desired_times(tmp_path):
     """
     Tests that TXTExport can be exported at desired times
+    Also catches the bug #682
     """
     my_model = F.Simulation()
 
     my_model.mesh = F.MeshFromVertices(np.linspace(0, 1))
     my_model.materials = F.Material(1, 1, 0)
-    my_model.settings = F.Settings(1e-10, 1e-10, final_time=1)
+    my_model.settings = F.Settings(1e-10, 1e-10, final_time=1e-7)
     my_model.T = F.Temperature(500)
-    my_model.dt = F.Stepsize(0.1)
+    my_model.dt = F.Stepsize(1e-9)
 
     my_export = F.TXTExport(
-        "solute", times=[0.2, 0.5], filename="{}/mobile_conc.txt".format(tmp_path)
+        "solute", times=[1e-8, 2e-8], filename="{}/mobile_conc.txt".format(tmp_path)
     )
     my_model.exports = [my_export]
 
@@ -252,3 +253,20 @@ def test_derived_quantities_exported_last_timestep_with_small_stepsize(tmp_path)
     my_model.run()
 
     assert os.path.exists(f"{tmp_path}/out.csv")
+
+
+def test_small_timesteps_final_time_bug():
+    """
+    Test to catch the bug #682
+    Runs a sim on small timescales and checks that the final time is reached
+    """
+    my_model = F.Simulation(log_level=40)
+    my_model.mesh = F.MeshFromVertices(np.linspace(0, 1, 10))
+    my_model.materials = F.Material(1, 1, 0.1)
+    my_model.T = F.Temperature(1000)
+    my_model.settings = F.Settings(1e-10, 1e-10, final_time=1e-7)
+    my_model.dt = F.Stepsize(1e-9)
+    my_model.initialise()
+    my_model.run()
+
+    assert np.isclose(my_model.t, my_model.settings.final_time, atol=0.0)

--- a/test/system/test_misc.py
+++ b/test/system/test_misc.py
@@ -121,7 +121,11 @@ def test_wrong_value_for_bc_field(field):
         sim.initialise()
 
 
-def test_txt_export_desired_times(tmp_path):
+@pytest.mark.parametrize(
+    "final_time,stepsize,export_times",
+    [(1, 0.1, [0.2, 0.5]), (1e-7, 1e-9, [1e-8, 1.5e-8, 2e-8])],
+)
+def test_txt_export_desired_times(tmp_path, final_time, stepsize, export_times):
     """
     Tests that TXTExport can be exported at desired times
     Also catches the bug #682
@@ -130,12 +134,12 @@ def test_txt_export_desired_times(tmp_path):
 
     my_model.mesh = F.MeshFromVertices(np.linspace(0, 1))
     my_model.materials = F.Material(1, 1, 0)
-    my_model.settings = F.Settings(1e-10, 1e-10, final_time=1e-7)
+    my_model.settings = F.Settings(1e-10, 1e-10, final_time=final_time)
     my_model.T = F.Temperature(500)
-    my_model.dt = F.Stepsize(1e-9)
+    my_model.dt = F.Stepsize(stepsize)
 
     my_export = F.TXTExport(
-        "solute", times=[1e-8, 2e-8], filename="{}/mobile_conc.txt".format(tmp_path)
+        "solute", times=export_times, filename="{}/mobile_conc.txt".format(tmp_path)
     )
     my_model.exports = [my_export]
 


### PR DESCRIPTION
## Proposed changes

When performing simulations on small timescales (e.g., `final_time=1e-7`), some bugs appear due to the use of `np.isclose` with the default parameters (atol, rtol). For example (see below), computation stops without reaching the final time. As @RemDelaporteMathurin suggested, the current PR attempts to fix the bug by setting `atol=0` in `np.isclose`. 

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
MWE:
```python
import festim as F
import numpy as np

my_model = F.Simulation(log_level = 40)

my_model.mesh = F.MeshFromVertices(np.linspace(0, 1, 10))

my_model.materials = F.Material(
    id=1,
    D_0=1,
    E_D=0.1,
)

my_model.T = F.Temperature(1000)

my_model.settings = F.Settings(
    absolute_tolerance=1e-10,
    relative_tolerance=1e-10,
    final_time=1e-7,
)

my_model.dt = F.Stepsize(
    initial_value=1e-10,
)

my_model.initialise()
my_model.run()
``` 
Stops at 90%:
```
Defining initial values
Defining variational problem
Defining source terms
Defining boundary conditions
Time stepping...
90.0 %        9.0e-08 s    Ellapsed time so far: 3.2 s
``` 