### PR TITLE
Soret coefficient as a function of temperature

### DIFF
--- a/docs/source/theory.rst
+++ b/docs/source/theory.rst
@@ -41,9 +41,9 @@ FESTIM can include the Soret effect :cite:`Pendergrass1976,Longhurst1985` (also 
 .. math::
     :label: eq_Soret
 
-    J = -D \nabla c_\mathrm{m} - D\frac{Q^* c_\mathrm{m}}{R_g T^2} \nabla T
+    J = -D \nabla c_\mathrm{m} - D\frac{Q^* c_\mathrm{m}}{k_B T^2} \nabla T
 
-where :math:`Q^*` is the Soret coefficient (also called heat of transport) and :math:`R_g` is the gas constant.
+where :math:`Q^*` is the Soret coefficient (also called heat of transport) and :math:`k_B` is the Boltzmann constant.
 
 Conservation of chemical potential at interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -112,7 +112,7 @@ According to the latter, the rate :math:`k(T)` of a thermally activated process 
 
     k(T) = k_0 \exp \left[-\frac{E_k}{k_B T} \right]
 
-where :math:`k_0` is the pre-exponential factor, :math:`E_k` is the process activation energy, :math:`k_B` is the Boltzmann constant, and :math:`T` is the temperature. 
+where :math:`k_0` is the pre-exponential factor, :math:`E_k` is the process activation energy, and :math:`T` is the temperature. 
 
 Heat transfer
 ^^^^^^^^^^^^^^

--- a/docs/source/userguide/materials.rst
+++ b/docs/source/userguide/materials.rst
@@ -35,7 +35,7 @@ Some other parameters are optional and are only required for some types of simul
 * :code:`thermal_cond`: the thermal conductivity in W/m/K
 * :code:`heat_capacity`: the heat capacity in J/kg/K
 * :code:`rho`: the volumetric density in kg/m3
-* :code:`H`: the heat of transport in J/mol that takes a dictionary {"free_enthalpy": …, "entropy": …} so that H = free_enthalpy + entropy*T. For more information see :ref:`Soret effect`.
+* :code:`Q`: the heat of transport in eV. For more information see :ref:`Soret effect`.
 
 --------------------
 Integration with HTM

--- a/festim/concentration/mobile.py
+++ b/festim/concentration/mobile.py
@@ -1,4 +1,4 @@
-from festim import Concentration, FluxBC, k_B, R, RadioactiveDecay
+from festim import Concentration, FluxBC, k_B, RadioactiveDecay
 from fenics import *
 
 
@@ -80,10 +80,12 @@ class Mobile(Concentration):
                 if mesh.type == "cartesian":
                     F += dot(D * grad(c_0), grad(self.test_function)) * dx
                     if soret:
-                        Q = material.free_enthalpy * T.T + material.entropy
+                        Q = material.Q
+                        if callable(Q):
+                            Q = Q(T.T)
                         F += (
                             dot(
-                                D * Q * c_0 / (R * T.T**2) * grad(T.T),
+                                D * Q * c_0 / (k_B * T.T**2) * grad(T.T),
                                 grad(self.test_function),
                             )
                             * dx

--- a/festim/exports/derived_quantities/derived_quantities.py
+++ b/festim/exports/derived_quantities/derived_quantities.py
@@ -79,7 +79,7 @@ class DerivedQuantities:
             quantity.D = materials.D
             quantity.S = materials.S
             quantity.thermal_cond = materials.thermal_cond
-            quantity.H = materials.H
+            quantity.Q = materials.Q
 
     def compute(self, t):
         # TODO need to support for soret flag in surface flux

--- a/festim/exports/derived_quantities/derived_quantity.py
+++ b/festim/exports/derived_quantities/derived_quantity.py
@@ -15,7 +15,7 @@ class DerivedQuantity(Export):
         self.D = None
         self.S = None
         self.thermal_cond = None
-        self.H = None
+        self.Q = None
         self.data = []
         self.t = []
 

--- a/festim/exports/derived_quantities/surface_flux.py
+++ b/festim/exports/derived_quantities/surface_flux.py
@@ -1,4 +1,4 @@
-from festim import SurfaceQuantity, R
+from festim import SurfaceQuantity, k_B
 import fenics as f
 
 
@@ -22,8 +22,8 @@ class SurfaceFlux(SurfaceQuantity):
             flux += f.assemble(
                 self.prop
                 * self.function
-                * self.H
-                / (R * self.T**2)
+                * self.Q
+                / (k_B * self.T**2)
                 * f.dot(f.grad(self.T), self.n)
                 * self.ds(self.surface)
             )

--- a/festim/materials/material.py
+++ b/festim/materials/material.py
@@ -18,9 +18,8 @@ class Material:
             be a function of T. Defaults to None.
         borders (list, optional): The borders of the 1D subdomain.
             Only needed in 1D with several materials. Defaults to None.
-        H (dict, optional): heat of transport (J/mol).
-            {"free_enthalpy": ..., "entropy": ...} so that
-            H = free_enthalpy + entropy*T. Defaults to None.
+        Q (float or callable, optional): heat of transport (eV). Can
+            be a function of T. Defaults to None.
         solubility_law (str, optional): the material's solubility law.
             Can be "henry" or "sievert". Defaults to "sievert".
         name (str, optional): name of the material. Defaults to None.
@@ -37,7 +36,7 @@ class Material:
         heat_capacity=None,
         rho=None,
         borders=None,
-        H=None,
+        Q=None,
         solubility_law="sievert",
         name=None,
     ) -> None:
@@ -51,10 +50,7 @@ class Material:
         self.heat_capacity = heat_capacity
         self.rho = rho
         self.borders = borders
-        self.H = H
-        if H is not None:
-            self.free_enthalpy = H["free_enthalpy"]
-            self.entropy = H["entropy"]
+        self.Q = Q
         if solubility_law not in ["henry", "sievert"]:
             raise ValueError(
                 "Acceptable values for solubility_law are 'henry' and 'sievert'"

--- a/festim/materials/material.py
+++ b/festim/materials/material.py
@@ -23,6 +23,18 @@ class Material:
         solubility_law (str, optional): the material's solubility law.
             Can be "henry" or "sievert". Defaults to "sievert".
         name (str, optional): name of the material. Defaults to None.
+
+    Example::
+
+        my_mat = Material(
+            id=1,
+            D_0=2e-7,
+            E_d=0.2,
+            thermal_cond=lambda T: 3 * T + 2,
+            heat_capacity=lambda T: 4 * T + 8,
+            rho=lambda T: 7 * T + 5,
+            Q=lambda T: -0.5 * T**2,
+        )
     """
 
     def __init__(

--- a/festim/materials/materials.py
+++ b/festim/materials/materials.py
@@ -21,7 +21,7 @@ class Materials:
         self.thermal_cond = None
         self.heat_capacity = None
         self.density = None
-        self.H = None
+        self.Q = None
 
     def check_borders(self, size):
         """Checks that the borders of the materials match
@@ -131,7 +131,7 @@ class Materials:
             "heat_capacity": [],
             "rho": [],
             "borders": [],
-            "H": [],
+            "Q": [],
         }
 
         for attr, value in attributes.items():
@@ -261,8 +261,8 @@ class Materials:
             self.thermal_cond = ThermalProp(self, vm, T, "thermal_cond", degree=2)
             self.heat_capacity = ThermalProp(self, vm, T, "heat_capacity", degree=2)
             self.density = ThermalProp(self, vm, T, "rho", degree=2)
-        if self.materials[0].H is not None:
-            self.H = HCoeff(self, vm, T, degree=2)
+        if self.materials[0].Q is not None:
+            self.Q = ThermalProp(self, vm, T, "Q", degree=2)
 
     def solubility_as_function(self, mesh, T):
         """
@@ -358,24 +358,6 @@ class ThermalProp(f.UserExpression):
             value[0] = attribute(self._T(x))
         else:
             value[0] = attribute
-
-    def value_shape(self):
-        return ()
-
-
-class HCoeff(f.UserExpression):
-    def __init__(self, materials, vm, T, **kwargs):
-        super().__init__(kwargs)
-        self._T = T
-        self._vm = vm
-        self._materials = materials
-
-    def eval_cell(self, value, x, ufc_cell):
-        cell = f.Cell(self._vm.mesh(), ufc_cell.index)
-        subdomain_id = self._vm[cell]
-        material = self._materials.find_material_from_id(subdomain_id)
-
-        value[0] = material.free_enthalpy + self._T(x) * material.entropy
 
     def value_shape(self):
         return ()

--- a/test/system/test_system.py
+++ b/test/system/test_system.py
@@ -474,28 +474,14 @@ def test_run_MMS_soret(tmpdir):
     D_0 = 2
     k_B = festim.k_B
     D = D_0 * sp.exp(-E_D / k_B / T)
-    H = -2
-    S = 3
-    R = festim.R
+    Q = lambda T: -2e-5 * T + 3e-5
     f = sp.diff(u, festim.t) - sp.diff(
-        (
-            D
-            * (
-                sp.diff(u, festim.x)
-                + (H * T + S) * u / (R * T**2) * sp.diff(T, festim.x)
-            )
-        ),
+        (D * (sp.diff(u, festim.x) + Q(T) * u / (k_B * T**2) * sp.diff(T, festim.x))),
         festim.x,
     )
 
     def run(h):
-        my_materials = festim.Materials(
-            [
-                festim.Material(
-                    id=1, D_0=D_0, E_D=E_D, H={"free_enthalpy": H, "entropy": S}
-                )
-            ]
-        )
+        my_materials = festim.Materials([festim.Material(id=1, D_0=D_0, E_D=E_D, Q=Q)])
         my_initial_conditions = [
             festim.InitialCondition(field=0, value=u),
         ]

--- a/test/unit/test_exports/test_derived_quantities/test_derived_quantities.py
+++ b/test/unit/test_exports/test_derived_quantities/test_derived_quantities.py
@@ -103,7 +103,7 @@ class TestAssignPropertiesToQuantities:
     my_mats = Materials()
     my_mats.D = f.Function(V)
     my_mats.S = f.Function(V)
-    my_mats.H = f.Function(V)
+    my_mats.Q = f.Function(V)
     my_mats.thermal_cond = f.Function(V)
     T = f.Function(V)
 
@@ -117,9 +117,9 @@ class TestAssignPropertiesToQuantities:
         for quantity in self.my_quantities.derived_quantities:
             assert quantity.S == self.my_mats.S
 
-    def test_quantities_have_H(self):
+    def test_quantities_have_Q(self):
         for quantity in self.my_quantities.derived_quantities:
-            assert quantity.H == self.my_mats.H
+            assert quantity.Q == self.my_mats.Q
 
     def test_quantities_have_thermal_cond(self):
         for quantity in self.my_quantities.derived_quantities:

--- a/test/unit/test_exports/test_derived_quantities/test_surface_flux.py
+++ b/test/unit/test_exports/test_derived_quantities/test_surface_flux.py
@@ -1,4 +1,4 @@
-from festim import SurfaceFlux, R
+from festim import SurfaceFlux, k_B
 import fenics as f
 
 
@@ -32,7 +32,7 @@ class TestCompute:
     ds = f.Measure("ds", domain=mesh, subdomain_data=surface_markers)
     D = f.Constant(2)
     thermal_cond = f.Constant(3)
-    H = f.Constant(4)
+    Q = f.Constant(4)
 
     surface = 1
     n = f.FacetNormal(mesh)
@@ -43,7 +43,7 @@ class TestCompute:
     my_h_flux.n = n
     my_h_flux.ds = ds
     my_h_flux.T = T
-    my_h_flux.H = H
+    my_h_flux.Q = Q
 
     my_heat_flux = SurfaceFlux("T", surface)
     my_heat_flux.D = D
@@ -73,8 +73,8 @@ class TestCompute:
         expected_flux += f.assemble(
             self.D
             * self.c
-            * self.H
-            / (R * self.T**2)
+            * self.Q
+            / (k_B * self.T**2)
             * f.dot(f.grad(self.T), self.n)
             * self.ds(self.surface)
         )

--- a/test/unit/test_materials.py
+++ b/test/unit/test_materials.py
@@ -1,18 +1,15 @@
-from festim import Material, Materials
 import festim as F
 from fenics import *
 import pytest
-
-from festim.temperature.temperature_solver import HeatTransferProblem
 
 
 def test_find_material_from_id():
     """Tests the function find_material_from_id() for cases with one id per
     material
     """
-    mat_1 = Material(id=1, D_0=None, E_D=None)
-    mat_2 = Material(id=2, D_0=None, E_D=None)
-    my_Mats = Materials([mat_1, mat_2])
+    mat_1 = F.Material(id=1, D_0=None, E_D=None)
+    mat_2 = F.Material(id=2, D_0=None, E_D=None)
+    my_Mats = F.Materials([mat_1, mat_2])
     assert my_Mats.find_material_from_id(1) == mat_1
     assert my_Mats.find_material_from_id(2) == mat_2
 
@@ -22,8 +19,8 @@ def test_find_material_from_id_with_several_ids():
     per material
     """
 
-    mat_1 = Material(id=[1, 2], D_0=None, E_D=None)
-    my_Mats = Materials([mat_1])
+    mat_1 = F.Material(id=[1, 2], D_0=None, E_D=None)
+    my_Mats = F.Materials([mat_1])
     assert my_Mats.find_material_from_id(1) == mat_1
     assert my_Mats.find_material_from_id(2) == mat_1
 
@@ -34,11 +31,11 @@ def test_find_material_from_id_unfound_id():
     without the searched ID
         - check that an error is rasied
     """
-    mat_1 = Material(id=5, D_0=None, E_D=None)
-    mat_2 = Material(id=2, D_0=None, E_D=None)
-    mat_3 = Material(id=-1, D_0=None, E_D=None)
+    mat_1 = F.Material(id=5, D_0=None, E_D=None)
+    mat_2 = F.Material(id=2, D_0=None, E_D=None)
+    mat_3 = F.Material(id=-1, D_0=None, E_D=None)
 
-    my_Mats = Materials([mat_1, mat_2, mat_3])
+    my_Mats = F.Materials([mat_1, mat_2, mat_3])
     id_test = 1
     with pytest.raises(ValueError, match="Couldn't find ID {}".format(id_test)):
         my_Mats.find_material_from_id(id_test)
@@ -46,9 +43,9 @@ def test_find_material_from_id_unfound_id():
 
 def test_find_material_from_name():
     """Checks the function find_material_from_name() returns the correct material"""
-    mat_1 = Material(id=1, D_0=None, E_D=None, name="mat1")
-    mat_2 = Material(id=2, D_0=None, E_D=None, name="mat2")
-    my_Mats = Materials([mat_1, mat_2])
+    mat_1 = F.Material(id=1, D_0=None, E_D=None, name="mat1")
+    mat_2 = F.Material(id=2, D_0=None, E_D=None, name="mat2")
+    my_Mats = F.Materials([mat_1, mat_2])
     assert my_Mats.find_material_from_name("mat1") == mat_1
     assert my_Mats.find_material_from_name("mat2") == mat_2
 
@@ -57,11 +54,11 @@ def test_find_material_from_name_unfound_name():
     """
     Check find_material_from_name raises an error when the name is not found
     """
-    mat_1 = Material(id=5, D_0=None, E_D=None)
-    mat_2 = Material(id=2, D_0=None, E_D=None)
-    mat_3 = Material(id=-1, D_0=None, E_D=None)
+    mat_1 = F.Material(id=5, D_0=None, E_D=None)
+    mat_2 = F.Material(id=2, D_0=None, E_D=None)
+    mat_3 = F.Material(id=-1, D_0=None, E_D=None)
 
-    my_Mats = Materials([mat_1, mat_2, mat_3])
+    my_Mats = F.Materials([mat_1, mat_2, mat_3])
     name_test = "coucou"
     with pytest.raises(
         ValueError, match="No material with name {} was found".format(name_test)
@@ -74,8 +71,8 @@ def test_unused_thermal_cond():
     Checks warnings when some keys are unused
     """
 
-    mat_1 = Material(id=1, D_0=1, E_D=2, thermal_cond=2)
-    my_mats = Materials([mat_1])
+    mat_1 = F.Material(id=1, D_0=1, E_D=2, thermal_cond=2)
+    my_mats = F.Materials([mat_1])
     with pytest.warns(UserWarning, match=r"thermal_cond key will be ignored"):
         my_mats.check_for_unused_properties(T=F.Temperature(100), derived_quantities=[])
 
@@ -93,7 +90,7 @@ def test_unused_thermal_cond():
 
 def test_missing_thermal_cond():
     """Tests that an error is raised when the thermal cond is missing"""
-    my_mats = Materials([Material(1, D_0=1, E_D=1)])
+    my_mats = F.Materials([F.Material(1, D_0=1, E_D=1)])
     with pytest.raises(ValueError, match="Missing thermal_cond in materials"):
         my_mats.check_missing_properties(
             T=F.HeatTransferProblem(), derived_quantities=[]
@@ -102,7 +99,7 @@ def test_missing_thermal_cond():
 
 def test_missing_heat_capacity():
     """Tests that an error is raised when the heat_capacity is missing"""
-    my_mats = Materials([Material(1, D_0=1, E_D=1, thermal_cond=1, rho=1)])
+    my_mats = F.Materials([F.Material(1, D_0=1, E_D=1, thermal_cond=1, rho=1)])
     with pytest.raises(ValueError, match="Missing heat_capacity in materials"):
         my_mats.check_missing_properties(
             T=F.HeatTransferProblem(), derived_quantities=[]
@@ -111,7 +108,9 @@ def test_missing_heat_capacity():
 
 def test_missing_rho():
     """Tests that an error is raised when the rho is missing"""
-    my_mats = Materials([Material(1, D_0=1, E_D=1, thermal_cond=1, heat_capacity=1)])
+    my_mats = F.Materials(
+        [F.Material(1, D_0=1, E_D=1, thermal_cond=1, heat_capacity=1)]
+    )
     with pytest.raises(ValueError, match="Missing rho in materials"):
         my_mats.check_missing_properties(
             T=F.HeatTransferProblem(), derived_quantities=[]
@@ -123,9 +122,9 @@ def test_different_ids_in_materials():
     Checks that an error is raised when two materials have the same id
     """
 
-    mat_1 = Material(id=1, D_0=1, E_D=2)
-    mat_2 = Material(id=1, D_0=2, E_D=3)
-    my_mats = Materials([mat_1, mat_2])
+    mat_1 = F.Material(id=1, D_0=1, E_D=2)
+    mat_2 = F.Material(id=1, D_0=2, E_D=3)
+    my_mats = F.Materials([mat_1, mat_2])
     with pytest.raises(ValueError, match=r"Some materials have the same id"):
         my_mats.check_unique_ids()
 
@@ -135,8 +134,8 @@ def test_unused_keys():
     Checks warnings when some keys are unused
     """
 
-    mat_1 = Material(id=1, D_0=1, E_D=2, rho=2)
-    my_mats = Materials([mat_1])
+    mat_1 = F.Material(id=1, D_0=1, E_D=2, rho=2)
+    my_mats = F.Materials([mat_1])
 
     with pytest.warns(UserWarning, match=r"rho key will be ignored"):
         my_mats.check_for_unused_properties(T=F.Temperature(200), derived_quantities={})
@@ -149,9 +148,9 @@ def test_unused_keys():
 
 
 def test_non_matching_properties():
-    mat_1 = Material(id=1, D_0=1, E_D=2, rho=2)
-    mat_2 = Material(id=1, D_0=1, E_D=2)
-    my_mats = Materials([mat_1, mat_2])
+    mat_1 = F.Material(id=1, D_0=1, E_D=2, rho=2)
+    mat_2 = F.Material(id=1, D_0=1, E_D=2)
+    my_mats = F.Materials([mat_1, mat_2])
     with pytest.raises(ValueError, match=r"rho is not defined for all materials"):
         my_mats.check_consistency()
 
@@ -159,57 +158,57 @@ def test_non_matching_properties():
 class TestCheckBorders:
     def test_works(self):
         materials = [
-            Material(id=1, D_0=None, E_D=None, borders=[0.5, 0.7]),
-            Material(id=2, D_0=None, E_D=None, borders=[0, 0.5]),
+            F.Material(id=1, D_0=None, E_D=None, borders=[0.5, 0.7]),
+            F.Material(id=2, D_0=None, E_D=None, borders=[0, 0.5]),
         ]
         size = 0.7
-        assert Materials(materials).check_borders(size) is True
+        assert F.Materials(materials).check_borders(size) is True
 
     def test_not_beginning_at_zero(self):
         with pytest.raises(ValueError, match=r"zero"):
             size = 0.7
             materials = [
-                Material(id=1, D_0=None, E_D=None, borders=[0.5, 0.7]),
-                Material(id=1, D_0=None, E_D=None, borders=[0.2, 0.5]),
+                F.Material(id=1, D_0=None, E_D=None, borders=[0.5, 0.7]),
+                F.Material(id=1, D_0=None, E_D=None, borders=[0.2, 0.5]),
             ]
-            Materials(materials).check_borders(size)
+            F.Materials(materials).check_borders(size)
 
     def test_not_matching(self):
         with pytest.raises(ValueError, match=r"each other"):
             materials = [
-                Material(id=1, D_0=None, E_D=None, borders=[0.5, 1]),
-                Material(id=1, D_0=None, E_D=None, borders=[0, 0.6]),
-                Material(id=1, D_0=None, E_D=None, borders=[0.6, 1]),
+                F.Material(id=1, D_0=None, E_D=None, borders=[0.5, 1]),
+                F.Material(id=1, D_0=None, E_D=None, borders=[0, 0.6]),
+                F.Material(id=1, D_0=None, E_D=None, borders=[0.6, 1]),
             ]
             size = 1
-            Materials(materials).check_borders(size)
+            F.Materials(materials).check_borders(size)
 
     def test_not_matching_with_size(self):
         with pytest.raises(ValueError, match=r"size"):
             materials = [
-                Material(id=1, D_0=None, E_D=None, borders=[0, 1]),
+                F.Material(id=1, D_0=None, E_D=None, borders=[0, 1]),
             ]
             size = 3
-            Materials(materials).check_borders(size)
+            F.Materials(materials).check_borders(size)
 
     def test_1_material_2_subdomains(self):
-        materials = Materials([Material([1, 2], 1, 0, borders=[[0, 1], [1, 9]])])
+        materials = F.Materials([F.Material([1, 2], 1, 0, borders=[[0, 1], [1, 9]])])
 
         materials.check_borders(size=9)
 
     def test_2_materials_3_subdomains(self):
-        materials = Materials(
+        materials = F.Materials(
             [
-                Material([1, 2], 1, 0, borders=[[0, 1], [1, 5]]),
-                Material(3, 1, 0, borders=[5, 9]),
+                F.Material([1, 2], 1, 0, borders=[[0, 1], [1, 5]]),
+                F.Material(3, 1, 0, borders=[5, 9]),
             ]
         )
         materials.check_borders(size=9)
 
     def test_1_material_1_id_2_borders(self):
-        materials = Materials(
+        materials = F.Materials(
             [
-                Material(1, 1, 0, borders=[[0, 1], [1, 9]]),
+                F.Material(1, 1, 0, borders=[[0, 1], [1, 9]]),
             ]
         )
         materials.check_borders(size=9)
@@ -220,8 +219,8 @@ def test_material_with_multiple_ids_solubility():
     per material
     """
 
-    mat_1 = Material(id=[1, 2], D_0=1, E_D=1)
-    my_mats = Materials([mat_1])
+    mat_1 = F.Material(id=[1, 2], D_0=1, E_D=1)
+    my_mats = F.Materials([mat_1])
     mesh = UnitIntervalMesh(10)
     vm = MeshFunction("size_t", mesh, 1, 1)
     my_mats.create_properties(vm, T=Constant(300))
@@ -235,7 +234,7 @@ def test_create_properties():
     """
     mesh = UnitIntervalMesh(10)
     DG_1 = FunctionSpace(mesh, "DG", 1)
-    mat_1 = Material(
+    mat_1 = F.Material(
         1,
         D_0=1,
         E_D=0,
@@ -244,9 +243,9 @@ def test_create_properties():
         thermal_cond=4,
         heat_capacity=5,
         rho=6,
-        H={"free_enthalpy": 5, "entropy": 6},
+        Q=11,
     )
-    mat_2 = Material(
+    mat_2 = F.Material(
         2,
         D_0=2,
         E_D=0,
@@ -255,9 +254,9 @@ def test_create_properties():
         thermal_cond=5,
         heat_capacity=6,
         rho=7,
-        H={"free_enthalpy": 6, "entropy": 6},
+        Q=12,
     )
-    materials = Materials([mat_1, mat_2])
+    materials = F.Materials([mat_1, mat_2])
     mf = MeshFunction("size_t", mesh, 1, 0)
     for cell in cells(mesh):
         x = cell.midpoint().x()
@@ -271,7 +270,7 @@ def test_create_properties():
     thermal_cond = interpolate(materials.thermal_cond, DG_1)
     cp = interpolate(materials.heat_capacity, DG_1)
     rho = interpolate(materials.density, DG_1)
-    H = interpolate(materials.H, DG_1)
+    Q = interpolate(materials.Q, DG_1)
     S = interpolate(materials.S, DG_1)
 
     for cell in cells(mesh):
@@ -279,18 +278,18 @@ def test_create_properties():
         assert thermal_cond(cell.midpoint().x()) == mf[cell] + 3
         assert cp(cell.midpoint().x()) == mf[cell] + 4
         assert rho(cell.midpoint().x()) == mf[cell] + 5
-        assert H(cell.midpoint().x()) == mf[cell] + 10
+        assert Q(cell.midpoint().x()) == mf[cell] + 10
         assert S(cell.midpoint().x()) == mf[cell] + 6
 
 
 def test_E_S_without_S_0():
     with pytest.raises(ValueError, match="S_0 cannot be None"):
-        Material(1, 1, 1, S_0=None, E_S=1)
+        F.Material(1, 1, 1, S_0=None, E_S=1)
 
 
 def test_S_0_without_E_S():
     with pytest.raises(ValueError, match="E_S cannot be None"):
-        Material(1, 1, 1, S_0=1, E_S=None)
+        F.Material(1, 1, 1, S_0=1, E_S=None)
 
 
 def test_error_wrong_solubility_law_string():
@@ -299,4 +298,4 @@ def test_error_wrong_solubility_law_string():
         ValueError,
         match="Acceptable values for solubility_law are 'henry' and 'sievert'",
     ):
-        Material(1, 1, 1, solubility_law="foo")
+        F.Material(1, 1, 1, solubility_law="foo")


### PR DESCRIPTION
This PR makes it possible to set the Soret coefficient as a function of temperature, according to #458. Following the discussion, the parameter is renamed to `Q` and expressed in eV. Most of the changes are made based on #468.

Basic usage:
```python
from FESTIM import Material

my_mat = Material(id=1, D_0=1, E_D=0, Q=lambda T: 2 + 5 * T)
# or
my_mat = Material(id=1, D_0=1, E_D=0, Q=10)

``` 
## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [x] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
