### PR TITLE
No python version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       shell: bash -l {0}
       run: |
         # conda upgrade --strict-channel-priority -c conda-forge --all
-        conda install -c conda-forge fenics numpy=1.24 python=3.10
+        conda install -c conda-forge fenics numpy=1.24
 
     - name: Install dependencies
       shell: bash -l {0}


### PR DESCRIPTION
## Proposed changes

I started noticing CI failures here #823 and there #826 

I reproduced the issue locally and realised that removing the python=3.10 solved the issue.

@minrk I don't know if something changed in the conda recipe that could explain this?


