### PR TITLE
IC improvements for Heat Transfer

### DIFF
--- a/docs/source/userguide/temperature.rst
+++ b/docs/source/userguide/temperature.rst
@@ -68,6 +68,17 @@ For a steady-state problem:
 
 :ref:`Boundary conditions<boundary conditions>` and :ref:`heat sources<sources>` can then be applied to this heat transfer problem.
 
+For transient problems, an initial condition is required:
+
+.. code-block:: python
+
+    model.T = HeatTransferProblem(
+        transient=True,
+        initial_condition=300,
+    )
+
+Initial conditions can be given as float, sympy expressions or a :class:`festim.InitialCondition` instance in order to read from a XDMF file (see :ref:`Initial Conditions<Initial Conditions>` for more details).
+
 ----------------
 From a XDMF file
 ----------------

--- a/festim/temperature/temperature_solver.py
+++ b/festim/temperature/temperature_solver.py
@@ -86,7 +86,7 @@ class HeatTransferProblem(festim.Temperature):
         self.v_T = f.TestFunction(V)
         if self.transient and self.initial_condition is None:
             raise AttributeError(
-                "Initial condition is required for transient simulation"
+                "Initial condition is required for transient heat transfer simulations"
             )
         if self.transient and self.initial_condition:
             if isinstance(self.initial_condition.value, str):

--- a/festim/temperature/temperature_solver.py
+++ b/festim/temperature/temperature_solver.py
@@ -8,7 +8,7 @@ class HeatTransferProblem(festim.Temperature):
     Args:
         transient (bool, optional): If True, a transient simulation will
             be run. Defaults to True.
-        initial_condition (festim.InitialCondition, optional): The initial condition.
+        initial_condition (int, float, sp.Expr, festim.InitialCondition, optional): The initial condition.
             Only needed if transient is True.
         absolute_tolerance (float, optional): the absolute tolerance of the newton
             solver. Defaults to 1e-03
@@ -55,6 +55,17 @@ class HeatTransferProblem(festim.Temperature):
         self.sources = []
         self.boundary_conditions = []
         self.sub_expressions = []
+
+    @property
+    def initial_condition(self):
+        return self._initial_condition
+
+    @initial_condition.setter
+    def initial_condition(self, value):
+        if isinstance(value, (int, float, sp.Expr)):
+            self._initial_condition = festim.InitialCondition(field="T", value=value)
+        else:
+            self._initial_condition = value
 
     # TODO rename initialise?
     def create_functions(self, materials, mesh, dt=None):

--- a/festim/temperature/temperature_solver.py
+++ b/festim/temperature/temperature_solver.py
@@ -73,7 +73,10 @@ class HeatTransferProblem(festim.Temperature):
         self.T = f.Function(V, name="T")
         self.T_n = f.Function(V, name="T_n")
         self.v_T = f.TestFunction(V)
-
+        if self.transient and self.initial_condition is None:
+            raise AttributeError(
+                "Initial condition is required for transient simulation"
+            )
         if self.transient and self.initial_condition:
             if isinstance(self.initial_condition.value, str):
                 if self.initial_condition.value.endswith(".xdmf"):

--- a/test/system/test_misc.py
+++ b/test/system/test_misc.py
@@ -330,3 +330,23 @@ def test_materials_setter():
     test_materials = F.Materials([])
     my_model.materials = test_materials
     assert my_model.materials is test_materials
+
+
+def test_error_raised_when_no_IC_heat_transfer():
+    """
+    Checks that an error is raised when no initial condition is provided for
+    transient heat transfer simulations
+    """
+    my_model = F.Simulation()
+
+    my_model.T = F.HeatTransferProblem(transient=True, initial_condition=None)
+    my_model.mesh = F.MeshFromVertices(np.linspace(0, 1, 10))
+    my_model.materials = F.Material(1, 1, 0.1)
+    my_model.settings = F.Settings(1e-10, 1e-10, final_time=1e-7)
+    my_model.dt = F.Stepsize(1e-9)
+
+    with pytest.raises(
+        AttributeError,
+        match="Initial condition is required for transient heat transfer simulations",
+    ):
+        my_model.initialise()

--- a/test/unit/test_temperature.py
+++ b/test/unit/test_temperature.py
@@ -69,9 +69,7 @@ def test_formulation_heat_transfer():
     bc1 = festim.DirichletBC(surfaces=[1], value=u, field="T")
     bc2 = festim.FluxBC(surfaces=[2], value=2, field="T")
 
-    my_temp = festim.HeatTransferProblem(
-        transient=True, initial_condition=festim.InitialCondition(field="T", value=0)
-    )
+    my_temp = festim.HeatTransferProblem(transient=True, initial_condition=0)
     my_temp.boundary_conditions = [bc1, bc2]
     my_temp.sources = [festim.Source(-4, volume=[1], field="T")]
     my_temp.create_functions(my_mats, my_mesh, dt=dt)


### PR DESCRIPTION
## Proposed changes

Currently when running a transient Heat Transfer problem, an initial condition is required.
The process is a bit cumbersome as if users just want to initialise the temperature to say 300 K then they have to
- create a `InitialCondition` object
- give it the field `"T"` (which is redundant!)
- pass it to `HeatTransferProblem`

This PR simplifies the process.
Now users can simply give a float, int or sympy Expression as the `initial_condition` argument.
If users want to give a initial condition from XDMF then the process is unchanged.

Moreover, this adds an error when transient heat transfer sims are run without giving an IC.

Documentation was also updated as the confusion was first reported [here](https://festim.discourse.group/t/heat-transfer-problem-how-to-set-up-transient-calcumations/39/1).


## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
