### PR TITLE
Fix SurfaceFlux with Soret

### DIFF
--- a/festim/exports/derived_quantities/derived_quantities.py
+++ b/festim/exports/derived_quantities/derived_quantities.py
@@ -154,7 +154,6 @@ class DerivedQuantities(list):
             quantity.Q = materials.Q
 
     def compute(self, t):
-        # TODO need to support for soret flag in surface flux
         row = [t]
         for quantity in self:
             if isinstance(quantity, (MaximumVolume, MinimumVolume)):

--- a/festim/exports/derived_quantities/surface_flux.py
+++ b/festim/exports/derived_quantities/surface_flux.py
@@ -35,6 +35,7 @@ class SurfaceFlux(SurfaceQuantity):
 
     def __init__(self, field, surface) -> None:
         super().__init__(field=field, surface=surface)
+        self.soret = None
 
     @property
     def export_unit(self):
@@ -70,11 +71,11 @@ class SurfaceFlux(SurfaceQuantity):
         }
         return field_to_prop[self.field]
 
-    def compute(self, soret=False):
+    def compute(self):
         flux = f.assemble(
             self.prop * f.dot(f.grad(self.function), self.n) * self.ds(self.surface)
         )
-        if soret and self.field in [0, "0", "solute"]:
+        if self.soret and self.field in [0, "0", "solute"]:
             flux += f.assemble(
                 self.prop
                 * self.function
@@ -136,7 +137,7 @@ class SurfaceFluxCylindrical(SurfaceFlux):
             raise ValueError("Azimuthal range must be between 0 and pi")
         self._azimuth_range = value
 
-    def compute(self, soret=False):
+    def compute(self):
 
         if self.r is None:
             mesh = (
@@ -155,7 +156,7 @@ class SurfaceFluxCylindrical(SurfaceFlux):
             * f.dot(f.grad(self.function), self.n)
             * self.ds(self.surface)
         )
-        if soret and self.field in [0, "0", "solute"]:
+        if self.soret and self.field in [0, "0", "solute"]:
             flux += f.assemble(
                 self.prop
                 * self.r
@@ -234,7 +235,7 @@ class SurfaceFluxSpherical(SurfaceFlux):
             raise ValueError("Azimuthal range must be between 0 and pi")
         self._azimuth_range = value
 
-    def compute(self, soret=False):
+    def compute(self):
 
         if self.r is None:
             mesh = (
@@ -252,7 +253,7 @@ class SurfaceFluxSpherical(SurfaceFlux):
             * f.dot(f.grad(self.function), self.n)
             * self.ds(self.surface)
         )
-        if soret and self.field in [0, "0", "solute"]:
+        if self.soret and self.field in [0, "0", "solute"]:
             flux += f.assemble(
                 self.prop
                 * self.r**2

--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -418,8 +418,7 @@ class Simulation:
                         self.dt.milestones.append(time)
                 self.dt.milestones.sort()
 
-        # set Soret to True
-        for export in self.exports:
+            # set Soret to True for SurfaceFlux quantities
             if isinstance(export, festim.DerivedQuantities):
                 for q in export:
                     if isinstance(q, festim.SurfaceFlux):

--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -418,6 +418,14 @@ class Simulation:
                         self.dt.milestones.append(time)
                 self.dt.milestones.sort()
 
+        # set Soret to True
+        for export in self.exports:
+            if isinstance(export, festim.DerivedQuantities):
+                for q in export:
+                    if isinstance(q, festim.SurfaceFlux):
+                        q.soret = self.settings.soret
+                        q.T = self.T.T
+
     def run(self, completion_tone=False):
         """Runs the model.
 

--- a/test/unit/test_exports/test_derived_quantities/test_surface_flux.py
+++ b/test/unit/test_exports/test_derived_quantities/test_surface_flux.py
@@ -53,6 +53,7 @@ class TestCompute:
     my_h_flux.ds = ds
     my_h_flux.T = T
     my_h_flux.Q = Q
+    my_h_flux.soret = True
 
     my_heat_flux = SurfaceFlux("T", surface)
     my_heat_flux.D = D
@@ -87,7 +88,7 @@ class TestCompute:
             * f.dot(f.grad(self.T), self.n)
             * self.ds(self.surface)
         )
-        flux = self.my_h_flux.compute(soret=True)
+        flux = self.my_h_flux.compute()
         assert flux == expected_flux
 
 
@@ -149,6 +150,7 @@ def test_compute_cylindrical(r0, radius, height, c_top, c_bottom, soret):
 
     my_flux.n = f.FacetNormal(mesh_fenics)
     my_flux.ds = ds
+    my_flux.soret = soret
 
     expected_value = (
         -2
@@ -177,7 +179,7 @@ def test_compute_cylindrical(r0, radius, height, c_top, c_bottom, soret):
             * (0.5 * r1**2 - 0.5 * r0**2)
         )
 
-    computed_value = my_flux.compute(soret=soret)
+    computed_value = my_flux.compute()
 
     assert np.isclose(computed_value, expected_value)
 
@@ -236,6 +238,7 @@ def test_compute_spherical(r0, radius, c_left, c_right, soret):
 
     my_flux.n = f.FacetNormal(mesh_fenics)
     my_flux.ds = ds
+    my_flux.soret = soret
 
     # expected value is the integral of the flux over the surface
     flux_value = float(my_flux.D) * (c_left - c_right) / (r1 - r0)
@@ -259,7 +262,7 @@ def test_compute_spherical(r0, radius, c_left, c_right, soret):
             * r1**2
         )
 
-    computed_value = my_flux.compute(soret=soret)
+    computed_value = my_flux.compute()
 
     assert np.isclose(computed_value, expected_value)
 


### PR DESCRIPTION
## Proposed changes

This is a fix for #830.

The `compute` method of `SurfaceFlux` had a `soret` argument defaulting to `False`. However, this was not integrated correctly with the rest of the implementation.

What I did is I removed this argument and replaced it by an attribute of `SurfaceFlux`. This attribute is set to `True` or `False` during `Simulation.initialise`. Also, the `T` attribute of `SurfaceFlux` is set at the same time in order to calculate the soret flux.

This bug did not affect any of the actual solving step and the equations were correctly solved with Soret. This is only a post-processing bug with SurfaceFlux (the other derived quantities are unaffected).

Note: I propagated this fix to the cylindrical and spherical versions of `SurfaceFlux`.

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
