### PR TITLE
`SurfaceKinetics` docs and form

### DIFF
--- a/festim/boundary_conditions/fluxes/surface_kinetics.py
+++ b/festim/boundary_conditions/fluxes/surface_kinetics.py
@@ -13,8 +13,8 @@ class SurfaceKinetics(FluxBC):
 
     .. math::
 
-        -D \nabla c_\mathrm{m} \cdot \mathbf{n} = -\lambda_{\mathrm{IS}} \dfrac{\partial c_{\mathrm{m}}}{\partial t}
-        - J_{\mathrm{bs}} + J_{\mathrm{sb}},
+        -D \nabla c_\mathrm{m} \cdot \mathbf{n} = \lambda_{\mathrm{IS}} \dfrac{\partial c_{\mathrm{m}}}{\partial t}
+        + J_{\mathrm{bs}} - J_{\mathrm{sb}},
 
     where :math:`c_{\mathrm{m}}` is the concentration of mobile hydrogen (:math:`\mathrm{H \ m}^{-3}`),
     :math:`c_{\mathrm{s}}` is the surface concentration of adsorbed hydrogen (:math:`\mathrm{H \ m}^{-2}`),
@@ -163,7 +163,7 @@ class SurfaceKinetics(FluxBC):
                 )
                 # Flux to solute species
                 self.form += (
-                    -lambda_IS
+                    lambda_IS
                     * (solute - solute_prev)
                     / dt.value
                     * solute_test_function

--- a/test/system/test_system.py
+++ b/test/system/test_system.py
@@ -1220,3 +1220,98 @@ def test_MMS_decay_with_trap():
     )
     print(msg)
     assert error_max_u < tol_u and error_max_v < tol_v
+
+
+def test_MMS_surface_kinetics():
+    """
+    MMS test for SurfaceKinetics BC
+    """
+    exact_solution_cm = lambda x, t: 1 + 2 * x**2 + x + 2 * t
+    exact_solution_cs = (
+        lambda t: n_surf * (1 + 2 * t + 2 * lambda_IS - D) / (2 * n_IS - 1 - 2 * t)
+    )
+
+    n_IS = 20
+    n_surf = 5
+    D = 7
+    lambda_IS = 2
+    k_bs = n_IS / n_surf
+    k_sb = 2 * n_IS / n_surf
+
+    solute_source = 2 * (1 - 2 * D)
+
+    def J_vs(T, surf_conc, t):
+        return (
+            2 * n_surf * (2 * n_IS + 2 * lambda_IS - D) / (2 * n_IS - 1 - 2 * t) ** 2
+            + 2 * lambda_IS
+            - D
+        )
+
+    my_materials = festim.Material(id=1, D_0=D, E_D=0)
+
+    my_mesh = festim.MeshFromVertices(np.linspace(0, 1, 1000))
+
+    my_sources = [festim.Source(solute_source, volume=1, field=0)]
+
+    my_temp = 300
+
+    my_bcs = [
+        festim.SurfaceKinetics(
+            k_sb=k_sb,
+            k_bs=k_bs,
+            lambda_IS=lambda_IS,
+            n_surf=n_surf,
+            n_IS=n_IS,
+            J_vs=J_vs,
+            surfaces=1,
+            initial_condition=exact_solution_cs(t=0),
+            t=festim.t,
+        ),
+        festim.DirichletBC(
+            surfaces=2, value=exact_solution_cm(x=1, t=festim.t), field=0
+        ),
+    ]
+
+    my_ics = [
+        festim.InitialCondition(
+            field=0, value=exact_solution_cm(x=festim.x, t=festim.t)
+        )
+    ]
+
+    my_settings = festim.Settings(
+        absolute_tolerance=1e-10, relative_tolerance=1e-10, transient=True, final_time=5
+    )
+
+    my_dt = festim.Stepsize(0.005)
+
+    my_dq = festim.DerivedQuantities([festim.AdsorbedHydrogen(surface=1)])
+    my_exports = [my_dq]
+
+    my_sim = festim.Simulation(
+        mesh=my_mesh,
+        materials=my_materials,
+        boundary_conditions=my_bcs,
+        initial_conditions=my_ics,
+        sources=my_sources,
+        temperature=my_temp,
+        settings=my_settings,
+        dt=my_dt,
+        exports=my_exports,
+    )
+
+    my_sim.initialise()
+    my_sim.run()
+
+    t = my_dq.t
+    error_max_c = compute_error(
+        exact_solution_cm(x=festim.x, t=t[-1]),
+        computed=my_sim.mobile.post_processing_solution,
+        t=my_sim.t,
+        norm="error_max",
+    )
+
+    tol = 5e-5
+
+    error_max_cs = np.max(np.abs(my_dq[0].data - exact_solution_cs(np.array(t))))
+
+    assert error_max_c < tol and error_max_cs < tol

--- a/test/unit/test_boundary_conditions.py
+++ b/test/unit/test_boundary_conditions.py
@@ -688,7 +688,7 @@ def test_create_form_surf_kinetics():
         (adsorbed - adsorbed_prev) / dt.value * adsorbed_test_function * ds(1)
     )
     expected_form += (
-        -lambda_IS * (solute - solute_prev) / dt.value * solute_test_function * ds(1)
+        lambda_IS * (solute - solute_prev) / dt.value * solute_test_function * ds(1)
     )
     expected_form += -(j_vs + J_bs - J_sb) * adsorbed_test_function * ds(1)
     expected_form += (J_bs - J_sb) * solute_test_function * ds(1)


### PR DESCRIPTION
## Proposed changes
From discussions with @RemDelaporteMathurin, I suppose that there are mistakes in the variational form for `SurfaceKinetics` BC and API docs. 

The current docs states that the BC for solute species is:
$-D \nabla c_\mathrm{m} \cdot \mathbf{n} = -\lambda_{\mathrm{IS}} \dfrac{\partial c_{\mathrm{m}}}{\partial t}- J_{\mathrm{bs}} + J_{\mathrm{sb}}.$
If $\mathbf{n}$ is the outward normal vector of the boundary, at steady-state 1D, this should yield: $D\dfrac{\partial c_\mathrm{m}}{\partial x}= -J_{\mathrm{bs}}+J_{\mathrm{sb}}$, what contradicts [Pick & Sonnenberg](https://www.sciencedirect.com/science/article/abs/pii/0022311585904593). I assume, the correct form is:
$-D \nabla c_\mathrm{m} \cdot \mathbf{n} = \lambda_{\mathrm{IS}} \dfrac{\partial c_{\mathrm{m}}}{\partial t}+J_{\mathrm{bs}} - J_{\mathrm{sb}}.$

To check the implementation, here is a simple [MMS test](https://github.com/KulaginVladimir/FESTIM-SurfaceKinetics-Validation/blob/main/MMS/MMS.ipynb), based on the approach of @RemDelaporteMathurin 

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
