### PR TITLE
RaiseError when DirichletBC is set with another BC

### DIFF
--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -210,9 +210,7 @@ class Simulation:
 
         # collect all DirichletBCs
         dc_bcs = [
-            bc
-            for bc in self.boundary_conditions
-            if isinstance(bc, festim.DirichletBC) and (bc.field in valid_fields)
+            bc for bc in self.boundary_conditions if isinstance(bc, festim.DirichletBC)
         ]
 
         for bc in self.boundary_conditions:
@@ -229,11 +227,14 @@ class Simulation:
                     bc == dc_bc or bc.field != dc_bc.field
                 ):  # skip if the same BC or different fields
                     continue
-                for surf in bc.surfaces:
-                    if surf in dc_bc.surfaces:
-                        raise ValueError(
-                            f"A DirichletBC is simultaneously set with another boundary condition on surface {surf} for field {dc_bc.field}"
-                        )
+                # check if BCs share the same surfaces using the set().isdisjoint() method
+                # that returns True if the first set has no elements in common with other containers
+                if not set(bc.surfaces).isdisjoint(dc_bc.surfaces):
+                    # convert lists of surfaces to sets and obtain their intersetion
+                    intersection = set(bc.surfaces) & set(dc_bc.surfaces)
+                    raise ValueError(
+                        f"A DirichletBC is simultaneously set with another boundary condition on surfaces {intersection} for field {dc_bc.field}"
+                    )
 
     def initialise(self):
         """Initialise the model. Defines markers, create the suitable function

--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -230,7 +230,7 @@ class Simulation:
                 # check if BCs share the same surfaces using the set().isdisjoint() method
                 # that returns True if the first set has no elements in common with other containers
                 if not set(bc.surfaces).isdisjoint(dc_bc.surfaces):
-                    # convert lists of surfaces to sets and obtain their intersetion
+                    # convert lists of surfaces to sets and obtain their intersection
                     intersection = set(bc.surfaces) & set(dc_bc.surfaces)
                     raise ValueError(
                         f"A DirichletBC is simultaneously set with another boundary condition on surfaces {intersection} for field {dc_bc.field}"

--- a/test/system/test_misc.py
+++ b/test/system/test_misc.py
@@ -121,6 +121,33 @@ def test_wrong_value_for_bc_field(field):
         sim.initialise()
 
 
+@pytest.mark.parametrize("field", ["solute", "T"])
+@pytest.mark.parametrize("surfaces", [1, 2, [1, 2]])
+def test_error_DirichletBC_on_same_surface(field, surfaces):
+    """
+    Tests that an error is raised when a DiricheltBC is set on
+    a surface together with another boundary condition for the
+    same field
+    """
+    sim = F.Simulation()
+
+    sim.mesh = F.MeshFromVertices(np.linspace(0, 1, num=10))
+
+    sim.T = F.Temperature(500)
+
+    sim.materials = F.Materials([F.Material(1, D_0=1, E_D=0)])
+
+    sim.settings = F.Settings(1e-10, 1e-10, transient=False)
+
+    with pytest.raises(ValueError):
+        sim.boundary_conditions = [
+            F.FluxBC(value=1, field=field, surfaces=1),
+            F.DirichletBC(value=1, field=field, surfaces=2),
+            F.DirichletBC(value=1, field=field, surfaces=surfaces),
+        ]
+        sim.initialise()
+
+
 @pytest.mark.parametrize(
     "final_time,stepsize,export_times",
     [(1, 0.1, [0.2, 0.5]), (1e-7, 1e-9, [1e-8, 1.5e-8, 2e-8])],


### PR DESCRIPTION
## Proposed changes

With this PR, the error will be raised when `F.DirichletBC` is simultaneously set with `F.FluxBC` or `F.DirichletBC` on the same surface, according to the proposal of @RemDelaporteMathurin in #472. 

@RemDelaporteMathurin, @jhdark I added a test for this, but it worth examining.

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
