### PR TITLE
added TotalVolume to allowed cartesian quantities

### DIFF
--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -311,6 +311,7 @@ class Simulation:
                 festim.SurfaceFlux,
                 festim.AverageSurface,
                 festim.AverageVolume,
+                festim.TotalVolume,
             ]
             + all_types_quantities,
             "cylindrical": [festim.SurfaceFluxCylindrical] + all_types_quantities,


### PR DESCRIPTION
I just noticed a warning was thrown when using TotalVolume in cartesian coordinates when it shouldn't