### PR TITLE
Move icons to header in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -121,6 +121,18 @@ html_theme_options = {
             "icon": "fa-brands fa-slack",
         },
     ],
+    "article_header_end": [
+        "navbar-icon-links",
+        "article-header-buttons",
+    ],
+}
+
+html_sidebars = {
+    "**": [
+        "navbar-logo",
+        "search-button-field",
+        "sbt-sidebar-nav",
+    ],
 }
 
 html_title = "FESTIM Documentation"


### PR DESCRIPTION
## Proposed changes

Following the modifications proposed in https://github.com/executablebooks/sphinx-book-theme/issues/833 by @danilopeixoto we can finally move the icons to the header as we initially wanted.

@danilopeixoto, do you know by any chance if there is a way to combine this and have some icons in the header and others in the sidebar?

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [x] Documentation Update (if none of the other choices apply)
- [ ] New tests
