### PR TITLE
Error message when temperature is not defined

### DIFF
--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -253,6 +253,8 @@ class Simulation:
             raise AttributeError("dt must be None in steady state simulations")
         if self.settings.transient and self.dt is None:
             raise AttributeError("dt must be provided in transient simulations")
+        if not self.T:
+            raise AttributeError("Temperature is not defined")
 
         # initialise dt
         if self.settings.transient:

--- a/test/simulation/test_initialise.py
+++ b/test/simulation/test_initialise.py
@@ -147,3 +147,24 @@ def test_cartesian_and_surface_flux_warning(quantity, sys):
     # test
     with pytest.warns(UserWarning, match=f"may not work as intended for {sys} meshes"):
         my_model.initialise()
+
+
+def test_error_is_raised_when_no_temp():
+    """
+    Creates a Simulation object and checks that an AttributeError is raised
+    when .initialise() is called without a Temperature object defined
+    """
+    my_model = F.Simulation()
+
+    my_model.mesh = F.MeshFromVertices([0, 1, 2, 3])
+
+    my_model.materials = F.Material(D_0=1, E_D=0, id=1)
+
+    my_model.settings = F.Settings(
+        absolute_tolerance=1e-10,
+        relative_tolerance=1e-10,
+        transient=False,
+    )
+
+    with pytest.raises(AttributeError, match="Temperature is not defined"):
+        my_model.initialise()


### PR DESCRIPTION
## Proposed changes

I've noticed that it's easy to miss the temperature field when setting up a model. And the error message that's produced isn't straightforward:

```
Traceback (most recent call last):
  File "/home/remidm/FESTIM/mwe_2.py", line 19, in <module>
    my_model.initialise()
  File "/home/remidm/FESTIM/festim/generic_simulation.py", line 264, in initialise
    self.attribute_source_terms()
  File "/home/remidm/FESTIM/festim/generic_simulation.py", line 173, in attribute_source_terms
    self.T.sources = []
    ^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'sources'
```

Instead, this PR adds a clearer error message upon calling `initialise()`

```
Traceback (most recent call last):
  File "/home/remidm/FESTIM/mwe_2.py", line 18, in <module>
    my_model.initialise()
  File "/home/remidm/FESTIM/festim/generic_simulation.py", line 257, in initialise
    raise AttributeError("Temperature is not defined")
AttributeError: Temperature is not defined
```


## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
