### PR TITLE
`Reaction.product` now accepts a list of `Species`

### DIFF
--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -670,11 +670,16 @@ class HydrogenTransportProblem:
                     * self.dx(reaction.volume.id)
                 )
             # product
-            self.formulation += (
-                -reaction.reaction_term(self.temperature_fenics)
-                * reaction.product.test_function
-                * self.dx(reaction.volume.id)
-            )
+            if isinstance(reaction.product, list):
+                products = reaction.product
+            else:
+                products = [reaction.product]
+            for product in products:
+                self.formulation += (
+                    -reaction.reaction_term(self.temperature_fenics)
+                    * product.test_function
+                    * self.dx(reaction.volume.id)
+                )
         # add sources
         for source in self.sources:
             self.formulation -= (

--- a/festim/reaction.py
+++ b/festim/reaction.py
@@ -91,10 +91,20 @@ class Reaction:
         self._reactant2 = value
 
     def __repr__(self) -> str:
-        return f"Reaction({self.reactant1} + {self.reactant2} <--> {self.product}, {self.k_0}, {self.E_k}, {self.p_0}, {self.E_p})"
+        if isinstance(self.product, list):
+            products = " + ".join([str(product) for product in self.product])
+            print(products)
+        else:
+            products = self.product
+        return f"Reaction({self.reactant1} + {self.reactant2} <--> {products}, {self.k_0}, {self.E_k}, {self.p_0}, {self.E_p})"
 
     def __str__(self) -> str:
-        return f"{self.reactant1} + {self.reactant2} <--> {self.product}"
+        if isinstance(self.product, list):
+            products = " + ".join([str(product) for product in self.product])
+            print(products)
+        else:
+            products = self.product
+        return f"{self.reactant1} + {self.reactant2} <--> {products}"
 
     def reaction_term(self, temperature):
         """Compute the reaction term at a given temperature.

--- a/festim/reaction.py
+++ b/festim/reaction.py
@@ -93,7 +93,6 @@ class Reaction:
     def __repr__(self) -> str:
         if isinstance(self.product, list):
             products = " + ".join([str(product) for product in self.product])
-            print(products)
         else:
             products = self.product
         return f"Reaction({self.reactant1} + {self.reactant2} <--> {products}, {self.k_0}, {self.E_k}, {self.p_0}, {self.E_p})"
@@ -101,7 +100,6 @@ class Reaction:
     def __str__(self) -> str:
         if isinstance(self.product, list):
             products = " + ".join([str(product) for product in self.product])
-            print(products)
         else:
             products = self.product
         return f"{self.reactant1} + {self.reactant2} <--> {products}"

--- a/festim/reaction.py
+++ b/festim/reaction.py
@@ -108,5 +108,13 @@ class Reaction:
         c_A = self.reactant1.concentration
         c_B = self.reactant2.concentration
 
-        c_C = self.product.solution
-        return k * c_A * c_B - p * c_C
+        if isinstance(self.product, list):
+            products = self.product
+        else:
+            products = [self.product]
+
+        products_of_product = products[0].solution
+        for product in products[1:]:
+            products_of_product *= product.solution
+
+        return k * c_A * c_B - p * products_of_product

--- a/test/test_complex_reaction.py
+++ b/test/test_complex_reaction.py
@@ -1,0 +1,168 @@
+import numpy as np
+import festim as F
+
+
+def concentration_A_exact(t, c_A_0, k, p):
+    """Analytical solution for the concentration of species A in a reaction A + B <-> C + D
+    assuming [A]_0 = [B]_0 and [C]_0 = [D]_0 = 0
+
+    Args:
+        t (float or ndarray): time
+        c_A_0 (float): initial concentration of A
+        k (float): forward reaction rate
+        p (float): backward reaction rate
+
+    Returns:
+        ndarray: the concentration of A at a given time
+    """
+
+    A = 1 - p / k
+    B = 2 * p / k * c_A_0
+    C = -p / k * c_A_0**2
+    roots = np.roots([A, B, C])
+
+    if len(roots) == 1:
+        a = roots[0]
+        b = roots[0]
+    else:
+        a, b = roots[0], roots[1]
+    correction_factor = (
+        1 - p / k
+    )  # TODO verify why this.... but checks out with scipy.solve_ivp
+    F = ((c_A_0 - a) / (c_A_0 - b)) * np.exp(-(a - b) * correction_factor * k * t)
+    return (a - b * F) / (1 - F)
+
+
+def model_test_reaction(stepsize):
+    """Creates a festim model with a single reaction and runs it.
+    The reaction is A + B <-> C + D
+
+    Args:
+        stepsize (float): the stepsize
+
+    Returns:
+        festim.HydrogenTransportProblem: the model
+    """
+
+    my_model = F.HydrogenTransportProblem()
+
+    # -------- Mesh --------- #
+
+    L = 1
+    vertices = np.linspace(0, L, num=10)
+    my_model.mesh = F.Mesh1D(vertices)
+
+    # -------- Materials and subdomains --------- #
+
+    mat = F.Material(D_0=1, E_D=0, name="mat")
+
+    my_subdomain = F.VolumeSubdomain1D(id=1, borders=[0, L], material=mat)
+    left_surface = F.SurfaceSubdomain1D(id=1, x=0)
+    right_surface = F.SurfaceSubdomain1D(id=2, x=L)
+
+    my_model.subdomains = [
+        my_subdomain,
+        left_surface,
+        right_surface,
+    ]
+
+    # -------- Hydrogen species and reactions --------- #
+
+    species_A = F.Species("A")
+    species_B = F.Species("B")
+    species_C = F.Species("C")
+    species_D = F.Species("D")
+
+    my_model.species = [
+        species_A,
+        species_B,
+        species_C,
+        species_D,
+    ]
+
+    my_model.reactions = [
+        F.Reaction(
+            k_0=350e-4,
+            E_k=0,
+            p_0=120e-4,
+            E_p=0,
+            reactant1=species_A,
+            reactant2=species_B,
+            product=[species_C, species_D],
+            volume=my_subdomain,
+        ),
+    ]
+
+    # -------- Temperature --------- #
+
+    my_model.temperature = 400
+
+    # -------- Boundary conditions --------- #
+
+    my_model.boundary_conditions = []
+
+    # -------- Initial conditions --------- #
+
+    my_model.initial_conditions = [
+        F.InitialCondition(value=1, species=species_A),
+        F.InitialCondition(value=1, species=species_B),
+    ]
+
+    # -------- Exports --------- #
+
+    total_A = F.TotalVolume(species_A, my_subdomain)
+    total_B = F.TotalVolume(species_B, my_subdomain)
+    total_C = F.TotalVolume(species_C, my_subdomain)
+    total_D = F.TotalVolume(species_D, my_subdomain)
+
+    my_model.exports = [total_A, total_B, total_C, total_D]
+
+    # -------- Settings --------- #
+
+    my_model.settings = F.Settings(
+        atol=1e-10, rtol=1e-10, max_iterations=30, final_time=200
+    )
+
+    my_model.settings.stepsize = F.Stepsize(initial_value=stepsize)
+
+    # -------- Run --------- #
+
+    my_model.initialise()
+
+    my_model.run()
+
+    return my_model
+
+
+def compute_error(model):
+    """Computes the relative L2 error norm between the analytical solution and the numerical solution
+
+    Args:
+        model (F.HydrogenTransportModel): the numerical festim model
+
+    Returns:
+        float: the relative L2 error norm
+    """
+    L = model.mesh.vertices[-1]
+    k = model.reactions[0].k_0
+    p = model.reactions[0].p_0
+    c_A_0 = model.initial_conditions[0].value
+    total_A = model.exports[0]
+    times = np.array(total_A.t)
+    data_total_A = total_A.data
+    data_total_A = np.array(data_total_A)
+    concentration_A_analytical = concentration_A_exact(t=times, c_A_0=c_A_0, k=k, p=p)
+
+    # relative l2 error norm
+    error = np.sqrt(
+        np.sum((concentration_A_analytical - data_total_A / L) ** 2)
+    ) / np.sqrt(np.sum(concentration_A_analytical**2))
+
+    return error
+
+
+def test_reaction():
+    stepsize = 1
+    model = model_test_reaction(stepsize)
+    error = compute_error(model)
+    assert error < 1e-2

--- a/test/test_complex_reaction.py
+++ b/test/test_complex_reaction.py
@@ -1,5 +1,6 @@
 import numpy as np
 import festim as F
+import pytest
 
 
 def concentration_A_exact(t, c_A_0, k, p):
@@ -36,12 +37,15 @@ def concentration_A_exact(t, c_A_0, k, p):
     return (a - b * F) / (1 - F)
 
 
-def model_test_reaction(stepsize):
+def model_test_reaction(stepsize=1, k=350e-4, p=120e-4, c_A_0=1):
     """Creates a festim model with a single reaction and runs it.
     The reaction is A + B <-> C + D
 
     Args:
         stepsize (float): the stepsize
+        k (float): the forward reaction rate
+        p (float): the backward reaction rate
+        c_A_0 (float): the initial concentration of A and B
 
     Returns:
         festim.HydrogenTransportProblem: the model
@@ -85,9 +89,9 @@ def model_test_reaction(stepsize):
 
     my_model.reactions = [
         F.Reaction(
-            k_0=350e-4,
+            k_0=k,
             E_k=0,
-            p_0=120e-4,
+            p_0=p,
             E_p=0,
             reactant1=species_A,
             reactant2=species_B,
@@ -107,8 +111,8 @@ def model_test_reaction(stepsize):
     # -------- Initial conditions --------- #
 
     my_model.initial_conditions = [
-        F.InitialCondition(value=1, species=species_A),
-        F.InitialCondition(value=1, species=species_B),
+        F.InitialCondition(value=c_A_0, species=species_A),
+        F.InitialCondition(value=c_A_0, species=species_B),
     ]
 
     # -------- Exports --------- #
@@ -164,8 +168,9 @@ def compute_error(model):
     return error
 
 
-def test_reaction():
-    stepsize = 1
-    model = model_test_reaction(stepsize)
+@pytest.mark.parametrize("k, p, c_A_0", [(350e-4, 120e-4, 3), (200e-4, 100e-4, 2)])
+def test_reaction(k, p, c_A_0):
+    """Test the reaction A + B <-> C + D with a festim model and compare the results with the analytical solution"""
+    model = model_test_reaction(stepsize=1, k=k, p=p, c_A_0=c_A_0)
     error = compute_error(model)
     assert error < 1e-2

--- a/test/test_complex_reaction.py
+++ b/test/test_complex_reaction.py
@@ -171,6 +171,6 @@ def compute_error(model):
 @pytest.mark.parametrize("k, p, c_A_0", [(350e-4, 120e-4, 3), (200e-4, 100e-4, 2)])
 def test_reaction(k, p, c_A_0):
     """Test the reaction A + B <-> C + D with a festim model and compare the results with the analytical solution"""
-    model = model_test_reaction(stepsize=1, k=k, p=p, c_A_0=c_A_0)
+    model = model_test_reaction(stepsize=0.5, k=k, p=p, c_A_0=c_A_0)
     error = compute_error(model)
     assert error < 1e-2

--- a/test/test_complex_reaction.py
+++ b/test/test_complex_reaction.py
@@ -5,6 +5,12 @@ import festim as F
 def concentration_A_exact(t, c_A_0, k, p):
     """Analytical solution for the concentration of species A in a reaction A + B <-> C + D
     assuming [A]_0 = [B]_0 and [C]_0 = [D]_0 = 0
+    can be obtained by solving
+    d[A]/dt = -k[A][B] + p[C][D]
+    where [A] = [B] and [C] = [D] = 0 at t=0
+    Moreover, [C] = [D] = [A]_0 - [A]
+    The equation then becomes
+    d[A]/dt = -k[A]^2 + p([A]_0 - [A])^2
 
     Args:
         t (float or ndarray): time
@@ -26,10 +32,7 @@ def concentration_A_exact(t, c_A_0, k, p):
         b = roots[0]
     else:
         a, b = roots[0], roots[1]
-    correction_factor = (
-        1 - p / k
-    )  # TODO verify why this.... but checks out with scipy.solve_ivp
-    F = ((c_A_0 - a) / (c_A_0 - b)) * np.exp(-(a - b) * correction_factor * k * t)
+    F = ((c_A_0 - a) / (c_A_0 - b)) * np.exp(-(a - b) * (k - p) * t)
     return (a - b * F) / (1 - F)
 
 

--- a/test/test_reaction.py
+++ b/test/test_reaction.py
@@ -52,6 +52,34 @@ def test_reaction_repr():
     assert repr(reaction) == expected_repr
 
 
+def test_reaction_repr_2_products():
+    """Test that the Reaction __repr__ method returns the expected string"""
+
+    # create two species
+    species1 = F.Species("A")
+    species2 = F.Species("B")
+
+    # create two product species
+    product1 = F.Species("C")
+    product2 = F.Species("D")
+
+    # create a reaction between the two species
+    reaction = F.Reaction(
+        species1,
+        species2,
+        [product1, product2],
+        k_0=1.0,
+        E_k=0.2,
+        p_0=0.1,
+        E_p=0.3,
+        volume=my_vol,
+    )
+
+    # check that the __repr__ method returns the expected string
+    expected_repr = "Reaction(A + B <--> C + D, 1.0, 0.2, 0.1, 0.3)"
+    assert repr(reaction) == expected_repr
+
+
 def test_reaction_str():
     """Test that the Reaction __str__ method returns the expected string"""
 

--- a/test/test_reaction.py
+++ b/test/test_reaction.py
@@ -72,6 +72,34 @@ def test_reaction_str():
     assert str(reaction) == expected_str
 
 
+def test_reaction_str_2_products():
+    """Test that the Reaction __str__ method returns the expected string when there are 2 products"""
+
+    # create two species
+    species1 = F.Species("A")
+    species2 = F.Species("B")
+
+    # create a product species
+    product1 = F.Species("C")
+    product2 = F.Species("D")
+
+    # create a reaction between the two species
+    reaction = F.Reaction(
+        species1,
+        species2,
+        [product1, product2],
+        k_0=1.0,
+        E_k=0.2,
+        p_0=0.1,
+        E_p=0.3,
+        volume=my_vol,
+    )
+
+    # check that the __str__ method returns the expected string
+    expected_str = "A + B <--> C + D"
+    assert str(reaction) == expected_str
+
+
 @pytest.mark.parametrize("temperature", [300.0, 350, 370, 500.0])
 def test_reaction_reaction_term(temperature):
     """Test that the Reaction.reaction_term method returns the expected reaction term"""
@@ -105,6 +133,51 @@ def test_reaction_reaction_term(temperature):
         k * species1.solution * species2.solution - p * product.solution
     )
 
+    assert reaction.reaction_term(temperature) == expected_reaction_term
+
+
+@pytest.mark.parametrize("temperature", [300.0, 350, 370, 500.0])
+def test_reaction_reaction_term_2_products(temperature):
+    """Test that the Reaction.reaction_term method returns the expected reaction term with two products"""
+
+    mesh = create_unit_cube(MPI.COMM_WORLD, 10, 10, 10)
+    V = functionspace(mesh, ("Lagrange", 1))
+
+    # create two species
+    species1 = F.Species("A")
+    species2 = F.Species("B")
+    species1.solution = Function(V)
+    species2.solution = Function(V)
+
+    # create a product species
+    product1 = F.Species("C")
+    product2 = F.Species("D")
+    product1.solution = Function(V)
+    product2.solution = Function(V)
+
+    # create a reaction between the two species
+    reaction = F.Reaction(
+        species1,
+        species2,
+        [product1, product2],
+        k_0=1.0,
+        E_k=0.2,
+        p_0=0.1,
+        E_p=0.3,
+        volume=my_vol,
+    )
+
+    # test the reaction term at a given temperature
+    def arrhenius(pre, act, T):
+        return pre * exp(-act / (F.k_B * T))
+
+    k = arrhenius(reaction.k_0, reaction.E_k, temperature)
+    p = arrhenius(reaction.p_0, reaction.E_p, temperature)
+
+    product_of_products = product1.solution * product2.solution
+    expected_reaction_term = (
+        k * species1.solution * species2.solution - p * product_of_products
+    )
     assert reaction.reaction_term(temperature) == expected_reaction_term
 
 


### PR DESCRIPTION
## Proposed changes

This PR fixes #702 by allowing users to give a list of `Species` for the product of a `Reaction`.

This gives us the ability to implement reactions of the type:

A + B <-> C + D

Need to merge #703 first since the tests use some of the functionality....

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [ ] Black formatted
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

