### PR TITLE
New default value for `DerivedQuantities.show_units`

### DIFF
--- a/festim/exports/derived_quantities/average_surface.py
+++ b/festim/exports/derived_quantities/average_surface.py
@@ -33,13 +33,17 @@ class AverageSurface(SurfaceQuantity):
         return ["cartesian"]
 
     @property
+    def export_unit(self):
+        if self.field == "T":
+            return "K"
+        else:
+            return "H m-3"
+
+    @property
     def title(self):
         quantity_title = f"Average {self.field} surface {self.surface}"
         if self.show_units:
-            if self.field == "T":
-                return quantity_title + " (K)"
-            else:
-                return quantity_title + " (H m-3)"
+            return quantity_title + f" ({self.export_unit})"
         else:
             return quantity_title
 

--- a/festim/exports/derived_quantities/average_volume.py
+++ b/festim/exports/derived_quantities/average_volume.py
@@ -32,13 +32,17 @@ class AverageVolume(VolumeQuantity):
         return ["cartesian"]
 
     @property
+    def export_unit(self):
+        if self.field == "T":
+            return "K"
+        else:
+            return "H m-3"
+
+    @property
     def title(self):
         quantity_title = f"Average {self.field} volume {self.volume}"
         if self.show_units:
-            if self.field == "T":
-                return quantity_title + " (K)"
-            else:
-                return quantity_title + " (H m-3)"
+            return quantity_title + f" ({self.export_unit})"
         else:
             return quantity_title
 

--- a/festim/exports/derived_quantities/derived_quantities.py
+++ b/festim/exports/derived_quantities/derived_quantities.py
@@ -24,7 +24,7 @@ class DerivedQuantities(list):
             iterations between each export. If None, the file will be
             exported at the last timestep. Defaults to None.
         show_units (bool, optional): will show the units of each
-            derived quantity in the title in export
+            derived quantity in the title in export. Defaults to True.
 
     Attributes:
         filename (str): the filename.
@@ -45,7 +45,7 @@ class DerivedQuantities(list):
         filename: str = None,
         nb_iterations_between_compute: int = 1,
         nb_iterations_between_exports: int = None,
-        show_units=False,
+        show_units=True,
     ) -> None:
         # checks that input is list
         if len(args) == 0:
@@ -125,11 +125,6 @@ class DerivedQuantities(list):
         header = ["t(s)"]
         for quantity in self:
             quantity.show_units = self.show_units
-            if self.show_units is False:
-                warnings.warn(
-                    "The current derived_quantities title style will be deprecated in a future release, please use show_units=True instead",
-                    DeprecationWarning,
-                )
             header.append(quantity.title)
         return header
 

--- a/festim/exports/derived_quantities/derived_quantity.py
+++ b/festim/exports/derived_quantities/derived_quantity.py
@@ -39,7 +39,7 @@ class DerivedQuantity(Export):
         self.T = None
         self.data = []
         self.t = []
-        self.show_units = False
+        self.show_units = True
 
     @property
     def allowed_meshes(self):

--- a/festim/exports/derived_quantities/maximum_surface.py
+++ b/festim/exports/derived_quantities/maximum_surface.py
@@ -29,13 +29,17 @@ class MaximumSurface(SurfaceQuantity):
         super().__init__(field=field, surface=surface)
 
     @property
+    def export_unit(self):
+        if self.field == "T":
+            return "K"
+        else:
+            return "H m-3"
+
+    @property
     def title(self):
         quantity_title = f"Maximum {self.field} surface {self.surface}"
         if self.show_units:
-            if self.field == "T":
-                return quantity_title + " (K)"
-            else:
-                return quantity_title + " (H m-3)"
+            return quantity_title + f" ({self.export_unit})"
         else:
             return quantity_title
 

--- a/festim/exports/derived_quantities/maximum_volume.py
+++ b/festim/exports/derived_quantities/maximum_volume.py
@@ -29,13 +29,17 @@ class MaximumVolume(VolumeQuantity):
         super().__init__(field=field, volume=volume)
 
     @property
+    def export_unit(self):
+        if self.field == "T":
+            return "K"
+        else:
+            return "H m-3"
+
+    @property
     def title(self):
         quantity_title = f"Maximum {self.field} volume {self.volume}"
         if self.show_units:
-            if self.field == "T":
-                return quantity_title + " (K)"
-            else:
-                return quantity_title + " (H m-3)"
+            return quantity_title + f" ({self.export_unit})"
         else:
             return quantity_title
 

--- a/festim/exports/derived_quantities/minimum_surface.py
+++ b/festim/exports/derived_quantities/minimum_surface.py
@@ -29,13 +29,17 @@ class MinimumSurface(SurfaceQuantity):
         super().__init__(field=field, surface=surface)
 
     @property
+    def export_unit(self):
+        if self.field == "T":
+            return "K"
+        else:
+            return "H m-3"
+
+    @property
     def title(self):
         quantity_title = f"Minimum {self.field} surface {self.surface}"
         if self.show_units:
-            if self.field == "T":
-                return quantity_title + " (K)"
-            else:
-                return quantity_title + " (H m-3)"
+            return quantity_title + f" ({self.export_unit})"
         else:
             return quantity_title
 

--- a/festim/exports/derived_quantities/minimum_volume.py
+++ b/festim/exports/derived_quantities/minimum_volume.py
@@ -29,13 +29,17 @@ class MinimumVolume(VolumeQuantity):
         super().__init__(field=field, volume=volume)
 
     @property
+    def export_unit(self):
+        if self.field == "T":
+            return "K"
+        else:
+            return "H m-3"
+
+    @property
     def title(self):
         quantity_title = f"Minimum {self.field} volume {self.volume}"
         if self.show_units:
-            if self.field == "T":
-                return quantity_title + " (K)"
-            else:
-                return quantity_title + " (H m-3)"
+            return quantity_title + f" ({self.export_unit})"
         else:
             return quantity_title
 

--- a/festim/exports/derived_quantities/point_value.py
+++ b/festim/exports/derived_quantities/point_value.py
@@ -31,13 +31,17 @@ class PointValue(DerivedQuantity):
         self.x = x
 
     @property
+    def export_unit(self):
+        if self.field == "T":
+            return "K"
+        else:
+            return "H m-3"
+
+    @property
     def title(self):
         quantity_title = f"{self.field} value at {self.x}"
         if self.show_units:
-            if self.field == "T":
-                return quantity_title + " (K)"
-            else:
-                return quantity_title + " (H m-3)"
+            return quantity_title + f" ({self.export_unit})"
         else:
             return quantity_title
 

--- a/festim/exports/derived_quantities/surface_flux.py
+++ b/festim/exports/derived_quantities/surface_flux.py
@@ -53,15 +53,13 @@ class SurfaceFlux(SurfaceQuantity):
 
     @property
     def title(self):
-        quantity_title = f"Flux surface {self.surface}: {self.field}"
+        if self.field == "T":
+            quantity_title = f"Heat flux surface {self.surface}"
+        else:
+            quantity_title = f"{self.field} flux surface {self.surface}"
+
         if self.show_units:
-            if self.field == "T":
-                quantity_title = f"Heat flux surface {self.surface}"
-            else:
-                quantity_title = f"{self.field} flux surface {self.surface}"
-
             return quantity_title + f" ({self.export_unit})"
-
         else:
             return quantity_title
 

--- a/test/unit/test_exports/test_derived_quantities/test_adsorbed_hydrogen.py
+++ b/test/unit/test_exports/test_derived_quantities/test_adsorbed_hydrogen.py
@@ -22,6 +22,7 @@ def test_title_with_units():
 
 def test_title_without_units():
     my_quantity = AdsorbedHydrogen(1)
+    my_quantity.show_units = False
     assert my_quantity.title == "Adsorbed H on surface 1"
 
 

--- a/test/unit/test_exports/test_derived_quantities/test_average_surface.py
+++ b/test/unit/test_exports/test_derived_quantities/test_average_surface.py
@@ -15,7 +15,10 @@ def test_title(field, surface):
     """
 
     my_average = AverageSurface(field, surface)
-    assert my_average.title == "Average {} surface {}".format(field, surface)
+    assert (
+        my_average.title
+        == f"Average {field} surface {surface} ({my_average.export_unit})"
+    )
 
 
 class TestCompute:

--- a/test/unit/test_exports/test_derived_quantities/test_average_volume.py
+++ b/test/unit/test_exports/test_derived_quantities/test_average_volume.py
@@ -15,7 +15,10 @@ def test_title(field, volume):
     """
 
     my_average = AverageVolume(field, volume)
-    assert my_average.title == "Average {} volume {}".format(field, volume)
+    assert (
+        my_average.title
+        == f"Average {field} volume {volume} ({my_average.export_unit})"
+    )
 
 
 class TestCompute:

--- a/test/unit/test_exports/test_derived_quantities/test_derived_quantities.py
+++ b/test/unit/test_exports/test_derived_quantities/test_derived_quantities.py
@@ -57,8 +57,7 @@ class TestMakeHeader:
         """
         my_derv_quant = DerivedQuantities([self.surface_flux_1])
 
-        for quantity in my_derv_quant:
-            quantity.function = f.Function(self.V)
+        my_derv_quant[0].function = f.Function(self.V)
 
         header = my_derv_quant.make_header()
 

--- a/test/unit/test_exports/test_derived_quantities/test_derived_quantities.py
+++ b/test/unit/test_exports/test_derived_quantities/test_derived_quantities.py
@@ -47,13 +47,21 @@ class TestMakeHeader:
     sph_surface_flux_2 = SurfaceFluxSpherical("T", 6)
     ads_h = AdsorbedHydrogen(1)
 
+    mesh = f.UnitIntervalMesh(10)
+    V = f.FunctionSpace(mesh, "P", 1)
+
     def test_simple(self):
         """
         Tests that a proper header is made for the output .csv file
         when there is only one festim.DerivedQuantity object
         """
         my_derv_quant = DerivedQuantities([self.surface_flux_1])
+
+        for quantity in my_derv_quant:
+            quantity.function = f.Function(self.V)
+
         header = my_derv_quant.make_header()
+
         expected_header = ["t(s)", self.surface_flux_1.title]
         assert header == expected_header
 
@@ -68,6 +76,9 @@ class TestMakeHeader:
                 self.tot_surf_1,
             ]
         )
+        for quantity in my_derv_quant:
+            quantity.function = f.Function(self.V)
+
         header = my_derv_quant.make_header()
         expected_header = ["t(s)", self.surface_flux_1.title, self.tot_surf_1.title]
         assert header == expected_header
@@ -89,6 +100,11 @@ class TestMakeHeader:
                 self.ads_h,
             ]
         )
+
+        # to compute the units of the quantities they need a function
+        for quantity in my_derv_quant:
+            quantity.function = f.Function(self.V)
+
         header = my_derv_quant.make_header()
         expected_header = ["t(s)"] + [
             self.surface_flux_1.title,

--- a/test/unit/test_exports/test_derived_quantities/test_hydrogen_flux.py
+++ b/test/unit/test_exports/test_derived_quantities/test_hydrogen_flux.py
@@ -31,4 +31,5 @@ def test_title_with_units(function, expected_title):
 
 def test_title_without_units():
     my_flux = HydrogenFlux(4)
-    assert my_flux.title == "Flux surface 4: solute"
+    my_flux.show_units = False
+    assert my_flux.title == "solute flux surface 4"

--- a/test/unit/test_exports/test_derived_quantities/test_maximum_surface.py
+++ b/test/unit/test_exports/test_derived_quantities/test_maximum_surface.py
@@ -16,7 +16,7 @@ def test_title(field, surface):
     """
 
     my_max = MaximumSurface(field, surface)
-    assert my_max.title == "Maximum {} surface {}".format(field, surface)
+    assert my_max.title == f"Maximum {field} surface {surface} ({my_max.export_unit})"
 
 
 class TestCompute:

--- a/test/unit/test_exports/test_derived_quantities/test_maximum_volume.py
+++ b/test/unit/test_exports/test_derived_quantities/test_maximum_volume.py
@@ -16,7 +16,7 @@ def test_title(field, volume):
     """
 
     my_max = MaximumVolume(field, volume)
-    assert my_max.title == "Maximum {} volume {}".format(field, volume)
+    assert my_max.title == f"Maximum {field} volume {volume} ({my_max.export_unit})"
 
 
 class TestCompute:

--- a/test/unit/test_exports/test_derived_quantities/test_minimum_surface.py
+++ b/test/unit/test_exports/test_derived_quantities/test_minimum_surface.py
@@ -16,7 +16,7 @@ def test_title(field, surface):
     """
 
     my_min = MinimumSurface(field, surface)
-    assert my_min.title == "Minimum {} surface {}".format(field, surface)
+    assert my_min.title == f"Minimum {field} surface {surface} ({my_min.export_unit})"
 
 
 class TestCompute:

--- a/test/unit/test_exports/test_derived_quantities/test_minimum_volume.py
+++ b/test/unit/test_exports/test_derived_quantities/test_minimum_volume.py
@@ -16,7 +16,7 @@ def test_title(field, volume):
     """
 
     my_min = MinimumVolume(field, volume)
-    assert my_min.title == "Minimum {} volume {}".format(field, volume)
+    assert my_min.title == f"Minimum {field} volume {volume} ({my_min.export_unit})"
 
 
 class TestCompute:

--- a/test/unit/test_exports/test_derived_quantities/test_point_value.py
+++ b/test/unit/test_exports/test_derived_quantities/test_point_value.py
@@ -14,7 +14,7 @@ def test_title(field):
     """
     x = 1
     my_value = PointValue(field, x)
-    assert my_value.title == "{} value at [{}]".format(field, x)
+    assert my_value.title == f"{field} value at [{x}] ({my_value.export_unit})"
 
 
 @pytest.mark.parametrize(

--- a/test/unit/test_exports/test_derived_quantities/test_surface_flux.py
+++ b/test/unit/test_exports/test_derived_quantities/test_surface_flux.py
@@ -20,7 +20,12 @@ def test_title(field, surface):
     """
 
     my_h_flux = SurfaceFlux(field, surface)
-    assert my_h_flux.title == "Flux surface {}: {}".format(surface, field)
+    my_h_flux.function = c_1D
+    if field == "T":
+        expected_title = f"Heat flux surface {surface} ({my_h_flux.export_unit})"
+    else:
+        expected_title = f"{field} flux surface {surface} ({my_h_flux.export_unit})"
+    assert my_h_flux.title == expected_title
 
 
 class TestCompute:
@@ -324,6 +329,7 @@ def test_cylindrical_flux_title_no_units_solute():
     festim.CylindricalSurfaceFlux with a solute field without units"""
 
     my_h_flux = SurfaceFluxCylindrical("solute", 2)
+    my_h_flux.show_units = False
     assert my_h_flux.title == "solute flux surface 2"
 
 
@@ -332,6 +338,7 @@ def test_cylindrical_flux_title_no_units_temperature():
     festim.CylindricalSurfaceFlux with a T field without units"""
 
     my_heat_flux = SurfaceFluxCylindrical("T", 4)
+    my_heat_flux.show_units = False
     assert my_heat_flux.title == "Heat flux surface 4"
 
 
@@ -357,6 +364,7 @@ def test_spherical_flux_title_no_units_solute():
     festim.SphericalSurfaceFlux with a solute field without units"""
 
     my_h_flux = SurfaceFluxSpherical("solute", 3)
+    my_h_flux.show_units = False
     assert my_h_flux.title == "solute flux surface 3"
 
 
@@ -365,6 +373,7 @@ def test_spherical_flux_title_no_units_temperature():
     festim.CSphericalSurfaceFlux with a T field without units"""
 
     my_heat_flux = SurfaceFluxSpherical("T", 5)
+    my_heat_flux.show_units = False
     assert my_heat_flux.title == "Heat flux surface 5"
 
 

--- a/test/unit/test_exports/test_derived_quantities/test_thermal_flux.py
+++ b/test/unit/test_exports/test_derived_quantities/test_thermal_flux.py
@@ -30,5 +30,6 @@ def test_title_with_units(function, expected_title):
 
 def test_title_without_units():
     my_flux = ThermalFlux(5)
+    my_flux.show_units = False
 
-    assert my_flux.title == "Flux surface 5: T"
+    assert my_flux.title == "Heat flux surface 5"

--- a/test/unit/test_exports/test_derived_quantities/test_total_surface.py
+++ b/test/unit/test_exports/test_derived_quantities/test_total_surface.py
@@ -17,7 +17,8 @@ def test_title(field, surface):
     """
 
     my_total = TotalSurface(field, surface)
-    assert my_total.title == "Total {} surface {}".format(field, surface)
+    my_total.function = c_2D
+    assert my_total.title == f"Total {field} surface {surface} ({my_total.export_unit})"
 
 
 class TestCompute:

--- a/test/unit/test_exports/test_derived_quantities/test_total_volume.py
+++ b/test/unit/test_exports/test_derived_quantities/test_total_volume.py
@@ -17,7 +17,8 @@ def test_title(field, volume):
     """
 
     my_total = TotalVolume(field, volume)
-    assert my_total.title == "Total {} volume {}".format(field, volume)
+    my_total.function = c_2D
+    assert my_total.title == f"Total {field} volume {volume} ({my_total.export_unit})"
 
 
 class TestCompute:


### PR DESCRIPTION
Fixes #860 but instead of deprecating the `show_units` argument, I just have it default to True.

What do you think @jhdark @KulaginVladimir? I thought it'd be nice to keep the functionality in case someone doesn't want the units in (eg. they are working in moles)...