### PR TITLE
Patch derived quantity overwriting csv file

### DIFF
--- a/festim/exports/surface_quantity.py
+++ b/festim/exports/surface_quantity.py
@@ -26,6 +26,7 @@ class SurfaceQuantity:
 
         self.t = []
         self.data = []
+        self._first_time_export = True
 
     @property
     def filename(self):
@@ -68,15 +69,16 @@ class SurfaceQuantity:
     def write(self, t):
         """If the filename doesnt exist yet, create it and write the header,
         then append the time and value to the file"""
-
-        if not os.path.isfile(self.filename):
-            title = "Flux surface {}: {}".format(self.surface.id, self.field.name)
-
-            if self.filename is not None:
-                with open(self.filename, mode="w", newline="") as file:
+        title = "Flux surface {}: {}".format(
+            self.surface.id, self.field.name
+        )  # TODO this should be an attribute of the quantity
+        if self.filename is not None:
+            if self._first_time_export:
+                header = ["t(s)", f"{title}"]
+                with open(self.filename, mode="w+", newline="") as file:
                     writer = csv.writer(file)
-                    writer.writerow(["t(s)", f"{title}"])
-
-        with open(self.filename, mode="a", newline="") as file:
-            writer = csv.writer(file)
-            writer.writerow([t, self.value])
+                    writer.writerow(header)
+                self._first_time_export = False
+            with open(self.filename, mode="a", newline="") as file:
+                writer = csv.writer(file)
+                writer.writerow([t, self.value])

--- a/festim/exports/surface_quantity.py
+++ b/festim/exports/surface_quantity.py
@@ -1,6 +1,5 @@
 import festim as F
 import csv
-import os
 
 
 class SurfaceQuantity:

--- a/test/test_surface_quantity.py
+++ b/test/test_surface_quantity.py
@@ -80,6 +80,7 @@ def test_write_overwrite(tmp_path):
     )
     my_export.value = 2.0
     my_export.write(0)
+    my_export.write(1)
 
     my_export2 = F.SurfaceFlux(
         filename=filename,
@@ -88,11 +89,12 @@ def test_write_overwrite(tmp_path):
     )
     my_export2.value = 3.0
     my_export2.write(1)
+    my_export2.write(2)
+    my_export2.write(3)
 
     data = np.genfromtxt(filename, delimiter=",", names=True)
-    print(data)
-    file_length = len(data)
-    expected_length = 1
+    file_length = data.size
+    expected_length = 3
 
     assert file_length == expected_length
 

--- a/test/test_surface_quantity.py
+++ b/test/test_surface_quantity.py
@@ -70,6 +70,33 @@ def test_title_generation(tmp_path, value):
     assert title[1] == expected_title
 
 
+def test_write_overwrite(tmp_path):
+    """Test that the write method overwrites the file if it already exists"""
+    filename = os.path.join(tmp_path, "my_export.csv")
+    my_export = F.SurfaceFlux(
+        filename=filename,
+        field=F.Species("test"),
+        surface=F.SurfaceSubdomain1D(id=1, x=0),
+    )
+    my_export.value = 2.0
+    my_export.write(0)
+
+    my_export2 = F.SurfaceFlux(
+        filename=filename,
+        field=F.Species("test"),
+        surface=F.SurfaceSubdomain1D(id=1, x=0),
+    )
+    my_export2.value = 3.0
+    my_export2.write(1)
+
+    data = np.genfromtxt(filename, delimiter=",", names=True)
+    print(data)
+    file_length = len(data)
+    expected_length = 1
+
+    assert file_length == expected_length
+
+
 def test_filename_setter_raises_TypeError():
     """Test that a TypeError is raised when the filename is not a string"""
 


### PR DESCRIPTION
## Proposed changes

This is a patch to #705 

I just reworked the logic to check if it's the first time we write the csv and if so write the file and write the header, otherwise just append to it.

That requires to add another attribute `._first_time_export`, I don't know if we should document it or not but I added _ to say it's a private attribute. What do you think @jhdark ?

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
