### PR TITLE
Deprecate list attributes

### DIFF
--- a/festim/concentration/traps/traps.py
+++ b/festim/concentration/traps/traps.py
@@ -1,6 +1,5 @@
 import festim
 import fenics as f
-import warnings
 
 
 class Traps(list):
@@ -20,27 +19,6 @@ class Traps(list):
         self.F = None
         self.extrinsic_formulations = []
         self.sub_expressions = []
-
-    @property
-    def traps(self):
-        warnings.warn(
-            "The traps attribute will be deprecated in a future release, please use festim.Traps as a list instead",
-            DeprecationWarning,
-        )
-        return self
-
-    @traps.setter
-    def traps(self, value):
-        warnings.warn(
-            "The traps attribute will be deprecated in a future release, please use festim.Traps as a list instead",
-            DeprecationWarning,
-        )
-        if isinstance(value, list):
-            if not all(isinstance(t, festim.Trap) for t in value):
-                raise TypeError("traps must be a list of festim.Trap")
-            super().__init__(value)
-        else:
-            raise TypeError("traps must be a list")
 
     def __setitem__(self, index, item):
         super().__setitem__(index, self._validate_trap(item))

--- a/festim/exports/derived_quantities/derived_quantities.py
+++ b/festim/exports/derived_quantities/derived_quantities.py
@@ -7,7 +7,6 @@ import fenics as f
 import os
 import numpy as np
 from typing import Union
-import warnings
 
 
 class DerivedQuantities(list):
@@ -62,29 +61,6 @@ class DerivedQuantities(list):
 
         self.data = []
         self.t = []
-
-    @property
-    def derived_quantities(self):
-        warnings.warn(
-            "The derived_quantities attribute will be deprecated in a future release, please use festim.DerivedQuantities as a list instead",
-            DeprecationWarning,
-        )
-        return self
-
-    @derived_quantities.setter
-    def derived_quantities(self, value):
-        warnings.warn(
-            "The derived_quantities attribute will be deprecated in a future release, please use festim.DerivedQuantities as a list instead",
-            DeprecationWarning,
-        )
-        if isinstance(value, list):
-            if not all(isinstance(t, DerivedQuantity) for t in value):
-                raise TypeError(
-                    "derived_quantities must be a list of festim.DerivedQuantity"
-                )
-            super().__init__(value)
-        else:
-            raise TypeError("derived_quantities must be a list")
 
     def __setitem__(self, index, item):
         super().__setitem__(index, self._validate_derived_quantity(item))

--- a/festim/exports/exports.py
+++ b/festim/exports/exports.py
@@ -1,6 +1,5 @@
 import festim
 import fenics as f
-import warnings
 
 
 class Exports(list):
@@ -21,33 +20,6 @@ class Exports(list):
         self.V_DG1 = None
         self.final_time = None
         self.nb_iterations = 0
-
-    @property
-    def exports(self):
-        warnings.warn(
-            "The exports attribute will be deprecated in a future release, please use festim.Exports as a list instead",
-            DeprecationWarning,
-        )
-        return self
-
-    @exports.setter
-    def exports(self, value):
-        warnings.warn(
-            "The exports attribute will be deprecated in a future release, please use festim.Exports as a list instead",
-            DeprecationWarning,
-        )
-        if isinstance(value, list):
-            if not all(
-                (
-                    isinstance(t, festim.Export)
-                    or isinstance(t, festim.DerivedQuantities)
-                )
-                for t in value
-            ):
-                raise TypeError("exports must be a list of festim.Export")
-            super().__init__(value)
-        else:
-            raise TypeError("exports must be a list")
 
     def __setitem__(self, index, item):
         super().__setitem__(index, self._validate_export(item))

--- a/festim/materials/materials.py
+++ b/festim/materials/materials.py
@@ -5,7 +5,6 @@ from festim import k_B, Material, HeatTransferProblem
 import festim
 import fenics as f
 from typing import Union
-import warnings
 
 
 class Materials(list):
@@ -28,27 +27,6 @@ class Materials(list):
         self.heat_capacity = None
         self.density = None
         self.Q = None
-
-    @property
-    def materials(self):
-        warnings.warn(
-            "The materials attribute will be deprecated in a future release, please use festim.Materials as a list instead",
-            DeprecationWarning,
-        )
-        return self
-
-    @materials.setter
-    def materials(self, value):
-        warnings.warn(
-            "The materials attribute will be deprecated in a future release, please use festim.Materials as a list instead",
-            DeprecationWarning,
-        )
-        if isinstance(value, list):
-            if not all(isinstance(t, festim.Material) for t in value):
-                raise TypeError("materials must be a list of festim.Material")
-            super().__init__(value)
-        else:
-            raise TypeError("materials must be a list")
 
     def __setitem__(self, index, item):
         super().__setitem__(index, self._validate_material(item))

--- a/test/unit/test_exports/test_derived_quantities/test_derived_quantities.py
+++ b/test/unit/test_exports/test_derived_quantities/test_derived_quantities.py
@@ -543,49 +543,6 @@ def test_assign_derived_quantitites_wrong_type():
             my_derived_quantities.insert(0, dq_combination)
 
 
-class TestDerivedQuantititesPropertyDeprWarn:
-    """
-    A temporary test to check DeprecationWarnings in festim.DerivedQuantitites.exports
-    """
-
-    my_derived_quantity = SurfaceFlux(0, 2)
-    my_derived_quantities = DerivedQuantities([])
-
-    def test_property_depr_warns(self):
-        with pytest.deprecated_call():
-            self.my_derived_quantities.derived_quantities
-
-    def test_property_setter_depr_warns(self):
-        with pytest.deprecated_call():
-            self.my_derived_quantities.derived_quantities = [self.my_derived_quantity]
-
-
-class TestDerivedQuantititesPropertyRaiseError:
-    """
-    A temporary test to check TypeErrors in festim.DerivedQuantitites.exports
-    """
-
-    my_derived_quantity = SurfaceFlux(0, 2)
-    my_derived_quantities = DerivedQuantities([])
-
-    def test_set_der_quants_wrong_type(self):
-        with pytest.raises(
-            TypeError,
-            match="derived_quantities must be a list",
-        ):
-            self.my_derived_quantities.derived_quantities = self.my_derived_quantity
-
-    def test_set_der_quants_list_wrong_type(self):
-        with pytest.raises(
-            TypeError,
-            match="derived_quantities must be a list of festim.DerivedQuantity",
-        ):
-            self.my_derived_quantities.derived_quantities = [
-                self.my_derived_quantity,
-                1,
-            ]
-
-
 def test_instanciate_with_no_derived_quantities():
     """
     Test to catch bug described in issue #724

--- a/test/unit/test_exports/test_exports.py
+++ b/test/unit/test_exports/test_exports.py
@@ -94,46 +94,6 @@ def test_assign_exports_wrong_type():
             my_exports.insert(0, export_combination)
 
 
-class TestExportsPropertyDeprWarn:
-    """
-    A temporary test to check DeprecationWarnings in festim.Exports.exports
-    """
-
-    my_export = festim.Export(field=0)
-    my_exports = festim.Exports([])
-
-    def test_property_depr_warns(self):
-        with pytest.deprecated_call():
-            self.my_exports.exports
-
-    def test_property_setter_depr_warns(self):
-        with pytest.deprecated_call():
-            self.my_exports.exports = [self.my_export]
-
-
-class TestExportsPropertyRaiseError:
-    """
-    A temporary test to check TypeErrors in festim.Exports.exports
-    """
-
-    my_export = festim.Export(field=0)
-    my_exports = festim.Exports([])
-
-    def test_set_exports_wrong_type(self):
-        with pytest.raises(
-            TypeError,
-            match="exports must be a list",
-        ):
-            self.my_exports.exports = self.my_export
-
-    def test_set_exports_list_wrong_type(self):
-        with pytest.raises(
-            TypeError,
-            match="exports must be a list of festim.Export",
-        ):
-            self.my_exports.exports = [self.my_export, 1]
-
-
 def test_instanciate_with_no_elements():
     """
     Test to catch bug described in issue #724

--- a/test/unit/test_materials.py
+++ b/test/unit/test_materials.py
@@ -402,46 +402,6 @@ def test_assign_materials_wrong_type():
             my_materials.insert(0, mat_combination)
 
 
-class TestMaterialsPropertyDeprWarn:
-    """
-    A temporary test to check DeprecationWarnings in F.Materials.materials
-    """
-
-    my_mat = F.Material(id=1, E_D=1, D_0=1)
-    my_mats = F.Materials([])
-
-    def test_property_depr_warns(self):
-        with pytest.deprecated_call():
-            self.my_mats.materials
-
-    def test_property_setter_depr_warns(self):
-        with pytest.deprecated_call():
-            self.my_mats.materials = [self.my_mat]
-
-
-class TestMaterialsPropertyRaiseError:
-    """
-    A temporary test to check TypeErrors in F.Materials.materials
-    """
-
-    my_mat = F.Material(id=1, E_D=1, D_0=1)
-    my_mats = F.Materials([])
-
-    def test_set_materials_wrong_type(self):
-        with pytest.raises(
-            TypeError,
-            match="materials must be a list",
-        ):
-            self.my_mats.materials = self.my_mat
-
-    def test_set_materials_list_wrong_type(self):
-        with pytest.raises(
-            TypeError,
-            match="materials must be a list of festim.Material",
-        ):
-            self.my_mats.materials = [self.my_mat, 1]
-
-
 def test_instanciate_with_no_elements():
     """
     Test to catch bug described in issue #724

--- a/test/unit/test_traps/test_traps.py
+++ b/test/unit/test_traps/test_traps.py
@@ -213,50 +213,6 @@ def test_assign_traps_wrong_type():
             my_traps.insert(0, trap_combination)
 
 
-class TestTrapsPropertyDeprWarn:
-    """
-    A temporary test to check DeprecationWarnings in festim.Traps.traps
-    """
-
-    my_mat = festim.Material(1, 1, 1)
-    my_trap = festim.Trap(1, 1, 1, 1, [my_mat], 1)
-
-    my_traps = festim.Traps([])
-
-    def test_property_depr_warns(self):
-        with pytest.deprecated_call():
-            self.my_traps.traps
-
-    def test_property_setter_depr_warns(self):
-        with pytest.deprecated_call():
-            self.my_traps.traps = [self.my_trap]
-
-
-class TestTrapsPropertyRaiseError:
-    """
-    A temporary test to check TypeErrors in festim.Traps.traps
-    """
-
-    my_mat = festim.Material(1, 1, 1)
-    my_trap = festim.Trap(1, 1, 1, 1, [my_mat], 1)
-
-    my_traps = festim.Traps([])
-
-    def test_set_traps_wrong_type(self):
-        with pytest.raises(
-            TypeError,
-            match="traps must be a list",
-        ):
-            self.my_traps.traps = self.my_trap
-
-    def test_set_traps_list_wrong_type(self):
-        with pytest.raises(
-            TypeError,
-            match="traps must be a list of festim.Trap",
-        ):
-            self.my_traps.traps = [self.my_trap, 1]
-
-
 def test_instanciate_with_no_elements():
     """
     Test to catch bug described in issue #724


### PR DESCRIPTION
## Proposed changes

Fix for #861 

Now certain classes such as DerivedQuantities, Traps and Exports now inherent from List, they no longer need attributes of themselves. The attributes were kept for backwards compatibility, but have been warned for the past two releases and now can be deprecated. 

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
