### PR TITLE
provide Stepsize as float or int

### DIFF
--- a/docs/source/userguide/stepsize.rst
+++ b/docs/source/userguide/stepsize.rst
@@ -73,7 +73,7 @@ This will modify the stepsize as needed.
 
 .. note::
     
-    When defining the simulation, if your stepsize is constant, you can define it simply by providing it as a `float`` or `int`:
+    If your stepsize is constant, you can define it simply as a ``float`` or ``int``:
     
     .. testcode::
 

--- a/docs/source/userguide/stepsize.rst
+++ b/docs/source/userguide/stepsize.rst
@@ -69,3 +69,14 @@ This will modify the stepsize as needed.
         max_stepsize=5,
         milestones=[1, 5, 6, 10]
         )
+
+
+.. note::
+    
+    When defining the simulation, if your stepsize is constant, you can define it simply by providing it as a `float`` or `int`:
+    
+    .. testcode::
+
+        my_model = F.Simulation()
+
+        my_model.dt = 2.0

--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -182,6 +182,21 @@ class Simulation:
                 "accepted types for T attribute are int, float, sympy.Expr or festim.Temperature"
             )
 
+    @property
+    def dt(self):
+        return self._dt
+
+    @dt.setter
+    def dt(self, value):
+        if value is None:
+            self._dt = value
+        elif isinstance(value, (int, float)):
+            self._dt = festim.Stepsize(value)
+        elif isinstance(value, festim.Stepsize):
+            self._dt = value
+        else:
+            raise TypeError("dt must be an int, float, or festim.Stepsize")
+
     def attribute_source_terms(self):
         """Assigns the source terms (in self.sources) to the correct field
         (self.mobile, self.T, or traps)

--- a/test/unit/test_stepsize.py
+++ b/test/unit/test_stepsize.py
@@ -132,7 +132,7 @@ def test_hit_stepsize_max_with_t_stop(time):
     assert my_stepsize.adaptive_stepsize["max_stepsize"](time) == max_stepsize(time)
 
 
-@pytest.mark.parametrize("time", [1, 2.5, "coucou", np.array([1, 2]), [1, 2]])
+@pytest.mark.parametrize("time", [1, 2.5, festim.Stepsize(1.0),"coucou", np.array([1, 2]), [1, 2]])
 def test_stepsize_as_value(time):
     """
     A test to check that users can pass an int or float to the dt attribute when
@@ -143,6 +143,7 @@ def test_stepsize_as_value(time):
 
     if isinstance(time, (int, float, festim.Stepsize)):
         my_model.dt = time
+        assert isinstance(my_model.dt, festim.Stepsize)
     else:
         with pytest.raises(
             TypeError, match="dt must be an int, float, or festim.Stepsize"

--- a/test/unit/test_stepsize.py
+++ b/test/unit/test_stepsize.py
@@ -130,3 +130,21 @@ def test_hit_stepsize_max_with_t_stop(time):
     )
     max_stepsize = lambda t: 1 if t >= 1 else None
     assert my_stepsize.adaptive_stepsize["max_stepsize"](time) == max_stepsize(time)
+
+
+@pytest.mark.parametrize("time", [1, 2.5, "coucou", np.array([1, 2]), [1, 2]])
+def test_stepsize_as_value(time):
+    """
+    A test to check that users can pass an int or float to the dt attribute when
+    initialising a F.Simulation class, and an error is raised when passed anything else
+    """
+
+    my_model = festim.Simulation()
+
+    if isinstance(time, (int, float, festim.Stepsize)):
+        my_model.dt = time
+    else:
+        with pytest.raises(
+            TypeError, match="dt must be an int, float, or festim.Stepsize"
+        ):
+            my_model.dt = time

--- a/test/unit/test_stepsize.py
+++ b/test/unit/test_stepsize.py
@@ -132,7 +132,9 @@ def test_hit_stepsize_max_with_t_stop(time):
     assert my_stepsize.adaptive_stepsize["max_stepsize"](time) == max_stepsize(time)
 
 
-@pytest.mark.parametrize("time", [1, 2.5, festim.Stepsize(1.0),"coucou", np.array([1, 2]), [1, 2]])
+@pytest.mark.parametrize(
+    "time", [1, 2.5, festim.Stepsize(1.0), "coucou", np.array([1, 2]), [1, 2]]
+)
 def test_stepsize_as_value(time):
     """
     A test to check that users can pass an int or float to the dt attribute when


### PR DESCRIPTION
## Proposed changes

Fix for #846 

With this change users can define the dt simply by an `int` or `float` such as:

```python
import festim as F

my_model = F.Simulation()

my_model.mesh = F.MeshFromVertices([1, 2, 3, 4])

my_model.materials = F.Material(id=1, D_0=1, E_D=0)
my_model.T = 300
my_model.settings = F.Settings(
    absolute_tolerance=1e-10,
    relative_tolerance=1e-10,
    transient=True,
    final_time=10,
)

my_model.dt = 1    # <------- provide stepsize as int or float


my_model.initialise()
my_model.run()
```

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
