### PR TITLE
`max_stepsize` attribute for `festim.Stepsize`

### DIFF
--- a/docs/source/userguide/stepsize.rst
+++ b/docs/source/userguide/stepsize.rst
@@ -28,6 +28,12 @@ To cap the stepsize after some time, the parameters ``t_stop`` and ``stepsize_st
 
     my_stepsize = F.Stepsize(initial_value=1.2, stepsize_change_ratio=1.5, dt_min=1e-6, t_stop=10, stepsize_stop_max=1.5)
 
+Please note that the parameters ``t_stop`` and ``stepsize_stop_max`` will be deprecated in a future release. To set the maximal value of the stepsize, consider using the ``max_stepsize`` parameter:
+
+.. code-block:: python
+
+    my_stepsize = F.Stepsize(initial_value=1.2, stepsize_change_ratio=1.5, dt_min=1e-6, max_stepsize=lambda t: 1 if t < 1 else 2)
+
 The ``milestones`` argument can be used to make sure the simulation passes through specific times.
 This will modify the stepsize as needed.
 

--- a/docs/source/userguide/stepsize.rst
+++ b/docs/source/userguide/stepsize.rst
@@ -28,11 +28,13 @@ To cap the stepsize after some time, the parameters ``t_stop`` and ``stepsize_st
 
     my_stepsize = F.Stepsize(initial_value=1.2, stepsize_change_ratio=1.5, dt_min=1e-6, t_stop=10, stepsize_stop_max=1.5)
 
-Please note that the parameters ``t_stop`` and ``stepsize_stop_max`` will be deprecated in a future release. To set the maximal value of the stepsize, consider using the ``max_stepsize`` parameter:
+.. warning::
+    
+    Please note that the parameters ``t_stop`` and ``stepsize_stop_max`` will be deprecated in a future release. To set the maximal value of the stepsize, consider using the ``max_stepsize`` parameter:
+    
+    .. code-block:: python
 
-.. code-block:: python
-
-    my_stepsize = F.Stepsize(initial_value=1.2, stepsize_change_ratio=1.5, dt_min=1e-6, max_stepsize=lambda t: 1 if t < 1 else 2)
+        my_stepsize = F.Stepsize(initial_value=1.2, stepsize_change_ratio=1.5, dt_min=1e-6, max_stepsize=lambda t: 1 if t < 1 else 2)
 
 The ``milestones`` argument can be used to make sure the simulation passes through specific times.
 This will modify the stepsize as needed.

--- a/festim/stepsize.py
+++ b/festim/stepsize.py
@@ -50,10 +50,14 @@ class Stepsize:
     ) -> None:
         self.adaptive_stepsize = None
         if stepsize_change_ratio is not None:
+            if t_stop or stepsize_stop_max:
+                warnings.warn(
+                    "stepsize_stop_max and t_stop attributes will be deprecated in a future release, please use max_stepsize instead",
+                    DeprecationWarning,
+                )
+                max_stepsize = lambda t: stepsize_stop_max if t >= t_stop else None
             self.adaptive_stepsize = {
                 "stepsize_change_ratio": stepsize_change_ratio,
-                "t_stop": t_stop,
-                "stepsize_stop_max": stepsize_stop_max,
                 "max_stepsize": max_stepsize,
                 "dt_min": dt_min,
             }
@@ -89,8 +93,6 @@ class Stepsize:
         if self.adaptive_stepsize:
             change_ratio = self.adaptive_stepsize["stepsize_change_ratio"]
             dt_min = self.adaptive_stepsize["dt_min"]
-            stepsize_stop_max = self.adaptive_stepsize["stepsize_stop_max"]
-            t_stop = self.adaptive_stepsize["t_stop"]
             max_stepsize = self.adaptive_stepsize["max_stepsize"]
             if callable(max_stepsize):
                 max_stepsize = max_stepsize(t)
@@ -104,15 +106,7 @@ class Stepsize:
             else:
                 self.value.assign(float(self.value) / change_ratio)
 
-            if t_stop is not None:
-                warnings.warn(
-                    "stepsize_stop_max and t_stop attributes will be deprecated in a future release, please use max_stepsize instead",
-                    DeprecationWarning,
-                )
-                if t >= t_stop:
-                    if float(self.value) > stepsize_stop_max:
-                        self.value.assign(stepsize_stop_max)
-            elif max_stepsize is not None:
+            if max_stepsize is not None:
                 if float(self.value) > max_stepsize:
                     self.value.assign(max_stepsize)
 

--- a/festim/stepsize.py
+++ b/festim/stepsize.py
@@ -94,8 +94,6 @@ class Stepsize:
             change_ratio = self.adaptive_stepsize["stepsize_change_ratio"]
             dt_min = self.adaptive_stepsize["dt_min"]
             max_stepsize = self.adaptive_stepsize["max_stepsize"]
-            if callable(max_stepsize):
-                max_stepsize = max_stepsize(t)
 
             if not converged:
                 self.value.assign(float(self.value) / change_ratio)
@@ -106,6 +104,8 @@ class Stepsize:
             else:
                 self.value.assign(float(self.value) / change_ratio)
 
+            if callable(max_stepsize):
+                max_stepsize = max_stepsize(t)
             if max_stepsize is not None:
                 if float(self.value) > max_stepsize:
                     self.value.assign(max_stepsize)

--- a/test/unit/test_stepsize.py
+++ b/test/unit/test_stepsize.py
@@ -38,6 +38,20 @@ class TestAdapt:
         new_value = float(my_stepsize.value)
         assert new_value == my_stepsize.adaptive_stepsize["stepsize_stop_max"]
 
+    def test_hit_stepsize_max_float(self, my_stepsize):
+        my_stepsize.value.assign(10)
+        my_stepsize.adaptive_stepsize["max_stepsize"] = 1
+        my_stepsize.adapt(t=6, converged=True, nb_it=2)
+        new_value = float(my_stepsize.value)
+        assert new_value == my_stepsize.adaptive_stepsize["max_stepsize"]
+
+    def test_hit_stepsize_max_callable(self, my_stepsize):
+        my_stepsize.value.assign(10)
+        my_stepsize.adaptive_stepsize["max_stepsize"] = lambda t: t * 0 + 1
+        my_stepsize.adapt(t=6, converged=True, nb_it=2)
+        new_value = float(my_stepsize.value)
+        assert new_value == my_stepsize.adaptive_stepsize["max_stepsize"](1)
+
 
 def test_milestones_are_hit():
     """Test that the milestones are hit at the correct times"""
@@ -86,3 +100,17 @@ def test_next_milestone():
             if expected_milestone is not None
             else next_milestone is None
         )
+
+
+def test_DeprecationWarning_t_stop():
+    """A temporary test to check DeprecationWarning in festim.Stepsize"""
+
+    my_stepsize = festim.Stepsize(
+        initial_value=1e-8,
+        stepsize_change_ratio=2,
+        dt_min=1,
+        t_stop=0,
+        stepsize_stop_max=1,
+    )
+    with pytest.deprecated_call():
+        my_stepsize.adapt(t=6, converged=True, nb_it=2)


### PR DESCRIPTION
## Proposed changes

As discussed in #507, this PR introduces `max_stepsize` attribute for `festim.Stepsize` instead of `t_stop` and `stepsize_stop_max`.  The old parameters are left unchanged, but a `DeprecationWarning` is added. With this change, the basic usage now becomes:

```python
my_stepsize = F.Stepsize(
    initial_value=0.5,
    stepsize_change_ratio=1.1,
    max_stepsize=lambda t: None if t < 1 else 2,
    dt_min=1e-05,
)
``` 

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
