### PR TITLE
Error if temperature BC or source with `F.Temperature`

### DIFF
--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -207,9 +207,9 @@ class Simulation:
         # set sources
         for source in self.sources:
             if source.field == "T" and not isinstance(
-                self.T, festim.temperature.temperature_solver.HeatTransferProblem
+                self.T, festim.HeatTransferProblem
             ):  # check that there is not a source defined in T as the same time as a festim.Temperature
-                raise ValueError(
+                raise TypeError(
                     "Heat transfer sources can only be used with HeatTransferProblem"
                 )
             if isinstance(source, festim.RadioactiveDecay) and source.field == "all":
@@ -249,10 +249,8 @@ class Simulation:
                 raise ValueError("SurfaceKinetics can only be used in 1D simulations")
 
             # check that there is not a Temperature defined at the same time as a boundary condition in T
-            if bc.field == "T" and not isinstance(
-                self.T, festim.temperature.temperature_solver.HeatTransferProblem
-            ):
-                raise ValueError(
+            if bc.field == "T" and not isinstance(self.T, festim.HeatTransferProblem):
+                raise TypeError(
                     "Heat transfer boundary conditions can only be used with HeatTransferProblem"
                 )
 

--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -242,6 +242,14 @@ class Simulation:
             ):
                 raise ValueError("SurfaceKinetics can only be used in 1D simulations")
 
+            # check that there is not a Temperature defined at the same time as a Dirichlet in T
+            if bc.field == "T" and not isinstance(
+                self.T, festim.temperature.temperature_solver.HeatTransferProblem
+            ):
+                raise ValueError(
+                    f"cannot use boundary conditions with Temperature, use HeatTransferProblem instead."
+                )
+
             # checks that DirichletBC or SurfaceKinetics is not set with another bc on the same surface
             # iterate through all BCs
             for dc_sk_bc in dc_sk_bcs:

--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -206,6 +206,12 @@ class Simulation:
 
         # set sources
         for source in self.sources:
+            if source.field == "T" and not isinstance(
+                self.T, festim.temperature.temperature_solver.HeatTransferProblem
+            ):  # check that there is not a source defined in T as the same time as a festim.Temperature
+                raise ValueError(
+                    "Heat transfer sources can only be used with HeatTransferProblem"
+                )
             if isinstance(source, festim.RadioactiveDecay) and source.field == "all":
                 # assign source to each of the unique festim.Concentration
                 # objects in field_to_object
@@ -242,12 +248,12 @@ class Simulation:
             ):
                 raise ValueError("SurfaceKinetics can only be used in 1D simulations")
 
-            # check that there is not a Temperature defined at the same time as a Dirichlet in T
+            # check that there is not a Temperature defined at the same time as a boundary condition in T
             if bc.field == "T" and not isinstance(
                 self.T, festim.temperature.temperature_solver.HeatTransferProblem
             ):
                 raise ValueError(
-                    f"cannot use boundary conditions with Temperature, use HeatTransferProblem instead."
+                    "Heat transfer boundary conditions can only be used with HeatTransferProblem"
                 )
 
             # checks that DirichletBC or SurfaceKinetics is not set with another bc on the same surface

--- a/test/system/test_misc.py
+++ b/test/system/test_misc.py
@@ -159,11 +159,20 @@ def test_error_DirichletBC_on_same_surface(field, surfaces):
         F.DirichletBC(value=1, field=field, surfaces=surfaces),
     ]
 
-    with pytest.raises(
-        ValueError,
-        match="DirichletBC is simultaneously set with another boundary condition",
-    ):
-        sim.initialise()
+    if field == "solute":
+        with pytest.raises(
+            ValueError,
+            match="DirichletBC is simultaneously set with another boundary condition",
+        ):
+            sim.initialise()
+    elif (
+        field == "T"
+    ):  # with festim.Temperature already defined there is another error given
+        with pytest.raises(
+            ValueError,
+            match="cannot use boundary conditions with Temperature, use HeatTransferProblem instead.",
+        ):
+            sim.initialise()
 
 
 @pytest.mark.parametrize("surfaces", [1, 2, [1, 2]])

--- a/test/system/test_misc.py
+++ b/test/system/test_misc.py
@@ -214,7 +214,6 @@ def test_source_on_T_with_Temp():
     sim.mesh = F.MeshFromVertices([0, 1, 2, 3])
     sim.materials = F.Material(id=1, D_0=1, E_D=0)
     sim.T = F.Temperature(value=500)
-    sim.boundary_conditions = []
     sim.settings = F.Settings(
         transient=False, absolute_tolerance=1e8, relative_tolerance=1e-8
     )

--- a/test/system/test_misc.py
+++ b/test/system/test_misc.py
@@ -169,7 +169,7 @@ def test_error_DirichletBC_on_same_surface(field, surfaces):
         field == "T"
     ):  # with festim.Temperature already defined there is another error given
         with pytest.raises(
-            ValueError,
+            TypeError,
             match="Heat transfer boundary conditions can only be used with HeatTransferProblem",
         ):
             sim.initialise()
@@ -197,11 +197,8 @@ def test_BC_on_T_with_Temp(bc):
     sim.settings = F.Settings(
         transient=False, absolute_tolerance=1e8, relative_tolerance=1e-8
     )
-    sim.sources = []
-    sim.dt = None
-    sim.exports = []
     with pytest.raises(
-        ValueError,
+        TypeError,
         match="Heat transfer boundary conditions can only be used with HeatTransferProblem",
     ):
         sim.initialise()
@@ -222,10 +219,8 @@ def test_source_on_T_with_Temp():
         transient=False, absolute_tolerance=1e8, relative_tolerance=1e-8
     )
     sim.sources = [F.Source(value=1, volume=1, field="T")]
-    sim.dt = None
-    sim.exports = []
     with pytest.raises(
-        ValueError,
+        TypeError,
         match="Heat transfer sources can only be used with HeatTransferProblem",
     ):
         sim.initialise()

--- a/test/unit/test_boundary_conditions.py
+++ b/test/unit/test_boundary_conditions.py
@@ -551,7 +551,7 @@ def custom_fun(T, solute, param1):
     "bc",
     [
         (festim.DissociationFlux(surfaces=[1], Kd_0=1, E_Kd=0, P=1e4)),
-        (festim.ConvectiveFlux(h_coeff=1, T_ext=1, surfaces=1)),
+        # (festim.ConvectiveFlux(h_coeff=1, T_ext=1, surfaces=1)),
         (festim.FluxBC(surfaces=1, value=1, field=0)),
         (festim.MassFlux(h_coeff=1, c_ext=1, surfaces=1)),
         (festim.RecombinationFlux(Kr_0=1e-20, E_Kr=0, order=2, surfaces=1)),
@@ -603,6 +603,26 @@ def test_flux_BC_initialise(bc):
     sim.dt = None
     sim.exports = []
     sim.initialise()
+
+
+def test_flux_BC_initialise_special_case():
+    """Special case because of the new test if Temperature is used with BC on T"""
+    sim = festim.Simulation()
+    sim.mesh = festim.MeshFromVertices([0, 1, 2, 3])
+    sim.materials = festim.Material(id=1, D_0=1, E_D=0)
+    sim.T = festim.Temperature(value=500)
+    sim.boundary_conditions = [festim.ConvectiveFlux(h_coeff=1, T_ext=1, surfaces=1)]
+    sim.settings = festim.Settings(
+        transient=False, absolute_tolerance=1e8, relative_tolerance=1e-8
+    )
+    sim.sources = []
+    sim.dt = None
+    sim.exports = []
+    with pytest.raises(
+        ValueError,
+        match="cannot use boundary conditions with Temperature, use HeatTransferProblem instead.",
+    ):
+        sim.initialise()
 
 
 def test_dissoc_flux():

--- a/test/unit/test_boundary_conditions.py
+++ b/test/unit/test_boundary_conditions.py
@@ -605,26 +605,6 @@ def test_flux_BC_initialise(bc):
     sim.initialise()
 
 
-def test_flux_BC_initialise_special_case():
-    """Special case because of the new test if Temperature is used with BC on T"""
-    sim = festim.Simulation()
-    sim.mesh = festim.MeshFromVertices([0, 1, 2, 3])
-    sim.materials = festim.Material(id=1, D_0=1, E_D=0)
-    sim.T = festim.Temperature(value=500)
-    sim.boundary_conditions = [festim.ConvectiveFlux(h_coeff=1, T_ext=1, surfaces=1)]
-    sim.settings = festim.Settings(
-        transient=False, absolute_tolerance=1e8, relative_tolerance=1e-8
-    )
-    sim.sources = []
-    sim.dt = None
-    sim.exports = []
-    with pytest.raises(
-        ValueError,
-        match="cannot use boundary conditions with Temperature, use HeatTransferProblem instead.",
-    ):
-        sim.initialise()
-
-
 def test_dissoc_flux():
     expr = 2 + festim.x
     T = fenics.Expression(sp.printing.ccode(expr), degree=1, t=0)

--- a/test/unit/test_initial_condition.py
+++ b/test/unit/test_initial_condition.py
@@ -1,5 +1,6 @@
 import festim
 import pytest
+import numpy
 
 
 def test_error_initialisation_from_xdmf_missing_time_step():
@@ -19,3 +20,32 @@ def test_error_initialisation_from_xdmf_missing_label():
     """
     with pytest.raises(ValueError, match=r"label"):
         festim.InitialCondition(value="my_file.xdmf", label=None, time_step=1)
+
+
+def test_temperature_and_DirichletBC():
+    """
+    Test that the code returns an error when a Dirichlet BC is set with T when there
+    is also a Festim.Temperature already set
+    """
+    my_model = festim.Simulation()
+
+    my_model.T = festim.Temperature(873)
+
+    my_model.mesh = festim.MeshFromVertices(vertices=numpy.linspace(0, 1, num=1000))
+
+    my_model.boundary_conditions = [
+        festim.DirichletBC(field="T", value=1200, surfaces=1),
+        festim.DirichletBC(field="T", value=373, surfaces=2),
+    ]
+
+    my_model.materials = festim.Material(1, 1, 0)
+
+    my_model.settings = festim.Settings(
+        absolute_tolerance=1e-10, relative_tolerance=1e-10, transient=False
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="cannot use boundary conditions with Temperature, use HeatTransferProblem instead.",
+    ):
+        my_model.initialise()

--- a/test/unit/test_initial_condition.py
+++ b/test/unit/test_initial_condition.py
@@ -1,6 +1,5 @@
 import festim
 import pytest
-import numpy
 
 
 def test_error_initialisation_from_xdmf_missing_time_step():
@@ -20,32 +19,3 @@ def test_error_initialisation_from_xdmf_missing_label():
     """
     with pytest.raises(ValueError, match=r"label"):
         festim.InitialCondition(value="my_file.xdmf", label=None, time_step=1)
-
-
-def test_temperature_and_DirichletBC():
-    """
-    Test that the code returns an error when a Dirichlet BC is set with T when there
-    is also a Festim.Temperature already set
-    """
-    my_model = festim.Simulation()
-
-    my_model.T = festim.Temperature(873)
-
-    my_model.mesh = festim.MeshFromVertices(vertices=numpy.linspace(0, 1, num=1000))
-
-    my_model.boundary_conditions = [
-        festim.DirichletBC(field="T", value=1200, surfaces=1),
-        festim.DirichletBC(field="T", value=373, surfaces=2),
-    ]
-
-    my_model.materials = festim.Material(1, 1, 0)
-
-    my_model.settings = festim.Settings(
-        absolute_tolerance=1e-10, relative_tolerance=1e-10, transient=False
-    )
-
-    with pytest.raises(
-        ValueError,
-        match="cannot use boundary conditions with Temperature, use HeatTransferProblem instead.",
-    ):
-        my_model.initialise()


### PR DESCRIPTION
## Proposed changes

Added check in the `generic_simulation` to prevent the use of festim.Temperature with boundary condition set on the `T` field (Issue #787 ).

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Some other tests had to be slightly modified, is there a better way than what I did ?
