### PR TITLE
allow Value for SourceBase

### DIFF
--- a/src/festim/source.py
+++ b/src/festim/source.py
@@ -33,13 +33,16 @@ class SourceBase:
 
     def __init__(
         self,
-        value: float
-        | int
-        | fem.Constant
-        | np.ndarray
-        | fem.Expression
-        | ufl.core.expr.Expr
-        | fem.Function,
+        value: (
+            float
+            | int
+            | fem.Constant
+            | np.ndarray
+            | fem.Expression
+            | ufl.core.expr.Expr
+            | fem.Function
+            | Value
+        ),
         volume: VolumeSubdomain,
     ):
         self.value = value
@@ -51,7 +54,10 @@ class SourceBase:
 
     @value.setter
     def value(self, value):
-        self._value = Value(value)
+        if isinstance(value, Value):
+            self._value = value
+        else:
+            self._value = Value(value)
 
     @property
     def volume(self):


### PR DESCRIPTION
## Proposed changes

We noticed with @jhdark that `ParticleSource` didn't accept `Value` as `value` argument. We had to make a custom class [here](https://github.com/LIBRA-project/LIBRA-one/blob/f629cdae250da354ff96c601a354eaee95276765/festim_model.py#L96-L106)

This PR simply accepts Value objects.

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

