### PR TITLE
Units in derived quantities title

### DIFF
--- a/festim/exports/derived_quantities/maximum_surface.py
+++ b/festim/exports/derived_quantities/maximum_surface.py
@@ -14,6 +14,7 @@ class MaximumSurface(DerivedQuantity):
     def __init__(self, field, surface) -> None:
         super().__init__(field)
         self.surface = surface
+
         self.title = "Maximum {} surface {}".format(self.field, self.surface)
 
     def compute(self, surface_markers):


### PR DESCRIPTION
## Proposed changes

With this change, users can opt to have units in the titles of the derived quantities file. They can do this with a new argument within the `DerivedQuantities` class like so:
```python
my_derived_quantities = F.DerivedQuantities(
    [
        F.TotalVolume("solute", volume=1),
        F.AverageVolume("solute", volume=1),
        F.MaximumVolume("solute", volume=1),
        F.MinimumVolume("solute", volume=1),
        F.SurfaceFlux("solute", surface=2),
    ],
    filename="derived_quantities.csv",
    show_units=True,
)
```
The unit is then added to the derived quantity's title, accounting for the mesh's dimension. For example, should a user call for a `TotalVolume` of the `solute` field in a 1D mesh case with units, the title will be `Total solute volume 1 (H m-2) `, whereas in the same case but in 2D, the title will be' Total solute volume 1 (H m-1) `.

The original format of the titles is left unchanged so as not to introduce breaking changes; however, it could be up for debate to change them to make them more consistent.

I have also taken the liberty to add doc strings to all of the derived quantities

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
