### PR TITLE
Temperature can be given as float or sp.Expr

### DIFF
--- a/docs/source/userguide/temperature.rst
+++ b/docs/source/userguide/temperature.rst
@@ -13,10 +13,10 @@ The temperature can be defined as a constant value in Kelvin (K):
 
 .. code-block:: python
 
-    my_temperature = Temperature(value=300)
+    my_temperature = 300
 
 
-Temperature can also be defined as an expression of time and/or space.
+Temperature can also be defined as an expression of time and/or space using the :class:`festim.Temperature`.
 For example:
 
 .. math::

--- a/docs/source/userguide/temperature.rst
+++ b/docs/source/userguide/temperature.rst
@@ -3,7 +3,8 @@ Temperature
 ===========
 
 Definition of a temperature field or problem is essential for hydrogen transport 
-and FESTIM as a whole. 
+and FESTIM as a whole.
+Regardless of how you define the temperature of the problem, it is passed to the :code:`T` attribute of the :class:`festim.Simulation` object.
 
 ----------------------
 Analytical expressions
@@ -16,7 +17,7 @@ The temperature can be defined as a constant value in Kelvin (K):
     my_temperature = 300
 
 
-Temperature can also be defined as an expression of time and/or space using the :class:`festim.Temperature`.
+Temperature can also be defined as an expression of time and/or space.
 For example:
 
 .. math::
@@ -29,7 +30,7 @@ would be passed to FESTIM as:
 
     from festim import x, t
 
-    my_temp = Temperature(300+2*x+3*t)
+    my_temp = 300 + 2*x + 3*t
 
 More complex expressions can be expressed with sympy:
 
@@ -44,9 +45,16 @@ would be passed to FESTIM as:
     from festim import x, t
     import sympy as sp
 
-    my_temp = Temperature(sp.exp(x)*sp.sin(t))
+    my_temp = sp.exp(x) * sp.sin(t)
 
-For more details, see :class:`festim.Temperature`.
+Conditional expressions are also possible:
+
+.. code-block:: python
+
+    from festim import x, t
+    import sympy as sp
+
+    my_temp = sp.Piecewise((400, F.t < 10), (300, True))
 
 ---------------------------
 From a heat transfer solver

--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -164,6 +164,19 @@ class Simulation:
                 "accepted types for exports are list, festim.Export or festim.Exports"
             )
 
+    @property
+    def T(self):
+        return self._T
+
+    @T.setter
+    def T(self, value):
+        if isinstance(value, festim.Temperature):
+            self._T = value
+        elif value is None:
+            self._T = value
+        elif isinstance(value, (int, float)):
+            self._T = festim.Temperature(value)
+
     def attribute_source_terms(self):
         """Assigns the source terms (in self.sources) to the correct field
         (self.mobile, self.T, or traps)
@@ -253,6 +266,7 @@ class Simulation:
             raise AttributeError("dt must be None in steady state simulations")
         if self.settings.transient and self.dt is None:
             raise AttributeError("dt must be provided in transient simulations")
+        print(self.T)
         if not self.T:
             raise AttributeError("Temperature is not defined")
 

--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -2,6 +2,7 @@ import festim
 from festim.h_transport_problem import HTransportProblem
 from fenics import *
 import numpy as np
+import sympy as sp
 import warnings
 
 
@@ -25,7 +26,7 @@ class Simulation:
             None.
         settings (festim.Settings, optional): The model's settings.
             Defaults to None.
-        temperature (int, float, festim.Temperature, optional): The model's
+        temperature (int, float, sympy.Expr, festim.Temperature, optional): The model's
             temperature. Can be an expression or a heat transfer model.
             Defaults to None.
         initial_conditions (list of festim.InitialCondition, optional):
@@ -174,7 +175,7 @@ class Simulation:
             self._T = value
         elif value is None:
             self._T = value
-        elif isinstance(value, (int, float)):
+        elif isinstance(value, (int, float, sp.Expr)):
             self._T = festim.Temperature(value)
 
     def attribute_source_terms(self):

--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -177,6 +177,10 @@ class Simulation:
             self._T = value
         elif isinstance(value, (int, float, sp.Expr)):
             self._T = festim.Temperature(value)
+        else:
+            raise TypeError(
+                "accepted types for T attribute are int, float, sympy.Expr or festim.Temperature"
+            )
 
     def attribute_source_terms(self):
         """Assigns the source terms (in self.sources) to the correct field

--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -266,7 +266,6 @@ class Simulation:
             raise AttributeError("dt must be None in steady state simulations")
         if self.settings.transient and self.dt is None:
             raise AttributeError("dt must be provided in transient simulations")
-        print(self.T)
         if not self.T:
             raise AttributeError("Temperature is not defined")
 

--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -25,7 +25,7 @@ class Simulation:
             None.
         settings (festim.Settings, optional): The model's settings.
             Defaults to None.
-        temperature (festim.Temperature, optional): The model's
+        temperature (int, float, festim.Temperature, optional): The model's
             temperature. Can be an expression or a heat transfer model.
             Defaults to None.
         initial_conditions (list of festim.InitialCondition, optional):

--- a/test/simulation/test_initialise.py
+++ b/test/simulation/test_initialise.py
@@ -1,6 +1,7 @@
 import festim as F
 from pathlib import Path
 import pytest
+import sympy as sp
 
 
 def test_initialise_changes_nb_of_sources():
@@ -149,11 +150,24 @@ def test_cartesian_and_surface_flux_warning(quantity, sys):
         my_model.initialise()
 
 
-@pytest.mark.parametrize("value", [100, 0, 100.0])
-def test_initialise_temp_as_number(value):
+@pytest.mark.parametrize(
+    "value",
+    [
+        100,
+        0,
+        100.0,
+        0.0,
+        100 + 1 * F.x,
+        0 + 1 * F.x,
+        F.x,
+        F.t,
+        sp.Piecewise((400, F.t < 10), (300, True)),
+    ],
+)
+def test_initialise_temp_as_number_or_sympy(value):
     """
     Creates a Simulation object and checks that the T attribute
-    can be given as an int or float
+    can be given as an int, a float or a sympy Expr
     """
     # build
     my_model = F.Simulation()

--- a/test/simulation/test_initialise.py
+++ b/test/simulation/test_initialise.py
@@ -149,6 +149,29 @@ def test_cartesian_and_surface_flux_warning(quantity, sys):
         my_model.initialise()
 
 
+@pytest.mark.parametrize("value", [100, 0, 100.0])
+def test_initialise_temp_as_number(value):
+    """
+    Creates a Simulation object and checks that the T attribute
+    can be given as an int or float
+    """
+    # build
+    my_model = F.Simulation()
+    my_model.mesh = F.MeshFromVertices([1, 2, 3])
+    my_model.materials = F.Material(id=1, D_0=1, E_D=0)
+    my_model.T = value
+    my_model.settings = F.Settings(
+        absolute_tolerance=1e-10, relative_tolerance=1e-10, transient=False
+    )
+
+    # run
+    my_model.initialise()
+
+    # test
+    assert isinstance(my_model.T, F.Temperature)
+    assert my_model.T.value == value
+
+
 def test_error_is_raised_when_no_temp():
     """
     Creates a Simulation object and checks that an AttributeError is raised

--- a/test/simulation/test_initialise.py
+++ b/test/simulation/test_initialise.py
@@ -205,3 +205,18 @@ def test_error_is_raised_when_no_temp():
 
     with pytest.raises(AttributeError, match="Temperature is not defined"):
         my_model.initialise()
+
+
+@pytest.mark.parametrize("value", ["coucou", [0, 0]])
+def test_wrong_type_temperature(value):
+    """
+    Creates a Simulation object and checks that a TypeError is raised
+    when the T attribute is given a value of the wrong type
+    """
+    my_model = F.Simulation()
+
+    with pytest.raises(
+        TypeError,
+        match="accepted types for T attribute are int, float, sympy.Expr or festim.Temperature",
+    ):
+        my_model.T = value


### PR DESCRIPTION
## Proposed changes

This fixes #741 by adding a setter/getter to the `T` attribute of `Simulation`.

Now, users can simply give the temperature as a numerical value or sympy Expression without having to create a `Temperature` object.

Little QoL improvement!

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)