### PR TITLE
Surface Flux fix

### DIFF
--- a/festim/exports/surface_flux.py
+++ b/festim/exports/surface_flux.py
@@ -25,13 +25,21 @@ class SurfaceFlux(F.SurfaceQuantity):
     ) -> None:
         super().__init__(field, surface, filename)
 
-    def compute(self, n, ds):
+    def compute(self, ds):
         """Computes the value of the surface flux at the surface
 
         Args:
-            n (ufl.geometry.FacetNormal): normal vector to the surface
             ds (ufl.Measure): surface measure of the model
         """
+
+        # obtain mesh normal from field
+        # if case multispecies, solution is an index, use sub_function_space
+        if isinstance(self.field.solution, ufl.indexed.Indexed):
+            mesh = self.field.sub_function_space.mesh
+        else:
+            mesh = self.field.solution.function_space.mesh
+        n = ufl.FacetNormal(mesh)
+
         self.value = fem.assemble_scalar(
             fem.form(
                 -self.D

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -826,9 +826,7 @@ class HydrogenTransportProblem:
         for export in self.exports:
             # TODO if export type derived quantity
             if isinstance(export, F.SurfaceQuantity):
-                export.compute(
-                    self.ds,
-                )
+                export.compute(self.ds)
                 # update export data
                 export.t.append(float(self.t))
 

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -827,7 +827,6 @@ class HydrogenTransportProblem:
             # TODO if export type derived quantity
             if isinstance(export, F.SurfaceQuantity):
                 export.compute(
-                    self.mesh.n,
                     self.ds,
                 )
                 # update export data

--- a/test/test_surface_quantity.py
+++ b/test/test_surface_quantity.py
@@ -43,7 +43,7 @@ def test_surface_flux_export_compute():
     my_export.D = D
 
     # RUN
-    my_export.compute(n=my_mesh.n, ds=ds)
+    my_export.compute(ds=ds)
 
     # TEST
     # flux = -D grad(c)_ \cdot n = -D dc/dx = -D * 4 * x


### PR DESCRIPTION
## Proposed changes

With this change, the mesh normal needed to evaluate the surface flux can be evaluated from the field rather than passing it in Hydrogen or HeatTransferProblem. The method is different depending if the problem being solved is multispecies or not, as the solution will either be a function or an index.

This should make it easier to process each future surface quantity export as each one will only need the `ds` ufl.measure:
```python
for export in self.exports:
    if isinstance(export, F.SurfaceQuantity):
        export.compute(self.ds)
```

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
