### PR TITLE
Printing messages in parallel runs

### DIFF
--- a/festim/__init__.py
+++ b/festim/__init__.py
@@ -27,6 +27,7 @@ from .helpers import (
     as_constant,
     as_expression,
     as_constant_or_expression,
+    festim_print,
 )
 
 from .meshing.mesh import Mesh

--- a/festim/concentration/mobile.py
+++ b/festim/concentration/mobile.py
@@ -178,7 +178,8 @@ class Mobile(Concentration):
         F_source = 0
         expressions_source = []
 
-        print("Defining source terms")
+        if MPI.comm_world.rank == 0:
+            print("Defining source terms")
         for source in self.sources:
             if type(source.volume) is list:
                 volumes = source.volume

--- a/festim/concentration/mobile.py
+++ b/festim/concentration/mobile.py
@@ -1,4 +1,11 @@
-from festim import Concentration, FluxBC, k_B, RadioactiveDecay, SurfaceKinetics
+from festim import (
+    Concentration,
+    FluxBC,
+    k_B,
+    RadioactiveDecay,
+    SurfaceKinetics,
+    festim_print,
+)
 from fenics import *
 
 
@@ -178,8 +185,7 @@ class Mobile(Concentration):
         F_source = 0
         expressions_source = []
 
-        if MPI.comm_world.rank == 0:
-            print("Defining source terms")
+        festim_print("Defining source terms")
         for source in self.sources:
             if type(source.volume) is list:
                 volumes = source.volume

--- a/festim/concentration/traps/extrinsic_trap.py
+++ b/festim/concentration/traps/extrinsic_trap.py
@@ -65,7 +65,8 @@ class ExtrinsicTrapBase(Trap):
             self._newton_solver = value
         elif isinstance(value, NewtonSolver):
             if self._newton_solver:
-                print("Settings for the Newton solver will be overwritten")
+                if MPI.comm_world.rank == 0:
+                    print("Settings for the Newton solver will be overwritten")
             self._newton_solver = value
         else:
             raise TypeError("accepted type for newton_solver is fenics.NewtonSolver")

--- a/festim/concentration/traps/extrinsic_trap.py
+++ b/festim/concentration/traps/extrinsic_trap.py
@@ -1,4 +1,4 @@
-from festim import Trap, as_constant_or_expression
+from festim import Trap, as_constant_or_expression, festim_print
 from fenics import NewtonSolver, MPI
 
 
@@ -65,8 +65,7 @@ class ExtrinsicTrapBase(Trap):
             self._newton_solver = value
         elif isinstance(value, NewtonSolver):
             if self._newton_solver:
-                if MPI.comm_world.rank == 0:
-                    print("Settings for the Newton solver will be overwritten")
+                festim_print("Settings for the Newton solver will be overwritten")
             self._newton_solver = value
         else:
             raise TypeError("accepted type for newton_solver is fenics.NewtonSolver")

--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -461,7 +461,8 @@ class Simulation:
             self.h_transport_problem.compute_jacobian()
 
         #  Time-stepping
-        print("Time stepping...")
+        if MPI.comm_world.rank == 0:
+            print("Time stepping...")
         while self.t < self.settings.final_time and not np.isclose(
             self.t, self.settings.final_time, atol=0
         ):
@@ -469,7 +470,8 @@ class Simulation:
 
     def run_steady(self):
         # Solve steady state
-        print("Solving steady state problem...")
+        if MPI.comm_world.rank == 0:
+            print("Solving steady state problem...")
 
         nb_iterations, converged = self.h_transport_problem.solve_once()
 
@@ -480,7 +482,8 @@ class Simulation:
         # print final message
         if converged:
             msg = "Solved problem in {:.2f} s".format(elapsed_time)
-            print(msg)
+            if MPI.comm_world.rank == 0:
+                print(msg)
         else:
             msg = "The solver diverged in "
             msg += "{:.0f} iteration(s) ({:.2f} s)".format(nb_iterations, elapsed_time)
@@ -517,9 +520,11 @@ class Simulation:
             not np.isclose(self.t, self.settings.final_time, atol=0)
             and self.log_level == 40
         ):
-            print(msg, end="\r")
+            if MPI.comm_world.rank == 0:
+                print(msg, end="\r")
         else:
-            print(msg)
+            if MPI.comm_world.rank == 0:
+                print(msg)
 
     def run_post_processing(self):
         """Create post processing functions and compute/write the exports"""

--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -461,8 +461,7 @@ class Simulation:
             self.h_transport_problem.compute_jacobian()
 
         #  Time-stepping
-        if MPI.comm_world.rank == 0:
-            print("Time stepping...")
+        festim.festim_print("Time stepping...")
         while self.t < self.settings.final_time and not np.isclose(
             self.t, self.settings.final_time, atol=0
         ):
@@ -470,8 +469,7 @@ class Simulation:
 
     def run_steady(self):
         # Solve steady state
-        if MPI.comm_world.rank == 0:
-            print("Solving steady state problem...")
+        festim.festim_print("Solving steady state problem...")
 
         nb_iterations, converged = self.h_transport_problem.solve_once()
 
@@ -482,8 +480,7 @@ class Simulation:
         # print final message
         if converged:
             msg = "Solved problem in {:.2f} s".format(elapsed_time)
-            if MPI.comm_world.rank == 0:
-                print(msg)
+            festim.festim_print(msg)
         else:
             msg = "The solver diverged in "
             msg += "{:.0f} iteration(s) ({:.2f} s)".format(nb_iterations, elapsed_time)
@@ -520,11 +517,9 @@ class Simulation:
             not np.isclose(self.t, self.settings.final_time, atol=0)
             and self.log_level == 40
         ):
-            if MPI.comm_world.rank == 0:
-                print(msg, end="\r")
+            festim.festim_print(msg, end="\r")
         else:
-            if MPI.comm_world.rank == 0:
-                print(msg)
+            festim.festim_print(msg)
 
     def run_post_processing(self):
         """Create post processing functions and compute/write the exports"""

--- a/festim/h_transport_problem.py
+++ b/festim/h_transport_problem.py
@@ -55,8 +55,9 @@ class HTransportProblem:
             self._newton_solver = value
         elif isinstance(value, NewtonSolver):
             if self._newton_solver:
-                if MPI.comm_world.rank == 0:
-                    print("Settings for the Newton solver will be overwritten")
+                festim.festim_print(
+                    "Settings for the Newton solver will be overwritten"
+                )
             self._newton_solver = value
         else:
             raise TypeError("accepted type for newton_solver is fenics.NewtonSolver")
@@ -103,8 +104,7 @@ class HTransportProblem:
         self.define_newton_solver()
 
         # Boundary conditions
-        if MPI.comm_world.rank == 0:
-            print("Defining boundary conditions")
+        festim.festim_print("Defining boundary conditions")
         self.create_dirichlet_bcs(materials, mesh)
         if self.settings.transient:
             self.traps.define_variational_problem_extrinsic_traps(mesh.dx, dt, self.T)
@@ -179,8 +179,7 @@ class HTransportProblem:
                     concentration.test_function = list(split(self.v))[index]
                     index += 1
 
-        if MPI.comm_world.rank == 0:
-            print("Defining initial values")
+        festim.festim_print("Defining initial values")
 
         field_to_component = {
             "solute": 0,

--- a/festim/h_transport_problem.py
+++ b/festim/h_transport_problem.py
@@ -55,7 +55,8 @@ class HTransportProblem:
             self._newton_solver = value
         elif isinstance(value, NewtonSolver):
             if self._newton_solver:
-                print("Settings for the Newton solver will be overwritten")
+                if MPI.comm_world.rank == 0:
+                    print("Settings for the Newton solver will be overwritten")
             self._newton_solver = value
         else:
             raise TypeError("accepted type for newton_solver is fenics.NewtonSolver")
@@ -102,7 +103,8 @@ class HTransportProblem:
         self.define_newton_solver()
 
         # Boundary conditions
-        print("Defining boundary conditions")
+        if MPI.comm_world.rank == 0:
+            print("Defining boundary conditions")
         self.create_dirichlet_bcs(materials, mesh)
         if self.settings.transient:
             self.traps.define_variational_problem_extrinsic_traps(mesh.dx, dt, self.T)
@@ -177,7 +179,9 @@ class HTransportProblem:
                     concentration.test_function = list(split(self.v))[index]
                     index += 1
 
-        print("Defining initial values")
+        if MPI.comm_world.rank == 0:
+            print("Defining initial values")
+
         field_to_component = {
             "solute": 0,
             "0": 0,
@@ -253,7 +257,9 @@ class HTransportProblem:
             dt (festim.Stepsize, optional): the stepsize, only needed if
                 self.settings.transient is True. Defaults to None.
         """
-        print("Defining variational problem")
+        if MPI.comm_world.rank == 0:
+            print("Defining variational problem")
+
         expressions = []
         F = 0
 

--- a/festim/helpers.py
+++ b/festim/helpers.py
@@ -1,6 +1,6 @@
 import festim
 import xml.etree.ElementTree as ET
-from fenics import Expression, UserExpression, Constant
+from fenics import Expression, UserExpression, Constant, MPI
 import sympy as sp
 
 
@@ -108,3 +108,8 @@ def extract_xdmf_labels(filename):
 
     unique_labels = list(set(labels))
     return unique_labels
+
+
+def festim_print(msg, end="\n"):
+    if MPI.comm_world.rank == 0:
+        print(msg, end=end)

--- a/festim/meshing/mesh_from_xdmf.py
+++ b/festim/meshing/mesh_from_xdmf.py
@@ -1,5 +1,5 @@
 import fenics as f
-from festim import Mesh
+from festim import Mesh, festim_print
 
 
 class MeshFromXDMF(Mesh):
@@ -43,8 +43,9 @@ class MeshFromXDMF(Mesh):
         f.XDMFFile(self.boundary_file).read(surface_markers, "f")
         surface_markers = f.MeshFunction("size_t", mesh, surface_markers)
 
-        if f.MPI.comm_world.rank == 0:
-            print("Succesfully load mesh with " + str(len(volume_markers)) + " cells")
+        festim_print(
+            "Succesfully load mesh with " + str(len(volume_markers)) + " cells"
+        )
 
         self.volume_markers = volume_markers
         self.surface_markers = surface_markers

--- a/festim/meshing/mesh_from_xdmf.py
+++ b/festim/meshing/mesh_from_xdmf.py
@@ -43,6 +43,8 @@ class MeshFromXDMF(Mesh):
         f.XDMFFile(self.boundary_file).read(surface_markers, "f")
         surface_markers = f.MeshFunction("size_t", mesh, surface_markers)
 
-        print("Succesfully load mesh with " + str(len(volume_markers)) + " cells")
+        if f.MPI.comm_world.rank == 0:
+            print("Succesfully load mesh with " + str(len(volume_markers)) + " cells")
+
         self.volume_markers = volume_markers
         self.surface_markers = surface_markers

--- a/festim/temperature/temperature_solver.py
+++ b/festim/temperature/temperature_solver.py
@@ -73,7 +73,8 @@ class HeatTransferProblem(festim.Temperature):
             self._newton_solver = value
         elif isinstance(value, f.NewtonSolver):
             if self._newton_solver:
-                print("Settings for the Newton solver will be overwritten")
+                if f.MPI.comm_world.rank == 0:
+                    print("Settings for the Newton solver will be overwritten")
             self._newton_solver = value
         else:
             raise TypeError("accepted type for newton_solver is fenics.NewtonSolver")
@@ -131,7 +132,9 @@ class HeatTransferProblem(festim.Temperature):
             self.define_newton_solver()
 
         if not self.transient:
-            print("Solving stationary heat equation")
+            if f.MPI.comm_world.rank == 0:
+                print("Solving stationary heat equation")
+
             dT = f.TrialFunction(self.T.function_space())
             JT = f.derivative(self.F, self.T, dT)
             problem = festim.Problem(JT, self.F, self.dirichlet_bcs)
@@ -153,8 +156,9 @@ class HeatTransferProblem(festim.Temperature):
             dt (festim.Stepsize, optional): the stepsize. Only needed if
                 self.transient is True. Defaults to None.
         """
+        if f.MPI.comm_world.rank == 0:
+            print("Defining variational problem heat transfers")
 
-        print("Defining variational problem heat transfers")
         T, T_n = self.T, self.T_n
         v_T = self.v_T
 

--- a/festim/temperature/temperature_solver.py
+++ b/festim/temperature/temperature_solver.py
@@ -73,8 +73,9 @@ class HeatTransferProblem(festim.Temperature):
             self._newton_solver = value
         elif isinstance(value, f.NewtonSolver):
             if self._newton_solver:
-                if f.MPI.comm_world.rank == 0:
-                    print("Settings for the Newton solver will be overwritten")
+                festim.festim_print(
+                    "Settings for the Newton solver will be overwritten"
+                )
             self._newton_solver = value
         else:
             raise TypeError("accepted type for newton_solver is fenics.NewtonSolver")
@@ -132,8 +133,7 @@ class HeatTransferProblem(festim.Temperature):
             self.define_newton_solver()
 
         if not self.transient:
-            if f.MPI.comm_world.rank == 0:
-                print("Solving stationary heat equation")
+            festim.festim_print("Solving stationary heat equation")
 
             dT = f.TrialFunction(self.T.function_space())
             JT = f.derivative(self.F, self.T, dT)
@@ -156,8 +156,7 @@ class HeatTransferProblem(festim.Temperature):
             dt (festim.Stepsize, optional): the stepsize. Only needed if
                 self.transient is True. Defaults to None.
         """
-        if f.MPI.comm_world.rank == 0:
-            print("Defining variational problem heat transfers")
+        festim.festim_print("Defining variational problem heat transfers")
 
         T, T_n = self.T, self.T_n
         v_T = self.v_T


### PR DESCRIPTION
## Proposed changes

Due to the way printing in python has been used within festim means that print messages are shown on every node, which in practice means printing the message repeatedly by the number of processors defined. For instance running the following script:

```python
import festim as F
import numpy as np

my_model = F.Simulation(
    mesh=F.MeshFromVertices(vertices=np.linspace(0, 1, num=1000)),
    materials=F.Material(id=1, D_0=1, E_D=0),
    temperature=300,
    settings=F.Settings(
        absolute_tolerance=1e-10,
        relative_tolerance=1e-10,
        transient=False,
    ),
)
my_model.initialise()
my_model.run()
``` 
running this in parallel using `mpirun -np 4 python mwe.py` with 4 processors would produce the following:

```
Defining initial values
Defining variational problem
Defining initial values
Defining variational problem
Defining initial values
Defining variational problem
Defining initial values
Defining variational problem
Defining source terms
Defining source terms
Defining source terms
Defining source terms
Defining boundary conditions
Solving steady state problem...
Defining boundary conditions
Solving steady state problem...
Defining boundary conditions
Solving steady state problem...
Defining boundary conditions
Solving steady state problem...
Solved problem in 0.00 s
Solved problem in 0.00 s
Solved problem in 0.00 s
Solved problem in 0.00 s
```

With these changes, the printing message is only done on the master process (or rank 0 process). Meaning printed messages will only appear once, no matter the number of processors used.

resulting in:
```
Defining initial values
Defining variational problem
Defining source terms
Defining boundary conditions
Solving steady state problem...
Solved problem in 0.00 s
```

making printed messaged much cleaner and easier for users to understand.

@KulaginVladimir don't suppose you know of anyway we could test this? I imagine it may have to be at the github actions level in order to run the test scripts in parallel. Which itself could open up a new can of worms as we should really be testing in parallel too.


## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
