### PR TITLE
`SurfaceKinetics` minor update

### DIFF
--- a/docs/source/theory.rst
+++ b/docs/source/theory.rst
@@ -339,15 +339,14 @@ The fluxes for subsurface-to-surface and surface-to-subsurface transitions are d
 .. math::
     :label: eq_Jbs
 
-    J_\mathrm{bs} = k_\mathrm{bs} \lambda_\mathrm{abs} c_\mathrm{m} \left(1-\dfrac{c_\mathrm{s}}{n_\mathrm{surf}}\right)
+    J_\mathrm{bs} = k_\mathrm{bs} c_\mathrm{m} \left(1-\dfrac{c_\mathrm{s}}{n_\mathrm{surf}}\right)
 
 .. math::
     :label: eq_Jsb
 
     J_\mathrm{sb} = k_\mathrm{sb} c_\mathrm{s} \left(1-\dfrac{c_\mathrm{m}}{n_\mathrm{IS}}\right)
 
-where :math:`n_\mathrm{surf}\,[\mathrm{m}^{-2}]` is the surface concentration of adsorption sites, :math:`n_\mathrm{IS}\,[\mathrm{m}^{-3}]` is the bulk concentration of interstitial sites,
-:math:`\lambda_\mathrm{abs}=n_\mathrm{surf}/n_\mathrm{IS}\,[\mathrm{m}]` is the characteristic distance between surface and subsurface sites, :math:`k_\mathrm{bs}\,[\mathrm{s}^{-1}]` 
+where :math:`n_\mathrm{surf}\,[\mathrm{m}^{-2}]` is the surface concentration of adsorption sites, :math:`n_\mathrm{IS}\,[\mathrm{m}^{-3}]` is the bulk concentration of interstitial sites, :math:`k_\mathrm{bs}\,[\mathrm{m}\,\mathrm{s}^{-1}]` 
 and :math:`k_\mathrm{sb}\,[\mathrm{s}^{-1}]` are the rate constants for subsurface-to-surface and surface-to-subsurface transitions, respectively. 
 Usually, these rate constants are expressed in the Arrhenius form: :math:`k_i=k_{i,0}\exp(-E_{k,i} / kT)`. Both these processes are assumed to take place
 if there are available sites on the surface (in the subsurface). Possible surface/subsurface saturation is accounted for with terms in brackets.

--- a/docs/source/userguide/boundary_conditions.rst
+++ b/docs/source/userguide/boundary_conditions.rst
@@ -116,13 +116,13 @@ The current class is supported for 1D simulations only. Refer to the :ref:`Kinet
     from festim import t
     import fenics as f
 
-    def k_bs(T, surf_conc, t):
+    def k_bs(T, surf_conc, mobile_conc, t):
         return 1e13*f.exp(-0.2/k_b/T)
 
-    def k_sb(T, surf_conc, t):
+    def k_sb(T, surf_conc, mobile_conc, t):
         return 1e13*f.exp(-1.0/k_b/T)
 
-    def J_vs(T, surf_conc, t):
+    def J_vs(T, surf_conc, mobile_conc, t):
 
         J_des = 2e5*surf_conc**2*f.exp(-1.2/k_b/T)
         J_ads = 1e17*(1-surf_conc/1e17)**2*f.conditional(t<10, 1, 0)

--- a/test/system/test_system.py
+++ b/test/system/test_system.py
@@ -1226,23 +1226,25 @@ def test_MMS_surface_kinetics():
     """
     MMS test for SurfaceKinetics BC
     """
-    exact_solution_cm = lambda x, t: 1 + 2 * x**2 + x + 2 * t
-    exact_solution_cs = (
-        lambda t: n_surf * (1 + 2 * t + 2 * lambda_IS - D) / (2 * n_IS - 1 - 2 * t)
-    )
 
     n_IS = 20
     n_surf = 5
     D = 7
     lambda_IS = 2
-    k_bs = n_IS / n_surf
+    k_bs = 3
     k_sb = 2 * n_IS / n_surf
 
+    exact_solution_cm = lambda x, t: 1 + 2 * x**2 + x + 2 * t
+    exact_solution_cs = (
+        lambda t: n_surf
+        * (3 * (1 + 2 * t) + 2 * lambda_IS - D)
+        / (2 * n_IS + 1 + 2 * t)
+    )
     solute_source = 2 * (1 - 2 * D)
 
-    def J_vs(T, surf_conc, t):
+    def J_vs(T, surf_conc, solute, t):
         return (
-            2 * n_surf * (2 * n_IS + 2 * lambda_IS - D) / (2 * n_IS - 1 - 2 * t) ** 2
+            2 * n_surf * (6 * n_IS - 2 * lambda_IS + D) / (2 * n_IS + 1 + 2 * t) ** 2
             + 2 * lambda_IS
             - D
         )

--- a/test/unit/test_boundary_conditions.py
+++ b/test/unit/test_boundary_conditions.py
@@ -620,14 +620,14 @@ def test_create_form_surf_kinetics():
     """
 
     # build
-    def k_sb(cs, T, prm1, prm2):
-        return 2 * T + cs**2 + prm1 - prm2
+    def k_sb(T, cs, cm, prm1, prm2):
+        return 2 * T + cs**2 / cm + prm1 - prm2
 
-    def k_bs(cs, T, prm1, prm2):
-        return 2 * T + 3 * cs + prm1 + prm2
+    def k_bs(T, cs, cm, prm1, prm2):
+        return 2 * T + 3 * cs + cm + prm1 + prm2
 
-    def J_vs(cs, T, prm1, prm2):
-        return 2 * T + 1
+    def J_vs(T, cs, cm, prm1, prm2):
+        return 2 * T + 5 * cm - 3 * cs
 
     lambda_IS = 1
     n_surf = 1
@@ -678,11 +678,11 @@ def test_create_form_surf_kinetics():
     # test
     p1 = my_bc.sub_expressions[0]
     p2 = my_bc.sub_expressions[1]
-    K_sb = k_sb(T.T, adsorbed, p1, p2)
-    K_bs = k_bs(T.T, adsorbed, p1, p2)
-    j_vs = J_vs(T.T, adsorbed, p1, p2)
+    K_sb = k_sb(T.T, adsorbed, solute, p1, p2)
+    K_bs = k_bs(T.T, adsorbed, solute, p1, p2)
+    j_vs = J_vs(T.T, adsorbed, solute, p1, p2)
     J_sb = K_sb * adsorbed * (1 - solute / n_IS)
-    J_bs = K_bs * (solute * n_surf / n_IS) * (1 - adsorbed / n_surf)
+    J_bs = K_bs * solute * (1 - adsorbed / n_surf)
 
     expected_form = (
         (adsorbed - adsorbed_prev) / dt.value * adsorbed_test_function * ds(1)


### PR DESCRIPTION
## Proposed changes

This PR fixes #925 in order to remove the hard-coded parameter $\lambda_{abs}$. With this change, the definition of $k_{bs}$ in theory (as a rate constant) will be correct. 

Additionally, `J_vs`, `k_bs`, and `k_sb` now accept `mobile` cocnentration by default allowing to account for fluxes that might depend on the concentration of subsurface H atoms (see [Baskes 1980](https://www.sciencedirect.com/science/article/abs/pii/0022311580901178), [Richards 1988](https://www.sciencedirect.com/science/article/abs/pii/0022311588903339), [Pisarev 1997](https://www.sciencedirect.com/science/article/abs/pii/S0022311597002018#preview-section-references)). 

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [x] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
