### PR TITLE
`tqdm.auto` instead of `tqdm.autonotebook` + refresh

### DIFF
--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -760,6 +760,7 @@ class HydrogenTransportProblem:
             )
             while self.t.value < self.settings.final_time:
                 self.iterate()
+            self.progress.refresh()  # refresh progress bar to show 100%
         else:
             # Solve steady-state
             self.solver.solve(self.u)

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -6,7 +6,7 @@ import basix.ufl
 import ufl
 from mpi4py import MPI
 import numpy as np
-import tqdm.autonotebook
+import tqdm.auto as tqdm
 import festim as F
 
 from dolfinx.mesh import meshtags
@@ -753,7 +753,7 @@ class HydrogenTransportProblem:
 
         if self.settings.transient:
             # Solve transient
-            self.progress = tqdm.autonotebook.tqdm(
+            self.progress = tqdm.tqdm(
                 desc="Solving H transport problem",
                 total=self.settings.final_time,
                 unit_scale=True,


### PR DESCRIPTION
I noticed that when running in notebooks there was a bunch of warnings from tqdm.

After a bit of reading (https://github.com/jmcarpenter2/swifter/pull/67) I switched `autonotebook` to `auto` and that got rid of the warning.

Also, the progress bar in notebooks is slick! 

<img width="747" alt="image" src="https://github.com/festim-dev/FESTIM/assets/40028739/521476d2-ec75-425e-a2ca-34cce640258a">

I also added a refresh call after the timestepping loop to make sure the bar displays 100% (and even still sometimes it doesn't work...)
