### PR TITLE
Bug in `test_unused_thermal_cond` due to pytest update

### DIFF
--- a/test/unit/test_materials.py
+++ b/test/unit/test_materials.py
@@ -3,6 +3,7 @@ from fenics import *
 import pytest
 import warnings
 
+
 def test_find_material_from_id():
     """Tests the function find_material_from_id() for cases with one id per
     material

--- a/test/unit/test_materials.py
+++ b/test/unit/test_materials.py
@@ -1,7 +1,7 @@
 import festim as F
 from fenics import *
 import pytest
-
+import warnings
 
 def test_find_material_from_id():
     """Tests the function find_material_from_id() for cases with one id per
@@ -78,14 +78,11 @@ def test_unused_thermal_cond():
 
     # this shouldn't throw warnings
     derived_quantities = [F.SurfaceFlux("T", surface=0)]
-    # record the warnings
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         my_mats.check_for_unused_properties(
             T=F.Temperature(100), derived_quantities=derived_quantities
         )
-
-    # check that no warning were raised
-    assert len(record) == 0
 
 
 def test_missing_thermal_cond():


### PR DESCRIPTION
## Proposed changes

Due to new release of pytest ([v8.0.0](https://pypi.org/project/pytest/8.0.0/)), `test_unused_thermal_cond` fails. The failure appears since `pytest.warns(None)` is depricated (since pytest [v7.0.0rc1](https://github.com/pytest-dev/pytest/issues/8645)) and all `PytestRemovedIn8Warning deprecation warnings are now errors by default` (since pytest [v8.0.0rc1](https://github.com/pytest-dev/pytest/issues/7363)). This PR modifies the test according to [suggestions](https://docs.pytest.org/en/7.1.x/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests).

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
