### PR TITLE
Always CI on different docker versions

### DIFF
--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -5,6 +5,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         container_version: [v0.9.0, nightly]
     container: dolfinx/dolfinx:${{ matrix.container_version }}


### PR DESCRIPTION
## Proposed changes

I noticed in #922 that if the docker CI fails on nightly it will cancel 0.9.0. We don't want this