### PR TITLE
Wrong value for error_on_nonconvergence in `NewtonSolver`

### DIFF
--- a/festim/concentration/traps/extrinsic_trap.py
+++ b/festim/concentration/traps/extrinsic_trap.py
@@ -15,7 +15,7 @@ class ExtrinsicTrapBase(Trap):
         relative_tolerance=1e-10,
         maximum_iterations=30,
         linear_solver=None,
-        preconditioner=None,
+        preconditioner="default",
         **kwargs,
     ):
         """Inits ExtrinsicTrap
@@ -73,7 +73,6 @@ class ExtrinsicTrapBase(Trap):
     def define_newton_solver(self):
         """Creates the Newton solver and sets its parameters"""
         self.newton_solver = NewtonSolver(MPI.comm_world)
-        self.newton_solver.parameters["error_on_nonconvergence"] = False
         self.newton_solver.parameters["absolute_tolerance"] = self.absolute_tolerance
         self.newton_solver.parameters["relative_tolerance"] = self.relative_tolerance
         self.newton_solver.parameters["maximum_iterations"] = self.maximum_iterations

--- a/festim/concentration/traps/extrinsic_trap.py
+++ b/festim/concentration/traps/extrinsic_trap.py
@@ -73,6 +73,7 @@ class ExtrinsicTrapBase(Trap):
     def define_newton_solver(self):
         """Creates the Newton solver and sets its parameters"""
         self.newton_solver = NewtonSolver(MPI.comm_world)
+        self.newton_solver.parameters["error_on_nonconvergence"] = True
         self.newton_solver.parameters["absolute_tolerance"] = self.absolute_tolerance
         self.newton_solver.parameters["relative_tolerance"] = self.relative_tolerance
         self.newton_solver.parameters["maximum_iterations"] = self.maximum_iterations

--- a/festim/temperature/temperature_solver.py
+++ b/festim/temperature/temperature_solver.py
@@ -223,6 +223,7 @@ class HeatTransferProblem(festim.Temperature):
     def define_newton_solver(self):
         """Creates the Newton solver and sets its parameters"""
         self.newton_solver = f.NewtonSolver(f.MPI.comm_world)
+        self.newton_solver.parameters["error_on_nonconvergence"] = True
         self.newton_solver.parameters["absolute_tolerance"] = self.absolute_tolerance
         self.newton_solver.parameters["relative_tolerance"] = self.relative_tolerance
         self.newton_solver.parameters["maximum_iterations"] = self.maximum_iterations

--- a/festim/temperature/temperature_solver.py
+++ b/festim/temperature/temperature_solver.py
@@ -223,7 +223,6 @@ class HeatTransferProblem(festim.Temperature):
     def define_newton_solver(self):
         """Creates the Newton solver and sets its parameters"""
         self.newton_solver = f.NewtonSolver(f.MPI.comm_world)
-        self.newton_solver.parameters["error_on_nonconvergence"] = False
         self.newton_solver.parameters["absolute_tolerance"] = self.absolute_tolerance
         self.newton_solver.parameters["relative_tolerance"] = self.relative_tolerance
         self.newton_solver.parameters["maximum_iterations"] = self.maximum_iterations

--- a/test/unit/test_temperature.py
+++ b/test/unit/test_temperature.py
@@ -262,3 +262,25 @@ def test_temperature_from_xdmf(tmpdir):
     temperature = festim.TemperatureFromXDMF(T_file, "T")
 
     assert temperature.is_steady_state()
+
+
+def test_heat_transfer_default_solver():
+    """
+    Tests that the default parameters for the Newton solver
+    of HeatTransferProblem are correct
+    """
+
+    heat_solver = festim.HeatTransferProblem()
+    heat_solver.define_newton_solver()
+
+    default_settings = {
+        "absolute_tolerance": 1e-3,
+        "relative_tolerance": 1e-10,
+        "maximum_iterations": 30,
+        "linear_solver": None,
+        "preconditioner": "default",
+        "error_on_nonconvergence": True,
+    }
+
+    for key in default_settings.keys():
+        assert default_settings[key] == heat_solver.newton_solver.parameters[key]

--- a/test/unit/test_traps/test_extrinsic_trap.py
+++ b/test/unit/test_traps/test_extrinsic_trap.py
@@ -79,12 +79,31 @@ class TestExtrinsicTrap:
         print(self.my_trap.form_density)
         assert self.my_trap.form_density.equals(expected_form)
 
+    def test_default_solver_parameters(self):
+        """
+        A test to check that the default parameters for the Newton solver
+        of ExtrinsicTrap are correct
+        """
+        self.my_trap.define_newton_solver()
+
+        default_settings = {
+            "absolute_tolerance": 1e0,
+            "relative_tolerance": 1e-10,
+            "maximum_iterations": 30,
+            "linear_solver": None,
+            "preconditioner": "default",
+            "error_on_nonconvergence": True,
+        }
+
+        for key in default_settings.keys():
+            assert default_settings[key] == self.my_trap.newton_solver.parameters[key]
+
     def test_solver_parameters(self):
         """
         A test to ensure the extrinsic trap solver parameters can be accessed
         """
-        self.my_trap.absolute_tolerance = 1
-        self.my_trap.relative_tolerance = 1
+        self.my_trap.absolute_tolerance = 1.0
+        self.my_trap.relative_tolerance = 1.0
         self.my_trap.maximum_iterations = 1
         self.my_trap.linear_solver = "mumps"
         self.my_trap.preconditioner = "icc"


### PR DESCRIPTION
## Proposed changes

This PR fixes the bug with default parameters of the Newton solver. Currently, a simulation won't stop if Newton solver for `HeatTransferProblem`/`ExtrinsicTrap` doesn't converge. This issue is related to the default value for the `error_on_nonconvergence` of Newton solvers. 

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
