### PR TITLE
allowed_meshes property for derived quantities

### DIFF
--- a/festim/exports/derived_quantities/average_surface.py
+++ b/festim/exports/derived_quantities/average_surface.py
@@ -29,6 +29,10 @@ class AverageSurface(SurfaceQuantity):
         super().__init__(field=field, surface=surface)
 
     @property
+    def allowed_meshes(self):
+        return ["cartesian"]
+
+    @property
     def title(self):
         quantity_title = f"Average {self.field} surface {self.surface}"
         if self.show_units:

--- a/festim/exports/derived_quantities/average_volume.py
+++ b/festim/exports/derived_quantities/average_volume.py
@@ -28,6 +28,10 @@ class AverageVolume(VolumeQuantity):
         super().__init__(field=field, volume=volume)
 
     @property
+    def allowed_meshes(self):
+        return ["cartesian"]
+
+    @property
     def title(self):
         quantity_title = f"Average {self.field} volume {self.volume}"
         if self.show_units:

--- a/festim/exports/derived_quantities/derived_quantity.py
+++ b/festim/exports/derived_quantities/derived_quantity.py
@@ -22,6 +22,12 @@ class DerivedQuantity(Export):
         self.t = []
         self.show_units = False
 
+    @property
+    def allowed_meshes(self):
+        # by default, all meshes are allowed
+        # override this method if that's not the case
+        return ["cartesian", "cylindrical", "spherical"]
+
 
 class VolumeQuantity(DerivedQuantity):
     """DerivedQuantity relative to a volume

--- a/festim/exports/derived_quantities/derived_quantity.py
+++ b/festim/exports/derived_quantities/derived_quantity.py
@@ -7,6 +7,24 @@ class DerivedQuantity(Export):
 
     Args:
         field (str, int):  the field ("solute", 0, 1, "T", "retention")
+
+    Attributes:
+        field (str, int):  the field ("solute", 0, 1, "T", "retention")
+        title (str): the title of the derived quantity
+        show_units (bool): show the units in the title in the derived quantities
+            file
+        function (fenics.Function): the solution function of
+            the field
+        dx (fenics.Measure): the measure of the volume
+        ds (fenics.Measure): the measure of the surface
+        n (fenics.Function): the normal vector
+        D (fenics.Function): the diffusion coefficient
+        S (fenics.Function): the source term
+        thermal_cond (fenics.Function): the thermal conductivity
+        Q (fenics.Function): the heat source term
+        data (list): the data of the derived quantity
+        t (list): the time values of the data
+        allowed_meshes (list): the allowed meshes for the derived quantity
     """
 
     def __init__(self, field) -> None:
@@ -18,6 +36,7 @@ class DerivedQuantity(Export):
         self.S = None
         self.thermal_cond = None
         self.Q = None
+        self.T = None
         self.data = []
         self.t = []
         self.show_units = False

--- a/festim/exports/derived_quantities/surface_flux.py
+++ b/festim/exports/derived_quantities/surface_flux.py
@@ -37,6 +37,10 @@ class SurfaceFlux(SurfaceQuantity):
         super().__init__(field=field, surface=surface)
 
     @property
+    def allowed_meshes(self):
+        return ["cartesian"]
+
+    @property
     def export_unit(self):
         # obtain domain dimension
         dim = self.function.function_space().mesh().topology().dim()
@@ -110,6 +114,10 @@ class SurfaceFluxCylindrical(SurfaceFlux):
         super().__init__(field=field, surface=surface)
         self.r = None
         self.azimuth_range = azimuth_range
+
+    @property
+    def allowed_meshes(self):
+        return ["cylindrical"]
 
     @property
     def title(self):
@@ -198,6 +206,10 @@ class SurfaceFluxSpherical(SurfaceFlux):
         self.r = None
         self.polar_range = polar_range
         self.azimuth_range = azimuth_range
+
+    @property
+    def allowed_meshes(self):
+        return ["spherical"]
 
     @property
     def title(self):

--- a/festim/exports/derived_quantities/total_surface.py
+++ b/festim/exports/derived_quantities/total_surface.py
@@ -31,6 +31,10 @@ class TotalSurface(SurfaceQuantity):
         super().__init__(field=field, surface=surface)
 
     @property
+    def allowed_meshes(self):
+        return ["cartesian"]
+
+    @property
     def export_unit(self):
         # obtain domain dimension
         try:

--- a/festim/exports/derived_quantities/total_volume.py
+++ b/festim/exports/derived_quantities/total_volume.py
@@ -31,6 +31,10 @@ class TotalVolume(VolumeQuantity):
         super().__init__(field=field, volume=volume)
 
     @property
+    def allowed_meshes(self):
+        return ["cartesian"]
+
+    @property
     def export_unit(self):
         # obtain domain dimension
         try:

--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -359,29 +359,10 @@ class Simulation:
 
         # raise warning if the derived quantities don't match the type of mesh
         # eg. SurfaceFlux is used with cylindrical mesh
-        all_types_quantities = [
-            festim.MaximumSurface,
-            festim.MinimumSurface,
-            festim.MaximumVolume,
-            festim.MinimumVolume,
-            festim.PointValue,
-        ]  # these quantities can be used with any mesh
-        allowed_quantities = {
-            "cartesian": [
-                festim.SurfaceFlux,
-                festim.AverageSurface,
-                festim.AverageVolume,
-                festim.TotalVolume,
-            ]
-            + all_types_quantities,
-            "cylindrical": [festim.SurfaceFluxCylindrical] + all_types_quantities,
-            "spherical": [festim.SurfaceFluxSpherical] + all_types_quantities,
-        }
-
         for export in self.exports:
             if isinstance(export, festim.DerivedQuantities):
                 for q in export:
-                    if not isinstance(q, tuple(allowed_quantities[self.mesh.type])):
+                    if self.mesh.type not in q.allowed_meshes:
                         warnings.warn(
                             f"{type(q)} may not work as intended for {self.mesh.type} meshes"
                         )

--- a/test/system/test_cylindrical_coordinates.py
+++ b/test/system/test_cylindrical_coordinates.py
@@ -40,6 +40,10 @@ def test_run_MMS():
         transient=False,
     )
 
+    exports = [
+        festim.DerivedQuantities([festim.SurfaceFluxCylindrical(field=0, surface=2)])
+    ]
+
     my_sim = festim.Simulation(
         mesh=my_mesh,
         materials=my_materials,
@@ -47,6 +51,7 @@ def test_run_MMS():
         temperature=my_temp,
         sources=my_sources,
         settings=my_settings,
+        exports=exports,
     )
 
     my_sim.initialise()

--- a/test/system/test_spherical_coordinates.py
+++ b/test/system/test_spherical_coordinates.py
@@ -40,6 +40,10 @@ def test_run_MMS():
         transient=False,
     )
 
+    exports = [
+        festim.DerivedQuantities([festim.SurfaceFluxSpherical(field=0, surface=2)])
+    ]
+
     my_sim = festim.Simulation(
         mesh=my_mesh,
         materials=my_materials,
@@ -47,6 +51,7 @@ def test_run_MMS():
         temperature=my_temp,
         sources=my_sources,
         settings=my_settings,
+        exports=exports,
     )
 
     my_sim.initialise()


### PR DESCRIPTION
## Proposed changes

Fix for #829 

This PR proposes to change the approach for knowing if certain quantities are allowed with various systems of coordinates (cartesian, cylindrical, spherical).

Instead of having a long list of allowed quantities for each mesh type in `Simulation.initialise` - which was very hard to maintain -, each quantity now has a property called `allowed_meshes` that is a list of mesh types that this property can be used with.
By default, the three mesh types are allowed.

When inheriting from the parent class, it is possible to override this property.

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
