### PR TITLE
Add error message when no final time is provided in transient simulations

### DIFF
--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -251,6 +251,10 @@ class Simulation:
         # check that dt attribute is None if the sim is steady state
         if not self.settings.transient and self.dt is not None:
             raise AttributeError("dt must be None in steady state simulations")
+        if self.settings.transient and self.settings.final_time is None:
+            raise AttributeError(
+                "final_time argument must be provided to settings in transient simulations"
+            )
         if self.settings.transient and self.dt is None:
             raise AttributeError("dt must be provided in transient simulations")
 

--- a/test/simulation/test_initialise.py
+++ b/test/simulation/test_initialise.py
@@ -168,3 +168,29 @@ def test_error_is_raised_when_no_temp():
 
     with pytest.raises(AttributeError, match="Temperature is not defined"):
         my_model.initialise()
+
+
+def test_error_raised_when_no_final_time():
+    """
+    Creates a Simulation object and checks that a AttributeError is raised
+    when .initialise() is called without a final_time argument
+    """
+
+    my_model = F.Simulation()
+
+    my_model.mesh = F.MeshFromVertices([0, 1, 2, 3])
+
+    my_model.materials = F.Material(D_0=1, E_D=0, id=1)
+
+    my_model.T = F.Temperature(500)
+
+    my_model.settings = F.Settings(
+        absolute_tolerance=1e-10,
+        relative_tolerance=1e-10,
+        transient=True,
+    )
+
+    my_model.dt = F.Stepsize(1)
+
+    with pytest.raises(AttributeError, match="final_time argument must be provided"):
+        my_model.initialise()

--- a/test/system/test_misc.py
+++ b/test/system/test_misc.py
@@ -76,6 +76,7 @@ def test_error_transient_without_stepsize():
         transient=True,
         absolute_tolerance=1e-10,
         relative_tolerance=1e-10,
+        final_time=10,
     )
 
     my_model.dt = None


### PR DESCRIPTION
## Proposed changes

As described in [this Discourse topic](https://festim.discourse.group/t/problems-when-reproducing-the-results-of-the-article/43/18?u=remidm) when users don't provide `final_time` to settings when running a transient simulation, the error is not explanatory.

This PR simply adds a check to `initialise()` and raises a dedicated error message.

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

