### PR TITLE
Reduce number of warnings

### DIFF
--- a/.github/workflows/ci_conda.yml
+++ b/.github/workflows/ci_conda.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Create Conda environment
       shell: bash -l {0}
       run: |
-        mamba install -c conda-forge fenics-dolfinx=0.7.0
+        mamba install -c conda-forge fenics-dolfinx=0.7.2
 
     - name: Install local package and dependencies
       shell: bash -l {0}

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -4,7 +4,7 @@ on: [pull_request, push]
 jobs:
   run-tests:
       runs-on: ubuntu-latest
-      container: dolfinx/dolfinx:v0.7.0
+      container: dolfinx/dolfinx:v0.7.2
       steps:
         - name: Checkout code
           uses: actions/checkout@v2

--- a/festim/boundary_conditions/dirichlet_bc.py
+++ b/festim/boundary_conditions/dirichlet_bc.py
@@ -91,7 +91,7 @@ class DirichletBC:
             facet_meshtags (ddolfinx.mesh.MeshTags): the mesh tags of the
                 surface facets
             mesh (dolfinx.mesh.Mesh): the mesh
-            function_space (dolfinx.fem.FunctionSpace): the function space
+            function_space (dolfinx.fem.FunctionSpaceBase): the function space
         """
         bc_facets = facet_meshtags.find(self.subdomain.id)
         bc_dofs = fem.locate_dofs_topological(function_space, mesh.fdim, bc_facets)
@@ -99,7 +99,7 @@ class DirichletBC:
         return bc_dofs
 
     def create_value(
-        self, mesh, function_space: fem.FunctionSpace, temperature, t: fem.Constant
+        self, mesh, function_space: fem.FunctionSpaceBase, temperature, t: fem.Constant
     ):
         """Creates the value of the boundary condition as a fenics object and sets it to
         self.value_fenics.
@@ -110,7 +110,7 @@ class DirichletBC:
 
         Args:
             mesh (dolfinx.mesh.Mesh) : the mesh
-            function_space (dolfinx.fem.FunctionSpace): the function space
+            function_space (dolfinx.fem.FunctionSpaceBase): the function space
             temperature (float): the temperature
             t (dolfinx.fem.Constant): the time
         """

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -708,7 +708,9 @@ class HydrogenTransportProblem:
 
     def iterate(self):
         """Iterates the model for a given time step"""
-        self.progress.update(min(self.dt.value, abs(self.settings.final_time - self.t.value)))
+        self.progress.update(
+            min(self.dt.value, abs(self.settings.final_time - self.t.value))
+        )
         self.t.value += self.dt.value
 
         self.update_time_dependent_values()

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -47,7 +47,7 @@ class HydrogenTransportProblem:
         traps (list of F.Trap): the traps of the model
         dx (dolfinx.fem.dx): the volume measure of the model
         ds (dolfinx.fem.ds): the surface measure of the model
-        function_space (dolfinx.fem.FunctionSpace): the function space of the
+        function_space (dolfinx.fem.FunctionSpaceBase): the function space of the
             model
         facet_meshtags (dolfinx.mesh.MeshTags): the facet meshtags of the model
         volume_meshtags (dolfinx.mesh.MeshTags): the volume meshtags of the
@@ -62,9 +62,9 @@ class HydrogenTransportProblem:
             that is used to update the temperature_fenics
         temperature_time_dependent (bool): True if the temperature is time
             dependent
-        V_DG_0 (dolfinx.fem.FunctionSpace): A DG function space of degree 0
+        V_DG_0 (dolfinx.fem.FunctionSpaceBase): A DG function space of degree 0
             over domain
-        V_DG_1 (dolfinx.fem.FunctionSpace): A DG function space of degree 1
+        V_DG_1 (dolfinx.fem.FunctionSpaceBase): A DG function space of degree 1
             over domain
         volume_subdomains (list of festim.VolumeSubdomain): the volume subdomains
             of the model
@@ -275,7 +275,7 @@ class HydrogenTransportProblem:
                     degree,
                     basix.LagrangeVariant.equispaced,
                 )
-                function_space_temperature = fem.FunctionSpace(
+                function_space_temperature = fem.functionspace(
                     self.mesh.mesh, element_temperature
                 )
                 self.temperature_fenics = fem.Function(function_space_temperature)
@@ -388,11 +388,11 @@ class HydrogenTransportProblem:
                     elements.append(element_CG)
             element = ufl.MixedElement(elements)
 
-        self.function_space = fem.FunctionSpace(self.mesh.mesh, element)
+        self.function_space = fem.functionspace(self.mesh.mesh, element)
 
         # create global DG function spaces of degree 0 and 1
-        self.V_DG_0 = fem.FunctionSpace(self.mesh.mesh, ("DG", 0))
-        self.V_DG_1 = fem.FunctionSpace(self.mesh.mesh, ("DG", 1))
+        self.V_DG_0 = fem.functionspace(self.mesh.mesh, ("DG", 0))
+        self.V_DG_1 = fem.functionspace(self.mesh.mesh, ("DG", 1))
 
         self.u = fem.Function(self.function_space)
         self.u_n = fem.Function(self.function_space)

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -2,9 +2,9 @@ from dolfinx import fem
 from dolfinx.mesh import meshtags
 from dolfinx.nls.petsc import NewtonSolver
 import basix
+import basix.ufl
 import ufl
 from mpi4py import MPI
-from dolfinx.mesh import meshtags
 import numpy as np
 import tqdm.autonotebook
 import festim as F
@@ -386,13 +386,25 @@ class HydrogenTransportProblem:
             for spe in self.species:
                 if isinstance(spe, F.Species):
                     elements.append(element_CG)
-            element = ufl.MixedElement(elements)
+            element = basix.ufl.mixed_element(elements)
 
         self.function_space = fem.functionspace(self.mesh.mesh, element)
 
         # create global DG function spaces of degree 0 and 1
-        self.V_DG_0 = fem.functionspace(self.mesh.mesh, ("DG", 0))
-        self.V_DG_1 = fem.functionspace(self.mesh.mesh, ("DG", 1))
+        element_DG0 = basix.ufl.element(
+            "DG",
+            self.mesh.mesh.basix_cell(),
+            0,
+            basix.LagrangeVariant.equispaced,
+        )
+        element_DG1 = basix.ufl.element(
+            "DG",
+            self.mesh.mesh.basix_cell(),
+            1,
+            basix.LagrangeVariant.equispaced,
+        )
+        self.V_DG_0 = fem.functionspace(self.mesh.mesh, element_DG0)
+        self.V_DG_1 = fem.functionspace(self.mesh.mesh, element_DG1)
 
         self.u = fem.Function(self.function_space)
         self.u_n = fem.Function(self.function_space)

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -708,7 +708,7 @@ class HydrogenTransportProblem:
 
     def iterate(self):
         """Iterates the model for a given time step"""
-        self.progress.update(self.dt.value)
+        self.progress.update(min(self.dt.value, abs(self.settings.final_time - self.t.value)))
         self.t.value += self.dt.value
 
         self.update_time_dependent_values()

--- a/festim/initial_condition.py
+++ b/festim/initial_condition.py
@@ -40,7 +40,7 @@ class InitialCondition:
         Args:
             mesh (dolfinx.mesh.Mesh) : the mesh
             temperature (float): the temperature
-            function_space(dolfinx.fem.FunctionSpace): the function space of the species
+            function_space(dolfinx.fem.FunctionSpaceBase): the function space of the species
         """
         x = ufl.SpatialCoordinate(mesh)
 

--- a/festim/mesh/mesh_1d.py
+++ b/festim/mesh/mesh_1d.py
@@ -1,5 +1,6 @@
 import dolfinx.mesh
 from mpi4py import MPI
+import basix.ufl
 import ufl
 import numpy as np
 import festim as F
@@ -33,9 +34,15 @@ class Mesh1D(F.Mesh):
 
     def generate_mesh(self):
         """Generates a 1D mesh"""
-        gdim, shape, degree = 1, "interval", 1
-        cell = ufl.Cell(shape, geometric_dimension=gdim)
-        domain = ufl.Mesh(ufl.VectorElement("Lagrange", cell, degree))
+        degree = 1
+        domain = ufl.Mesh(
+            basix.ufl.element(
+                basix.ElementFamily.P,
+                "interval",
+                degree,
+                shape=(1,)
+            )
+        )
 
         mesh_points = np.reshape(self.vertices, (len(self.vertices), 1))
         indexes = np.arange(self.vertices.shape[0])

--- a/festim/mesh/mesh_1d.py
+++ b/festim/mesh/mesh_1d.py
@@ -36,12 +36,7 @@ class Mesh1D(F.Mesh):
         """Generates a 1D mesh"""
         degree = 1
         domain = ufl.Mesh(
-            basix.ufl.element(
-                basix.ElementFamily.P,
-                "interval",
-                degree,
-                shape=(1,)
-            )
+            basix.ufl.element(basix.ElementFamily.P, "interval", degree, shape=(1,))
         )
 
         mesh_points = np.reshape(self.vertices, (len(self.vertices), 1))

--- a/festim/source.py
+++ b/festim/source.py
@@ -105,7 +105,7 @@ class Source:
             return False
 
     def create_value_fenics(
-        self, mesh, function_space: fem.FunctionSpace, temperature, t: fem.Constant
+        self, mesh, function_space: fem.FunctionSpaceBase, temperature, t: fem.Constant
     ):
         """Creates the value of the source as a fenics object and sets it to
         self.value_fenics.
@@ -116,7 +116,7 @@ class Source:
 
         Args:
             mesh (dolfinx.mesh.Mesh) : the mesh
-            function_space (dolfinx.fem.FunctionSpace): the function space
+            function_space (dolfinx.fem.FunctionSpaceBase): the function space
             temperature (float): the temperature
             t (dolfinx.fem.Constant): the time
         """

--- a/test/benchmark.py
+++ b/test/benchmark.py
@@ -5,7 +5,7 @@ from dolfinx.fem import (
     Constant,
     dirichletbc,
     Function,
-    FunctionSpace,
+    functionspace,
     locate_dofs_topological,
     locate_dofs_geometrical,
     form,
@@ -54,7 +54,7 @@ def fenics_test_permeation_problem(mesh_size=1001):
         1,
         basix.LagrangeVariant.equispaced,
     )
-    V = FunctionSpace(my_mesh, elements)
+    V = functionspace(my_mesh, elements)
     u = Function(V)
     u_n = Function(V)
     v = TestFunction(V)

--- a/test/test_h_transport_problem.py
+++ b/test/test_h_transport_problem.py
@@ -137,7 +137,7 @@ def test_iterate():
 
     mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 10, 10)
 
-    V = fem.FunctionSpace(mesh, ("CG", 1))
+    V = fem.FunctionSpace(mesh, ("Lagrange", 1))
     my_model.u = fem.Function(V)
     my_model.u_n = fem.Function(V)
     my_model.dt = fem.Constant(mesh, 2.0)
@@ -386,7 +386,7 @@ def test_post_processing_update_D_global():
 
     # create species and interpolate solution
     H = F.Species("H")
-    V = fem.FunctionSpace(my_mesh.mesh, ("CG", 1))
+    V = fem.FunctionSpace(my_mesh.mesh, ("Lagrange", 1))
     u = fem.Function(V)
     u.interpolate(lambda x: 2 * x[0] ** 2 + 1)
     H.solution = u

--- a/test/test_h_transport_problem.py
+++ b/test/test_h_transport_problem.py
@@ -137,7 +137,7 @@ def test_iterate():
 
     mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 10, 10)
 
-    V = fem.FunctionSpace(mesh, ("Lagrange", 1))
+    V = fem.functionspace(mesh, ("Lagrange", 1))
     my_model.u = fem.Function(V)
     my_model.u_n = fem.Function(V)
     my_model.dt = fem.Constant(mesh, 2.0)
@@ -386,7 +386,7 @@ def test_post_processing_update_D_global():
 
     # create species and interpolate solution
     H = F.Species("H")
-    V = fem.FunctionSpace(my_mesh.mesh, ("Lagrange", 1))
+    V = fem.functionspace(my_mesh.mesh, ("Lagrange", 1))
     u = fem.Function(V)
     u.interpolate(lambda x: 2 * x[0] ** 2 + 1)
     H.solution = u

--- a/test/test_h_transport_problem.py
+++ b/test/test_h_transport_problem.py
@@ -819,7 +819,7 @@ def test_adaptive_timestepping_grows():
 
     # RUN & TEST
     previous_value = stepsize.initial_value
-    for i in range(10):
+    while my_model.t.value < my_model.settings.final_time:
         my_model.iterate()
 
         # check that the current value is greater than the previous one
@@ -855,7 +855,7 @@ def test_adaptive_timestepping_shrinks():
 
     # RUN & TEST
     previous_value = stepsize.initial_value
-    for i in range(10):
+    while my_model.t.value < my_model.settings.final_time and my_model.dt.value > 0.1:
         my_model.iterate()
 
         # check that the current value is smaller than the previous one

--- a/test/test_initial_condition.py
+++ b/test/test_initial_condition.py
@@ -37,7 +37,7 @@ def test_create_value_fenics(input_value, expected_type):
     # BUILD
 
     # give function to species
-    V = fem.FunctionSpace(test_mesh.mesh, ("Lagrange", 1))
+    V = fem.functionspace(test_mesh.mesh, ("Lagrange", 1))
     c = fem.Function(V)
 
     my_species = F.Species("test")
@@ -58,7 +58,7 @@ def test_warning_raised_when_giving_time_as_arg():
     """Test that a warning is raised if the value is given with t in its arguments"""
 
     # give function to species
-    V = fem.FunctionSpace(test_mesh.mesh, ("Lagrange", 1))
+    V = fem.functionspace(test_mesh.mesh, ("Lagrange", 1))
     my_species = F.Species("test")
     my_species.prev_solution = fem.Function(V)
 

--- a/test/test_initial_condition.py
+++ b/test/test_initial_condition.py
@@ -37,7 +37,7 @@ def test_create_value_fenics(input_value, expected_type):
     # BUILD
 
     # give function to species
-    V = fem.FunctionSpace(test_mesh.mesh, ("CG", 1))
+    V = fem.FunctionSpace(test_mesh.mesh, ("Lagrange", 1))
     c = fem.Function(V)
 
     my_species = F.Species("test")
@@ -58,7 +58,7 @@ def test_warning_raised_when_giving_time_as_arg():
     """Test that a warning is raised if the value is given with t in its arguments"""
 
     # give function to species
-    V = fem.FunctionSpace(test_mesh.mesh, ("CG", 1))
+    V = fem.FunctionSpace(test_mesh.mesh, ("Lagrange", 1))
     my_species = F.Species("test")
     my_species.prev_solution = fem.Function(V)
 

--- a/test/test_reaction.py
+++ b/test/test_reaction.py
@@ -1,6 +1,6 @@
 import pytest
 import festim as F
-from dolfinx.fem import FunctionSpace, Function
+from dolfinx.fem import functionspace, Function
 from dolfinx.mesh import create_unit_cube
 from mpi4py import MPI
 from ufl import exp
@@ -77,7 +77,7 @@ def test_reaction_reaction_term(temperature):
     """Test that the Reaction.reaction_term method returns the expected reaction term"""
 
     mesh = create_unit_cube(MPI.COMM_WORLD, 10, 10, 10)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
 
     # create two species
     species1 = F.Species("A")

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -74,7 +74,7 @@ def test_create_value_fenics(value, expected_type):
 
     source = F.Source(volume=vol_subdomain, value=value, species=species)
 
-    my_function_space = fem.FunctionSpace(mesh, ("CG", 1))
+    my_function_space = fem.FunctionSpace(mesh, ("Lagrange", 1))
     T = fem.Constant(mesh, 550.0)
     t = fem.Constant(mesh, 0.0)
 
@@ -143,7 +143,7 @@ def test_ValueError_raised_when_callable_returns_wrong_type():
 
     source = F.Source(volume=vol_subdomain, value=my_value, species=species)
 
-    my_function_space = fem.FunctionSpace(mesh, ("CG", 1))
+    my_function_space = fem.FunctionSpace(mesh, ("Lagrange", 1))
     T = fem.Constant(mesh, 550.0)
     t = fem.Constant(mesh, 0.0)
 

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -74,7 +74,7 @@ def test_create_value_fenics(value, expected_type):
 
     source = F.Source(volume=vol_subdomain, value=value, species=species)
 
-    my_function_space = fem.FunctionSpace(mesh, ("Lagrange", 1))
+    my_function_space = fem.functionspace(mesh, ("Lagrange", 1))
     T = fem.Constant(mesh, 550.0)
     t = fem.Constant(mesh, 0.0)
 
@@ -143,7 +143,7 @@ def test_ValueError_raised_when_callable_returns_wrong_type():
 
     source = F.Source(volume=vol_subdomain, value=my_value, species=species)
 
-    my_function_space = fem.FunctionSpace(mesh, ("Lagrange", 1))
+    my_function_space = fem.functionspace(mesh, ("Lagrange", 1))
     T = fem.Constant(mesh, 550.0)
     t = fem.Constant(mesh, 0.0)
 

--- a/test/test_species.py
+++ b/test/test_species.py
@@ -3,7 +3,7 @@ import dolfinx
 import ufl
 import numpy as np
 import pytest
-from dolfinx.fem import FunctionSpace, Function
+from dolfinx.fem import functionspace, Function
 from dolfinx.mesh import create_unit_cube
 from mpi4py import MPI
 
@@ -84,7 +84,7 @@ def test_implicit_species_concentration():
 
     # set the solutions of the two species
     mesh = create_unit_cube(MPI.COMM_WORLD, 10, 10, 10)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     species1.solution = Function(V)
     species2.solution = Function(V)
 
@@ -109,7 +109,7 @@ def test_implicit_species_concentration_with_no_solution():
 
     # set the solution of the first species
     mesh = create_unit_cube(MPI.COMM_WORLD, 10, 10, 10)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     species1.solution = Function(V)
 
     # test that a ValueError is raised when the second species has no solution

--- a/test/test_surface_quantity.py
+++ b/test/test_surface_quantity.py
@@ -29,7 +29,7 @@ def surface_flux_export_compute():
     ds = ufl.Measure("ds", domain=my_mesh.mesh, subdomain_data=facet_meshtags)
 
     # give function to species
-    V = fem.FunctionSpace(my_mesh.mesh, ("CG", 1))
+    V = fem.functionspace(my_mesh.mesh, ("CG", 1))
     c = fem.Function(V)
     c.interpolate(lambda x: 2 * x[0] ** 2 + 1)
 

--- a/test/test_vtx.py
+++ b/test/test_vtx.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 mesh = dolfinx.mesh.create_unit_cube(MPI.COMM_WORLD, 10, 10, 10)
-V = dolfinx.fem.FunctionSpace(mesh, ("Lagrange", 1))
+V = dolfinx.fem.functionspace(mesh, ("Lagrange", 1))
 
 
 def test_vtx_export_one_function(tmpdir):

--- a/test/test_xdmf.py
+++ b/test/test_xdmf.py
@@ -24,7 +24,7 @@ def test_write(tmp_path):
     my_export.define_writer(MPI.COMM_WORLD)
 
     domain = mesh.create_unit_cube(MPI.COMM_WORLD, 10, 10, 10)
-    V = fem.FunctionSpace(domain, ("Lagrange", 1))
+    V = fem.functionspace(domain, ("Lagrange", 1))
     u = fem.Function(V)
 
     species.post_processing_solution = u


### PR DESCRIPTION
## Proposed changes

This PR removes a lot of the warnings triggered when running FESTIM (and the test suite).

A couple of warnings are hard to kill and are out of our range:

- `ffcx/ir/representation.py:206: DeprecationWarning: `product` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `prod` instead.` already fixed but not released https://github.com/FEniCS/ffcx/pull/626
- `DeprecationWarning: attach_operators_from_hash_data deprecated, please use UFLObject instead.` will be fixed in the next UFL release (see https://github.com/FEniCS/ufl/commit/4b6142a7c69f5360af10897c98aa9fec0f7d96ad)
- `DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).` will be fixed at some point https://github.com/tqdm/tqdm/pull/1519

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests 

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)