### PR TITLE
Custom solver

### DIFF
--- a/festim/__init__.py
+++ b/festim/__init__.py
@@ -113,3 +113,5 @@ from .concentration.traps.neutron_induced_trap import NeutronInducedTrap
 from .h_transport_problem import HTransportProblem
 
 from .generic_simulation import Simulation
+
+from .nonlinear_problem import Problem

--- a/festim/__init__.py
+++ b/festim/__init__.py
@@ -102,6 +102,7 @@ from .materials.materials import Materials
 from .concentration.concentration import Concentration
 from .initial_condition import InitialCondition
 from .concentration.mobile import Mobile
+from .nonlinear_problem import Problem
 from .concentration.theta import Theta
 
 from .concentration.traps.trap import Trap
@@ -113,5 +114,3 @@ from .concentration.traps.neutron_induced_trap import NeutronInducedTrap
 from .h_transport_problem import HTransportProblem
 
 from .generic_simulation import Simulation
-
-from .nonlinear_problem import Problem

--- a/festim/concentration/traps/extrinsic_trap.py
+++ b/festim/concentration/traps/extrinsic_trap.py
@@ -1,5 +1,5 @@
 from festim import Trap, as_constant_or_expression
-from fenics import NewtonSolver
+from fenics import NewtonSolver, MPI
 
 
 class ExtrinsicTrapBase(Trap):
@@ -57,7 +57,7 @@ class ExtrinsicTrapBase(Trap):
 
     def define_newton_solver(self):
         """Creates the Newton solver and sets its parameters"""
-        self.newton_solver = NewtonSolver()
+        self.newton_solver = NewtonSolver(MPI.comm_world)
         self.newton_solver.parameters["error_on_nonconvergence"] = False
         self.newton_solver.parameters["absolute_tolerance"] = self.absolute_tolerance
         self.newton_solver.parameters["relative_tolerance"] = self.relative_tolerance

--- a/festim/concentration/traps/extrinsic_trap.py
+++ b/festim/concentration/traps/extrinsic_trap.py
@@ -1,4 +1,5 @@
 from festim import Trap, as_constant_or_expression
+from fenics import NewtonSolver
 
 
 class ExtrinsicTrapBase(Trap):
@@ -14,6 +15,7 @@ class ExtrinsicTrapBase(Trap):
         relative_tolerance=1e-10,
         maximum_iterations=30,
         linear_solver=None,
+        preconditioner=None,
         **kwargs,
     ):
         """Inits ExtrinsicTrap
@@ -36,17 +38,32 @@ class ExtrinsicTrapBase(Trap):
                 If None, the default fenics linear solver will be used ("umfpack").
                 More information can be found at: https://fenicsproject.org/pub/tutorial/html/._ftut1017.html.
                 Defaults to None.
+            preconditioner (str, optional): preconditioning method for the newton solver,
+                options can be veiwed by print(list_krylov_solver_preconditioners()).
+                Defaults to None.
         """
         super().__init__(k_0, E_k, p_0, E_p, materials, density=None, id=id)
         self.absolute_tolerance = absolute_tolerance
         self.relative_tolerance = relative_tolerance
         self.maximum_iterations = maximum_iterations
         self.linear_solver = linear_solver
+        self.preconditioner = preconditioner
+        self.newton_solver = None
 
         for name, val in kwargs.items():
             setattr(self, name, as_constant_or_expression(val))
         self.density_previous_solution = None
         self.density_test_function = None
+
+    def define_newton_solver(self):
+        """Creates the Newton solver and sets its parameters"""
+        self.newton_solver = NewtonSolver()
+        self.newton_solver.parameters["error_on_nonconvergence"] = False
+        self.newton_solver.parameters["absolute_tolerance"] = self.absolute_tolerance
+        self.newton_solver.parameters["relative_tolerance"] = self.relative_tolerance
+        self.newton_solver.parameters["maximum_iterations"] = self.maximum_iterations
+        self.newton_solver.parameters["linear_solver"] = self.linear_solver
+        self.newton_solver.parameters["preconditioner"] = self.preconditioner
 
 
 class ExtrinsicTrap(ExtrinsicTrapBase):

--- a/festim/concentration/traps/extrinsic_trap.py
+++ b/festim/concentration/traps/extrinsic_trap.py
@@ -40,7 +40,7 @@ class ExtrinsicTrapBase(Trap):
                 Defaults to None.
             preconditioner (str, optional): preconditioning method for the newton solver,
                 options can be veiwed by print(list_krylov_solver_preconditioners()).
-                Defaults to None.
+                Defaults to "default".
         """
         super().__init__(k_0, E_k, p_0, E_p, materials, density=None, id=id)
         self.absolute_tolerance = absolute_tolerance
@@ -48,8 +48,8 @@ class ExtrinsicTrapBase(Trap):
         self.maximum_iterations = maximum_iterations
         self.linear_solver = linear_solver
         self.preconditioner = preconditioner
-        self.newton_solver = None
 
+        self.newton_solver = None
         for name, val in kwargs.items():
             setattr(self, name, as_constant_or_expression(val))
         self.density_previous_solution = None

--- a/festim/concentration/traps/extrinsic_trap.py
+++ b/festim/concentration/traps/extrinsic_trap.py
@@ -66,9 +66,7 @@ class ExtrinsicTrapBase(Trap):
             self._newton_solver = value
         elif isinstance(value, NewtonSolver):
             if self._newton_solver:
-                warnings.warn(
-                    "Settings for the Newton solver will be overwritten", UserWarning
-                )
+                print("Settings for the Newton solver will be overwritten")
             self._newton_solver = value
         else:
             raise TypeError("accepted type for newton_solver is fenics.NewtonSolver")

--- a/festim/concentration/traps/extrinsic_trap.py
+++ b/festim/concentration/traps/extrinsic_trap.py
@@ -1,5 +1,6 @@
 from festim import Trap, as_constant_or_expression
 from fenics import NewtonSolver, MPI
+import warnings
 
 
 class ExtrinsicTrapBase(Trap):
@@ -54,6 +55,23 @@ class ExtrinsicTrapBase(Trap):
             setattr(self, name, as_constant_or_expression(val))
         self.density_previous_solution = None
         self.density_test_function = None
+
+    @property
+    def newton_solver(self):
+        return self._newton_solver
+
+    @newton_solver.setter
+    def newton_solver(self, value):
+        if value is None:
+            self._newton_solver = value
+        elif isinstance(value, NewtonSolver):
+            if self._newton_solver:
+                warnings.warn(
+                    "Settings for the Newton solver will be overwritten", UserWarning
+                )
+            self._newton_solver = value
+        else:
+            raise TypeError("accepted type for newton_solver is fenics.NewtonSolver")
 
     def define_newton_solver(self):
         """Creates the Newton solver and sets its parameters"""

--- a/festim/concentration/traps/traps.py
+++ b/festim/concentration/traps/traps.py
@@ -120,7 +120,12 @@ class Traps(list):
                 du_t = f.TrialFunction(trap.density[0].function_space())
                 J_t = f.derivative(trap.form_density, trap.density[0], du_t)
                 problem = festim.Problem(J_t, trap.form_density, [])
+
+                f.begin(
+                    "Solving nonlinear variational problem."
+                )  # Add message to fenics logs
                 trap.newton_solver.solve(problem, trap.density[0].vector())
+                f.end()
 
     def update_extrinsic_traps_density(self):
         for trap in self:

--- a/festim/concentration/traps/traps.py
+++ b/festim/concentration/traps/traps.py
@@ -109,26 +109,18 @@ class Traps(list):
                 self.extrinsic_formulations.append(trap.form_density)
         self.sub_expressions.extend(expressions_extrinsic)
 
+    def define_newton_solver_extrinsic_traps(self):
+        for trap in self:
+            if isinstance(trap, festim.ExtrinsicTrapBase):
+                trap.define_newton_solver()
+
     def solve_extrinsic_traps(self):
         for trap in self:
             if isinstance(trap, festim.ExtrinsicTrapBase):
                 du_t = f.TrialFunction(trap.density[0].function_space())
                 J_t = f.derivative(trap.form_density, trap.density[0], du_t)
-                problem = f.NonlinearVariationalProblem(
-                    trap.form_density, trap.density[0], [], J_t
-                )
-                solver = f.NonlinearVariationalSolver(problem)
-                solver.parameters["newton_solver"][
-                    "absolute_tolerance"
-                ] = trap.absolute_tolerance
-                solver.parameters["newton_solver"][
-                    "relative_tolerance"
-                ] = trap.relative_tolerance
-                solver.parameters["newton_solver"][
-                    "maximum_iterations"
-                ] = trap.maximum_iterations
-                solver.parameters["newton_solver"]["linear_solver"] = trap.linear_solver
-                solver.solve()
+                problem = festim.Problem(J_t, trap.form_density, [])
+                trap.newton_solver.solve(problem, trap.density[0].vector())
 
     def update_extrinsic_traps_density(self):
         for trap in self:

--- a/festim/h_transport_problem.py
+++ b/festim/h_transport_problem.py
@@ -56,9 +56,7 @@ class HTransportProblem:
             self._newton_solver = value
         elif isinstance(value, NewtonSolver):
             if self._newton_solver:
-                warnings.warn(
-                    "Settings for the Newton solver will be overwritten", UserWarning
-                )
+                print("Settings for the Newton solver will be overwritten")
             self._newton_solver = value
         else:
             raise TypeError("accepted type for newton_solver is fenics.NewtonSolver")

--- a/festim/h_transport_problem.py
+++ b/festim/h_transport_problem.py
@@ -1,5 +1,6 @@
 from fenics import *
 import festim
+import warnings
 
 
 class HTransportProblem:
@@ -44,6 +45,23 @@ class HTransportProblem:
         self.V = None
         self.V_CG1 = None
         self.expressions = []
+
+    @property
+    def newton_solver(self):
+        return self._newton_solver
+
+    @newton_solver.setter
+    def newton_solver(self, value):
+        if value is None:
+            self._newton_solver = value
+        elif isinstance(value, NewtonSolver):
+            if self._newton_solver:
+                warnings.warn(
+                    "Settings for the Newton solver will be overwritten", UserWarning
+                )
+            self._newton_solver = value
+        else:
+            raise TypeError("accepted type for newton_solver is fenics.NewtonSolver")
 
     def initialise(self, mesh, materials, dt=None):
         """Assigns BCs, create suitable function space, initialise

--- a/festim/h_transport_problem.py
+++ b/festim/h_transport_problem.py
@@ -208,7 +208,7 @@ class HTransportProblem:
 
     def define_newton_solver(self):
         """Creates the Newton solver and sets its parameters"""
-        self.newton_solver = NewtonSolver()
+        self.newton_solver = NewtonSolver(MPI.comm_world)
         self.newton_solver.parameters["error_on_nonconvergence"] = False
         self.newton_solver.parameters[
             "absolute_tolerance"

--- a/festim/h_transport_problem.py
+++ b/festim/h_transport_problem.py
@@ -210,15 +210,15 @@ class HTransportProblem:
         """Creates the Newton solver and sets its parameters"""
         self.newton_solver = NewtonSolver(MPI.comm_world)
         self.newton_solver.parameters["error_on_nonconvergence"] = False
-        self.newton_solver.parameters[
-            "absolute_tolerance"
-        ] = self.settings.absolute_tolerance
-        self.newton_solver.parameters[
-            "relative_tolerance"
-        ] = self.settings.relative_tolerance
-        self.newton_solver.parameters[
-            "maximum_iterations"
-        ] = self.settings.maximum_iterations
+        self.newton_solver.parameters["absolute_tolerance"] = (
+            self.settings.absolute_tolerance
+        )
+        self.newton_solver.parameters["relative_tolerance"] = (
+            self.settings.relative_tolerance
+        )
+        self.newton_solver.parameters["maximum_iterations"] = (
+            self.settings.maximum_iterations
+        )
         self.newton_solver.parameters["linear_solver"] = self.settings.linear_solver
         self.newton_solver.parameters["preconditioner"] = self.settings.preconditioner
 

--- a/festim/h_transport_problem.py
+++ b/festim/h_transport_problem.py
@@ -61,6 +61,7 @@ class HTransportProblem:
             self.mobile.volume_markers = mesh.volume_markers
             self.mobile.T = self.T
         self.attribute_flux_boundary_conditions()
+
         # Define functions
         self.define_function_space(mesh)
         self.initialise_concentrations()
@@ -291,7 +292,6 @@ class HTransportProblem:
 
         problem = festim.Problem(J, self.F, self.bcs)
         nb_it, converged = self.newton_solver.solve(problem, self.u.vector())
-
         return nb_it, converged
 
     def update_previous_solutions(self):

--- a/festim/h_transport_problem.py
+++ b/festim/h_transport_problem.py
@@ -289,9 +289,12 @@ class HTransportProblem:
             J = derivative(self.F, self.u, du)
         else:
             J = self.J
-
         problem = festim.Problem(J, self.F, self.bcs)
+
+        begin("Solving nonlinear variational problem.")  # Add message to fenics logs
         nb_it, converged = self.newton_solver.solve(problem, self.u.vector())
+        end()
+
         return nb_it, converged
 
     def update_previous_solutions(self):

--- a/festim/nonlinear_problem.py
+++ b/festim/nonlinear_problem.py
@@ -3,7 +3,7 @@ import fenics as f
 
 class Problem(f.NonlinearProblem):
     """
-    Class to set up the nonlinear variational problem (F(u, v)=0) to solve
+    Class to set up a nonlinear variational problem (F(u, v)=0) to solve
     by the Newton method based on the form of the variational problem, the Jacobian
     form of the variational problem, and the boundary conditions
 

--- a/festim/nonlinear_problem.py
+++ b/festim/nonlinear_problem.py
@@ -1,0 +1,34 @@
+import fenics as f
+
+
+class Problem(f.NonlinearProblem):
+    """
+    Class to set up the nonlinear variational problem (F(u, v)=0) to solve
+    by the Newton method based on the form of the variational problem, the Jacobian
+    form of the variational problem, and the boundary conditions
+
+    Args:
+        bilinear_form (ufl.Form): the Jacobian form of the variational problem
+        linear_form (ufl.Form): the form of the variational problem
+        bcs (list): list of fenics.DirichletBC
+    """
+
+    def __init__(self, J, F, bcs):
+        self.bilinear_form = J
+        self.linear_form = F
+        self.bcs = bcs
+        f.NonlinearProblem.__init__(self)
+
+    def F(self, b, x):
+        """Assembles the RHS in AdU=b (JdU=F) and applies the boundary conditions"""
+        f.assemble(self.linear_form, tensor=b)
+        if self.bcs:
+            for bc in self.bcs:
+                bc.apply(b, x)
+
+    def J(self, A, x):
+        """Assembles the LHS in AdU=b (JdU=F) and applies the boundary conditions"""
+        f.assemble(self.bilinear_form, tensor=A)
+        if self.bcs:
+            for bc in self.bcs:
+                bc.apply(A)

--- a/festim/nonlinear_problem.py
+++ b/festim/nonlinear_problem.py
@@ -8,27 +8,27 @@ class Problem(f.NonlinearProblem):
     form of the variational problem, and the boundary conditions
 
     Args:
-        bilinear_form (ufl.Form): the Jacobian form of the variational problem
-        linear_form (ufl.Form): the form of the variational problem
+        jacobian_form (ufl.Form): the Jacobian form of the variational problem
+        residual_form (ufl.Form): the form of the variational problem
         bcs (list): list of fenics.DirichletBC
     """
 
     def __init__(self, J, F, bcs):
-        self.bilinear_form = J
-        self.linear_form = F
+        self.jacobian_form = J
+        self.residual_form = F
         self.bcs = bcs
         f.NonlinearProblem.__init__(self)
 
     def F(self, b, x):
-        """Assembles the RHS in AdU=b (JdU=F) and applies the boundary conditions"""
-        f.assemble(self.linear_form, tensor=b)
+        """Assembles the RHS in Ax=b and applies the boundary conditions"""
+        f.assemble(self.residual_form, tensor=b)
         if self.bcs:
             for bc in self.bcs:
                 bc.apply(b, x)
 
     def J(self, A, x):
-        """Assembles the LHS in AdU=b (JdU=F) and applies the boundary conditions"""
-        f.assemble(self.bilinear_form, tensor=A)
+        """Assembles the LHS in Ax=b and applies the boundary conditions"""
+        f.assemble(self.jacobian_form, tensor=A)
         if self.bcs:
             for bc in self.bcs:
                 bc.apply(A)

--- a/festim/nonlinear_problem.py
+++ b/festim/nonlinear_problem.py
@@ -17,18 +17,13 @@ class Problem(f.NonlinearProblem):
         self.jacobian_form = J
         self.residual_form = F
         self.bcs = bcs
+        self.assembler = f.SystemAssembler(self.jacobian_form, self.residual_form, self.bcs)
         f.NonlinearProblem.__init__(self)
 
     def F(self, b, x):
         """Assembles the RHS in Ax=b and applies the boundary conditions"""
-        f.assemble(self.residual_form, tensor=b)
-        if self.bcs:
-            for bc in self.bcs:
-                bc.apply(b, x)
+        self.assembler.assemble(b, x)
 
     def J(self, A, x):
         """Assembles the LHS in Ax=b and applies the boundary conditions"""
-        f.assemble(self.jacobian_form, tensor=A)
-        if self.bcs:
-            for bc in self.bcs:
-                bc.apply(A)
+        self.assembler.assemble(A)

--- a/festim/nonlinear_problem.py
+++ b/festim/nonlinear_problem.py
@@ -17,7 +17,9 @@ class Problem(f.NonlinearProblem):
         self.jacobian_form = J
         self.residual_form = F
         self.bcs = bcs
-        self.assembler = f.SystemAssembler(self.jacobian_form, self.residual_form, self.bcs)
+        self.assembler = f.SystemAssembler(
+            self.jacobian_form, self.residual_form, self.bcs
+        )
         f.NonlinearProblem.__init__(self)
 
     def F(self, b, x):

--- a/festim/nonlinear_problem.py
+++ b/festim/nonlinear_problem.py
@@ -8,8 +8,8 @@ class Problem(f.NonlinearProblem):
     form of the variational problem, and the boundary conditions
 
     Args:
-        jacobian_form (ufl.Form): the Jacobian form of the variational problem
-        residual_form (ufl.Form): the form of the variational problem
+        J (ufl.Form): the Jacobian form of the variational problem
+        F (ufl.Form): the form of the variational problem
         bcs (list): list of fenics.DirichletBC
     """
 

--- a/festim/settings.py
+++ b/festim/settings.py
@@ -25,6 +25,9 @@ class Settings:
             options can be veiwed by print(list_linear_solver_methods()).
             More information can be found at: https://fenicsproject.org/pub/tutorial/html/._ftut1017.html.
             Defaults to None, for the newton solver this is: "umfpack".
+        preconditioner (str, optional): preconditioning method for the newton solver,
+            options can be veiwed by print(list_krylov_solver_preconditioners()).
+            Defaults to None.
 
     Attributes:
         transient (bool): transient or steady state sim
@@ -40,6 +43,7 @@ class Settings:
         traps_element_type (str): Finite element used for traps.
         update_jacobian (bool):
         linear_solver (str): linear solver method for the newton solver
+        precondtitioner (str): preconditioning method for the newton solver
     """
 
     def __init__(
@@ -54,6 +58,7 @@ class Settings:
         traps_element_type="CG",
         update_jacobian=True,
         linear_solver=None,
+        preconditioner=None,
     ):
         # TODO maybe transient and final_time are redundant
         self.transient = transient
@@ -68,3 +73,4 @@ class Settings:
         self.traps_element_type = traps_element_type
         self.update_jacobian = update_jacobian
         self.linear_solver = linear_solver
+        self.preconditioner = preconditioner

--- a/festim/settings.py
+++ b/festim/settings.py
@@ -27,7 +27,7 @@ class Settings:
             Defaults to None, for the newton solver this is: "umfpack".
         preconditioner (str, optional): preconditioning method for the newton solver,
             options can be veiwed by print(list_krylov_solver_preconditioners()).
-            Defaults to None.
+            Defaults to "default".
 
     Attributes:
         transient (bool): transient or steady state sim

--- a/festim/settings.py
+++ b/festim/settings.py
@@ -22,11 +22,11 @@ class Settings:
             the formulation will be computed only once at the beggining.
             Else it will be computed at each time step. Defaults to True.
         linear_solver (str, optional): linear solver method for the newton solver,
-            options can be veiwed by print(list_linear_solver_methods()).
+            options can be viewed by print(list_linear_solver_methods()).
             More information can be found at: https://fenicsproject.org/pub/tutorial/html/._ftut1017.html.
             Defaults to None, for the newton solver this is: "umfpack".
         preconditioner (str, optional): preconditioning method for the newton solver,
-            options can be veiwed by print(list_krylov_solver_preconditioners()).
+            options can be viewed by print(list_krylov_solver_preconditioners()).
             Defaults to "default".
 
     Attributes:

--- a/festim/settings.py
+++ b/festim/settings.py
@@ -58,7 +58,7 @@ class Settings:
         traps_element_type="CG",
         update_jacobian=True,
         linear_solver=None,
-        preconditioner=None,
+        preconditioner="default",
     ):
         # TODO maybe transient and final_time are redundant
         self.transient = transient

--- a/festim/temperature/temperature_solver.py
+++ b/festim/temperature/temperature_solver.py
@@ -74,9 +74,7 @@ class HeatTransferProblem(festim.Temperature):
             self._newton_solver = value
         elif isinstance(value, f.NewtonSolver):
             if self._newton_solver:
-                warnings.warn(
-                    "Settings for the Newton solver will be overwritten", UserWarning
-                )
+                print("Settings for the Newton solver will be overwritten")
             self._newton_solver = value
         else:
             raise TypeError("accepted type for newton_solver is fenics.NewtonSolver")

--- a/festim/temperature/temperature_solver.py
+++ b/festim/temperature/temperature_solver.py
@@ -106,7 +106,13 @@ class HeatTransferProblem(festim.Temperature):
             dT = f.TrialFunction(self.T.function_space())
             JT = f.derivative(self.F, self.T, dT)
             problem = festim.Problem(JT, self.F, self.dirichlet_bcs)
+
+            f.begin(
+                "Solving nonlinear variational problem."
+            )  # Add message to fenics logs
             self.newton_solver.solve(problem, self.T.vector())
+            f.end()
+
             self.T_n.assign(self.T)
 
     def define_variational_problem(self, materials, mesh, dt=None):
@@ -227,7 +233,13 @@ class HeatTransferProblem(festim.Temperature):
             dT = f.TrialFunction(self.T.function_space())
             JT = f.derivative(self.F, self.T, dT)  # Define the Jacobian
             problem = festim.Problem(JT, self.F, self.dirichlet_bcs)
+
+            f.begin(
+                "Solving nonlinear variational problem."
+            )  # Add message to fenics logs
             self.newton_solver.solve(problem, self.T.vector())
+            f.end()
+
             self.T_n.assign(self.T)
 
     def is_steady_state(self):

--- a/festim/temperature/temperature_solver.py
+++ b/festim/temperature/temperature_solver.py
@@ -1,6 +1,7 @@
 import festim
 import fenics as f
 import sympy as sp
+import warnings
 
 
 class HeatTransferProblem(festim.Temperature):
@@ -62,6 +63,23 @@ class HeatTransferProblem(festim.Temperature):
         self.boundary_conditions = []
         self.sub_expressions = []
         self.newton_solver = None
+
+    @property
+    def newton_solver(self):
+        return self._newton_solver
+
+    @newton_solver.setter
+    def newton_solver(self, value):
+        if value is None:
+            self._newton_solver = value
+        elif isinstance(value, f.NewtonSolver):
+            if self._newton_solver:
+                warnings.warn(
+                    "Settings for the Newton solver will be overwritten", UserWarning
+                )
+            self._newton_solver = value
+        else:
+            raise TypeError("accepted type for newton_solver is fenics.NewtonSolver")
 
     # TODO rename initialise?
     def create_functions(self, materials, mesh, dt=None):

--- a/festim/temperature/temperature_solver.py
+++ b/festim/temperature/temperature_solver.py
@@ -23,7 +23,7 @@ class HeatTransferProblem(festim.Temperature):
             Defaults to None.
         preconditioner (str, optional): preconditioning method for the newton solver,
             options can be veiwed by print(list_krylov_solver_preconditioners()).
-            Defaults to None.
+            Defaults to "default".
 
     Attributes:
         F (fenics.Form): the variational form of the heat transfer problem
@@ -45,7 +45,7 @@ class HeatTransferProblem(festim.Temperature):
         relative_tolerance=1e-10,
         maximum_iterations=30,
         linear_solver=None,
-        preconditioner=None,
+        preconditioner="default",
     ) -> None:
         super().__init__()
         self.transient = transient
@@ -97,7 +97,9 @@ class HeatTransferProblem(festim.Temperature):
 
         self.define_variational_problem(materials, mesh, dt)
         self.create_dirichlet_bcs(mesh.surface_markers)
-        self.define_newton_solver_temperature()
+
+        if not self.newton_solver:
+            self.define_newton_solver()
 
         if not self.transient:
             print("Solving stationary heat equation")
@@ -183,7 +185,7 @@ class HeatTransferProblem(festim.Temperature):
                 for surf in bc.surfaces:
                     self.F += -bc.form * self.v_T * mesh.ds(surf)
 
-    def define_newton_solver_temperature(self):
+    def define_newton_solver(self):
         """Creates the Newton solver and sets its parameters"""
         self.newton_solver = f.NewtonSolver(f.MPI.comm_world)
         self.newton_solver.parameters["error_on_nonconvergence"] = False

--- a/festim/temperature/temperature_solver.py
+++ b/festim/temperature/temperature_solver.py
@@ -185,7 +185,7 @@ class HeatTransferProblem(festim.Temperature):
 
     def define_newton_solver_temperature(self):
         """Creates the Newton solver and sets its parameters"""
-        self.newton_solver = f.NewtonSolver()
+        self.newton_solver = f.NewtonSolver(f.MPI.comm_world)
         self.newton_solver.parameters["error_on_nonconvergence"] = False
         self.newton_solver.parameters["absolute_tolerance"] = self.absolute_tolerance
         self.newton_solver.parameters["relative_tolerance"] = self.relative_tolerance

--- a/festim/temperature/temperature_solver.py
+++ b/festim/temperature/temperature_solver.py
@@ -55,13 +55,13 @@ class HeatTransferProblem(festim.Temperature):
         self.maximum_iterations = maximum_iterations
         self.linear_solver = linear_solver
         self.preconditioner = preconditioner
-        self.newton_solver = None
 
         self.F = 0
         self.v_T = None
         self.sources = []
         self.boundary_conditions = []
         self.sub_expressions = []
+        self.newton_solver = None
 
     # TODO rename initialise?
     def create_functions(self, materials, mesh, dt=None):
@@ -96,8 +96,8 @@ class HeatTransferProblem(festim.Temperature):
                 self.T_n.assign(f.interpolate(self.initial_condition.value, V))
 
         self.define_variational_problem(materials, mesh, dt)
-        self.define_newton_solver()
         self.create_dirichlet_bcs(mesh.surface_markers)
+        self.define_newton_solver_temperature()
 
         if not self.transient:
             print("Solving stationary heat equation")
@@ -183,7 +183,7 @@ class HeatTransferProblem(festim.Temperature):
                 for surf in bc.surfaces:
                     self.F += -bc.form * self.v_T * mesh.ds(surf)
 
-    def define_newton_solver(self):
+    def define_newton_solver_temperature(self):
         """Creates the Newton solver and sets its parameters"""
         self.newton_solver = f.NewtonSolver()
         self.newton_solver.parameters["error_on_nonconvergence"] = False

--- a/test/h_transport_problem/test_solving.py
+++ b/test/h_transport_problem/test_solving.py
@@ -176,15 +176,15 @@ class Test_solve_once_with_custom_solver:
         # solve with the custom solver
         problem_2 = self.sim()
         problem_2.newton_solver = f.NewtonSolver()
-        problem_2.newton_solver.parameters[
-            "absolute_tolerance"
-        ] = problem_1.settings.absolute_tolerance
-        problem_2.newton_solver.parameters[
-            "relative_tolerance"
-        ] = problem_1.settings.relative_tolerance
-        problem_2.newton_solver.parameters[
-            "maximum_iterations"
-        ] = problem_1.settings.maximum_iterations
+        problem_2.newton_solver.parameters["absolute_tolerance"] = (
+            problem_1.settings.absolute_tolerance
+        )
+        problem_2.newton_solver.parameters["relative_tolerance"] = (
+            problem_1.settings.relative_tolerance
+        )
+        problem_2.newton_solver.parameters["maximum_iterations"] = (
+            problem_1.settings.maximum_iterations
+        )
         problem_2.solve_once()
 
         assert (problem_1.u.vector() == problem_2.u.vector()).all()

--- a/test/h_transport_problem/test_solving.py
+++ b/test/h_transport_problem/test_solving.py
@@ -98,12 +98,12 @@ def test_solve_once_returns_false():
     assert not converged
 
 
-@pytest.mark.parametrize("preconditioner",["default", "icc"])
+@pytest.mark.parametrize("preconditioner", ["default", "icc"])
 def test_solve_once_linear_solver_gmres(preconditioner):
     """
-    Checks that solve_once() works when an alternative linear solver is used 
+    Checks that solve_once() works when an alternative linear solver is used
     with/without a preconditioner rather than the default
-    
+
     Args:
         preconditioner (str): the preconditioning method
     """
@@ -136,5 +136,55 @@ def test_solve_once_linear_solver_gmres(preconditioner):
     # test
     assert converged
 
-    #def test_solve_once_with_custom_solver():
-        
+
+class Test_solve_once_with_custom_solver:
+    """
+    Checks that a custom newton sovler can be used
+    """
+
+    def sim(self):
+        """Defines a model"""
+        mesh = f.UnitIntervalMesh(8)
+        V = f.FunctionSpace(mesh, "CG", 1)
+
+        my_settings = festim.Settings(
+            absolute_tolerance=1e-10,
+            relative_tolerance=1e-10,
+            maximum_iterations=50,
+        )
+        my_problem = festim.HTransportProblem(
+            festim.Mobile(), festim.Traps([]), festim.Temperature(200), my_settings, []
+        )
+        my_problem.define_newton_solver()
+        my_problem.u = f.Function(V)
+        my_problem.u_n = f.Function(V)
+        my_problem.v = f.TestFunction(V)
+        my_problem.F = (
+            (my_problem.u - my_problem.u_n) * my_problem.v * f.dx
+            + 1 * my_problem.v * f.dx
+            + f.dot(f.grad(my_problem.u), f.grad(my_problem.v)) * f.dx
+        )
+        return my_problem
+
+    def test_custom_solver(self):
+        """Solves the system using the built-in solver and using the f.NewtonSolver"""
+
+        # solve with the built-in solver
+        problem_1 = self.sim()
+        problem_1.solve_once()
+
+        # solve with the custom solver
+        problem_2 = self.sim()
+        problem_2.newton_solver = f.NewtonSolver()
+        problem_2.newton_solver.parameters[
+            "absolute_tolerance"
+        ] = problem_1.settings.absolute_tolerance
+        problem_2.newton_solver.parameters[
+            "relative_tolerance"
+        ] = problem_1.settings.relative_tolerance
+        problem_2.newton_solver.parameters[
+            "maximum_iterations"
+        ] = problem_1.settings.maximum_iterations
+        problem_2.solve_once()
+
+        assert (problem_1.u.vector() == problem_2.u.vector()).all()

--- a/test/heat_transfer_problem/test_solving.py
+++ b/test/heat_transfer_problem/test_solving.py
@@ -3,12 +3,12 @@ import pytest
 import fenics as f
 
 
-@pytest.mark.parametrize("preconditioner",["default", "icc"])
+@pytest.mark.parametrize("preconditioner", ["default", "icc"])
 def test_create_functions_linear_solver_gmres(preconditioner):
     """
     Checks that the function created by create_functions() has the expected value when an
     alternative linear solver is used with/without a preconditioner rather than the default
-    
+
     Args:
         preconditioner (str): the preconditioning method
     """
@@ -36,3 +36,52 @@ def test_create_functions_linear_solver_gmres(preconditioner):
     my_problem.create_functions(materials=materials, mesh=mesh)
 
     assert my_problem.T(0.05) == pytest.approx(1)
+
+
+class Test_solve_once_with_custom_solver:
+    """
+    Checks that a custom newton sovler can be used
+    """
+
+    def sim(self):
+        """Defines a model"""
+        bcs = [
+            festim.DirichletBC(surfaces=[1, 2], value=1, field="T"),
+        ]
+
+        my_problem = festim.HeatTransferProblem(
+            transient=False,
+            absolute_tolerance=1e-03,
+            relative_tolerance=1e-10,
+            maximum_iterations=30,
+        )
+        my_problem.boundary_conditions = bcs
+        return my_problem
+
+    def test_custom_solver(self):
+        """Solves the system using the built-in solver and using the f.NewtonSolver"""
+        mesh = festim.MeshFromRefinements(10, size=0.1)
+        materials = festim.Materials(
+            [festim.Material(id=1, D_0=1, E_D=0, thermal_cond=1)]
+        )
+        mesh.define_measures(materials)
+
+        # solve with the built-in solver
+        problem_1 = self.sim()
+        problem_1.create_functions(materials=materials, mesh=mesh)
+
+        # solve with the custom solver
+        problem_2 = self.sim()
+        problem_2.newton_solver = f.NewtonSolver()
+        problem_2.newton_solver.parameters[
+            "absolute_tolerance"
+        ] = problem_1.absolute_tolerance
+        problem_2.newton_solver.parameters[
+            "relative_tolerance"
+        ] = problem_1.relative_tolerance
+        problem_2.newton_solver.parameters[
+            "maximum_iterations"
+        ] = problem_1.maximum_iterations
+        problem_2.create_functions(materials=materials, mesh=mesh)
+
+        assert (problem_1.T.vector() == problem_2.T.vector()).all()

--- a/test/heat_transfer_problem/test_solving.py
+++ b/test/heat_transfer_problem/test_solving.py
@@ -3,9 +3,15 @@ import pytest
 import fenics as f
 
 
-def test_create_functions_linear_solver_mumps():
-    """Checks that the function created by create_functions() has the expected value when an
-    alternative linear solver is used rather than the default"""
+@pytest.mark.parametrize("preconditioner",["default", "icc"])
+def test_create_functions_linear_solver_gmres(preconditioner):
+    """
+    Checks that the function created by create_functions() has the expected value when an
+    alternative linear solver is used with/without a preconditioner rather than the default
+    
+    Args:
+        preconditioner (str): the preconditioning method
+    """
 
     mesh = festim.MeshFromRefinements(10, size=0.1)
 
@@ -21,7 +27,8 @@ def test_create_functions_linear_solver_mumps():
         absolute_tolerance=1e-03,
         relative_tolerance=1e-10,
         maximum_iterations=30,
-        linear_solver="mumps",
+        linear_solver="gmres",
+        preconditioner=preconditioner,
     )
     my_problem.boundary_conditions = bcs
 

--- a/test/heat_transfer_problem/test_solving.py
+++ b/test/heat_transfer_problem/test_solving.py
@@ -73,15 +73,15 @@ class Test_solve_once_with_custom_solver:
         # solve with the custom solver
         problem_2 = self.sim()
         problem_2.newton_solver = f.NewtonSolver()
-        problem_2.newton_solver.parameters[
-            "absolute_tolerance"
-        ] = problem_1.absolute_tolerance
-        problem_2.newton_solver.parameters[
-            "relative_tolerance"
-        ] = problem_1.relative_tolerance
-        problem_2.newton_solver.parameters[
-            "maximum_iterations"
-        ] = problem_1.maximum_iterations
+        problem_2.newton_solver.parameters["absolute_tolerance"] = (
+            problem_1.absolute_tolerance
+        )
+        problem_2.newton_solver.parameters["relative_tolerance"] = (
+            problem_1.relative_tolerance
+        )
+        problem_2.newton_solver.parameters["maximum_iterations"] = (
+            problem_1.maximum_iterations
+        )
         problem_2.create_functions(materials=materials, mesh=mesh)
 
         assert (problem_1.T.vector() == problem_2.T.vector()).all()

--- a/test/system/test_misc.py
+++ b/test/system/test_misc.py
@@ -461,47 +461,44 @@ class TestWarningsCustomSolver:
         ):
             problem.traps[0].newton_solver = value
 
-    def test_warn_solver_h_transport(self):
+    def test_warn_solver_h_transport(self, capsys):
         """
         Checks that a warning is raised when the newton_solver attribute
         of the HTransportProblem class is overwritten
         """
         problem = self.sim()
         problem.initialise()
+        problem.h_transport_problem.newton_solver = f.NewtonSolver()
+        assert (
+            "Settings for the Newton solver will be overwritten"
+            in capsys.readouterr().out
+        )
 
-        with pytest.warns(
-            UserWarning,
-            match="Settings for the Newton solver will be overwritten",
-        ):
-            problem.h_transport_problem.newton_solver = f.NewtonSolver()
-
-    def test_warn_solver_heat_transport(self):
+    def test_warn_solver_heat_transport(self, capsys):
         """
         Checks that a warning is raised when the newton_solver attribute
         of the HeatTransferProblem class is overwritten
         """
         problem = self.sim()
         problem.initialise()
+        problem.T.newton_solver = f.NewtonSolver()
+        assert (
+            "Settings for the Newton solver will be overwritten"
+            in capsys.readouterr().out
+        )
 
-        with pytest.warns(
-            UserWarning,
-            match="Settings for the Newton solver will be overwritten",
-        ):
-            problem.T.newton_solver = f.NewtonSolver()
-
-    def test_warn_solver_ex_trap(self):
+    def test_warn_solver_ex_trap(self, capsys):
         """
         Checks that a warning is raised when the newton_solver attribute
         of the ExtrinsicTrap class is overwritten
         """
         problem = self.sim()
         problem.initialise()
-
-        with pytest.warns(
-            UserWarning,
-            match="Settings for the Newton solver will be overwritten",
-        ):
-            problem.traps[0].newton_solver = f.NewtonSolver()
+        problem.traps[0].newton_solver = f.NewtonSolver()
+        assert (
+            "Settings for the Newton solver will be overwritten"
+            in capsys.readouterr().out
+        )
 
 
 def test_error_raised_when_no_IC_heat_transfer():

--- a/test/system/test_misc.py
+++ b/test/system/test_misc.py
@@ -503,7 +503,7 @@ class TestWarningsCustomSolver:
         ):
             problem.traps[0].newton_solver = f.NewtonSolver()
 
-            
+
 def test_error_raised_when_no_IC_heat_transfer():
     """
     Checks that an error is raised when no initial condition is provided for

--- a/test/unit/test_traps/test_extrinsic_trap.py
+++ b/test/unit/test_traps/test_extrinsic_trap.py
@@ -87,4 +87,5 @@ class TestExtrinsicTrap:
         self.my_trap.relative_tolerance = 1
         self.my_trap.maximum_iterations = 1
         self.my_trap.linear_solver = "mumps"
-        self.my_trap.preconditioner = 'icc'
+        self.my_trap.preconditioner = "icc"
+        self.my_trap.newton_solver = f.NewtonSolver()

--- a/test/unit/test_traps/test_extrinsic_trap.py
+++ b/test/unit/test_traps/test_extrinsic_trap.py
@@ -76,3 +76,4 @@ class TestExtrinsicTrap:
         self.my_trap.relative_tolerance = 1
         self.my_trap.maximum_iterations = 1
         self.my_trap.linear_solver = "mumps"
+        self.my_trap.preconditioner = 'icc'

--- a/test/unit/test_traps/test_neutron_induced_trap.py
+++ b/test/unit/test_traps/test_neutron_induced_trap.py
@@ -146,7 +146,8 @@ class TestNeutronInducedTrapSolverParameters:
         absolute_tolerance=2.5,
         relative_tolerance=1.2e-10,
         maximum_iterations=13,
-        linear_solver="mumps",
+        linear_solver="gmres",
+        preconditioner="icc"
     )
 
     def test_attributes_from_instanciation(self):
@@ -158,7 +159,8 @@ class TestNeutronInducedTrapSolverParameters:
         assert self.my_trap.absolute_tolerance == 2.5
         assert self.my_trap.relative_tolerance == 1.2e-10
         assert self.my_trap.maximum_iterations == 13
-        assert self.my_trap.linear_solver == "mumps"
+        assert self.my_trap.linear_solver == "gmres"
+        assert self.my_trap.preconditioner == "icc"
 
     def test_attributes_change_since_instanciation(self):
         """

--- a/test/unit/test_traps/test_neutron_induced_trap.py
+++ b/test/unit/test_traps/test_neutron_induced_trap.py
@@ -147,7 +147,7 @@ class TestNeutronInducedTrapSolverParameters:
         relative_tolerance=1.2e-10,
         maximum_iterations=13,
         linear_solver="gmres",
-        preconditioner="icc"
+        preconditioner="icc",
     )
 
     def test_attributes_from_instanciation(self):


### PR DESCRIPTION
## Proposed changes

Following #673, this PR introduces:

- the possibility for the users to set the Newton solver preconditioner via `F.Settings(preconditioner="...")`
- the possibilty for the users to set a custom Newton solver after the model (`HeatTransferProblem`) initialisation. 

The expected usage of a custom Newton solver is:
```python

my_model.initialise()

class CustomSolver(fenics.NewtonSolver):
     .....

custom_solver = CustomSolver()
custom_solver.parameters["..."] = ...

my_model.h_transport_problem.newton_solver = custom_solver

my_model.run()
``` 
The same can be done for for the `F.ExtrinsicTrap` class:
```python
my_model.traps = [F.ExtrinsicTrap(...), ...]
for trap in my_model.traps:
    if isinstance(trap, F.ExtrinsicTrap)
        trap.newton_solver = CustomSolver()
``` 
and for the `HeatTransferProblem` (but before `my_model.initialise()` for the steady-state case!):

```python
my_model.T = F.HeatTransferProblem(...)
my_model.T.newton_solver = CustomSolver()
``` 


## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
