### PR TITLE
Allow functions to given as diffusion coefficient

### DIFF
--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -502,7 +502,11 @@ class HydrogenTransportProblem(problem.ProblemBase):
 
         # if diffusion coeffient has been given as a function, use that
         if self.volume_subdomains[0].material.D:
-            assert len(self.volume_subdomains) == 1
+            if len(self.volume_subdomains) > 1:
+                raise ValueError(
+                    "Giving the diffusion coefficient as a function is currently "
+                    "only supported for a single volume subdomain case"
+                )
             return self.volume_subdomains[0].material.D, None
 
         D_0 = fem.Function(self.V_DG_0)

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -497,6 +497,13 @@ class HydrogenTransportProblem(problem.ProblemBase):
                 for a given species
         """
         assert isinstance(species, _species.Species)
+        # create global D function
+        D = fem.Function(self.V_DG_1)
+
+        # if diffusion coeffient has been given as a function, use that
+        if self.volume_subdomains[0].material.D:
+            assert len(self.volume_subdomains) == 1
+            return self.volume_subdomains[0].material.D, None
 
         D_0 = fem.Function(self.V_DG_0)
         E_D = fem.Function(self.V_DG_0)
@@ -506,9 +513,6 @@ class HydrogenTransportProblem(problem.ProblemBase):
             # replace values of D_0 and E_D by values from the material
             D_0.x.array[cell_indices] = vol.material.get_D_0(species=species)
             E_D.x.array[cell_indices] = vol.material.get_E_D(species=species)
-
-        # create global D function
-        D = fem.Function(self.V_DG_1)
 
         expr = D_0 * ufl.exp(
             -E_D / as_fenics_constant(k_B, self.mesh.mesh) / self.temperature_fenics

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -503,7 +503,7 @@ class HydrogenTransportProblem(problem.ProblemBase):
         # if diffusion coeffient has been given as a function, use that
         if self.volume_subdomains[0].material.D:
             if len(self.volume_subdomains) > 1:
-                raise ValueError(
+                raise NotImplementedError(
                     "Giving the diffusion coefficient as a function is currently "
                     "only supported for a single volume subdomain case"
                 )

--- a/src/festim/material.py
+++ b/src/festim/material.py
@@ -86,6 +86,11 @@ class Material:
         self.solubility_law = solubility_law
         self.D = D
 
+        if self.D_0 and self.D:
+            raise ValueError(
+                "D_0 and D cannot be set at the same time. Please set only one of them."
+            )
+
     @property
     def D(self):
         return self._D

--- a/src/festim/material.py
+++ b/src/festim/material.py
@@ -213,7 +213,7 @@ class Material:
         else:
             raise TypeError("E_K_S must be either a float, int or a dict")
 
-    def get_diffusion_coefficient(self, mesh, temperature, species=None):
+    def get_diffusion_coefficient(self, mesh=None, temperature=None, species=None):
         """Defines the diffusion coefficient
 
         Args:

--- a/src/festim/material.py
+++ b/src/festim/material.py
@@ -25,6 +25,7 @@ class Material:
         density: the density of the material (kg/m3)
         heat_capacity: the heat capacity of the material (J/kg/K)
         solubility_law: the solubility law of the material ("sievert" or "henry")
+        D: the diffusion coefficient of the material (m2/s)
 
     Attributes:
         D_0: the pre-exponential factor of the
@@ -39,6 +40,8 @@ class Material:
         thermal_conductivity: the thermal conductivity of the material (W/m/K)
         density: the density of the material (kg/m3)
         heat_capacity: the heat capacity of the material (J/kg/K)
+        solubility_law: the solubility law of the material ("sievert" or "henry")
+        D: the diffusion coefficient of the material (m2/s)
 
     Examples:
         .. testsetup:: Material
@@ -69,6 +72,7 @@ class Material:
         heat_capacity: Optional[float] = None,
         name: Optional[str] = None,
         solubility_law: Optional[str] = None,
+        D: Optional[fem.Function] = None,
     ) -> None:
         self.D_0 = D_0
         self.E_D = E_D
@@ -80,6 +84,7 @@ class Material:
         self.heat_capacity = heat_capacity
         self.name = name
         self.solubility_law = solubility_law
+        self.D = D
 
     def get_D_0(self, species=None):
         """Returns the pre-exponential factor of the diffusion coefficient
@@ -215,6 +220,10 @@ class Material:
         # E_D = as_fenics_constant(E_D, mesh)
 
         # return D_0 * ufl.exp(-E_D / k_B / temperature)
+
+        if self.D:
+            assert isinstance(self.D, fem.Function)
+            return self.D
 
         if isinstance(self.D_0, float | int) and isinstance(self.E_D, float | int):
             D_0 = as_fenics_constant(self.D_0, mesh)

--- a/src/festim/material.py
+++ b/src/festim/material.py
@@ -1,4 +1,7 @@
 import ufl
+from dolfinx import fem
+
+from typing import Optional
 
 import festim as F
 
@@ -8,33 +11,33 @@ class Material:
     Material class
 
     Args:
-        D_0 (float or dict): the pre-exponential factor of the
+        D_0: the pre-exponential factor of the
             diffusion coefficient (m2/s)
-        E_D (float or dict): the activation energy of the diffusion
+        E_D: the activation energy of the diffusion
             coeficient (eV)
-        K_S_0 (float or dict): the pre-exponential factor of the
+        K_S_0: the pre-exponential factor of the
             solubility coefficient (H/m3/Pa0.5)
-        E_K_S (float or dict): the activation energy of the solubility
+        E_K_S: the activation energy of the solubility
             coeficient (eV)
-        name (str): the name of the material
-        thermal_conductivity (float, callable): the thermal conductivity of the material (W/m/K)
-        density (float, callable): the density of the material (kg/m3)
-        heat_capacity (float, callable): the heat capacity of the material (J/kg/K)
-        solubility_law (str): the solubility law of the material ("sievert" or "henry")
+        name: the name of the material
+        thermal_conductivity: the thermal conductivity of the material (W/m/K)
+        density: the density of the material (kg/m3)
+        heat_capacity: the heat capacity of the material (J/kg/K)
+        solubility_law: the solubility law of the material ("sievert" or "henry")
 
     Attributes:
-        D_0 (float or dict): the pre-exponential factor of the
+        D_0: the pre-exponential factor of the
             diffusion coefficient (m2/s)
-        E_D (float or dict): the activation energy of the diffusion
+        E_D: the activation energy of the diffusion
             coeficient (eV)
-        K_S_0 (float or dict): the pre-exponential factor of the
+        K_S_0: the pre-exponential factor of the
             solubility coefficient (H/m3/Pa0.5)
-        E_K_S (float or dict): the activation energy of the solubility
+        E_K_S: the activation energy of the solubility
             coeficient (eV)
-        name (str): the name of the material
-        thermal_conductivity (float, callable): the thermal conductivity of the material (W/m/K)
-        density (float, callable): the density of the material (kg/m3)
-        heat_capacity (float, callable): the heat capacity of the material (J/kg/K)
+        name: the name of the material
+        thermal_conductivity: the thermal conductivity of the material (W/m/K)
+        density: the density of the material (kg/m3)
+        heat_capacity: the heat capacity of the material (J/kg/K)
 
     Examples:
         .. testsetup:: Material
@@ -56,15 +59,15 @@ class Material:
 
     def __init__(
         self,
-        D_0,
-        E_D,
-        K_S_0=None,
-        E_K_S=None,
-        thermal_conductivity=None,
-        density=None,
-        heat_capacity=None,
-        name=None,
-        solubility_law=None,
+        D_0: Optional[float | int | fem.Function | dict[float, int]] = None,
+        E_D: Optional[float | int | fem.Function | dict[float, int]] = None,
+        K_S_0: Optional[float | int | dict[float, int]] = None,
+        E_K_S: Optional[float | int | dict[float, int]] = None,
+        thermal_conductivity: Optional[float] = None,
+        density: Optional[float] = None,
+        heat_capacity: Optional[float] = None,
+        name: Optional[str] = None,
+        solubility_law: Optional[str] = None,
     ) -> None:
         self.D_0 = D_0
         self.E_D = E_D
@@ -81,14 +84,15 @@ class Material:
         """Returns the pre-exponential factor of the diffusion coefficient
 
         Args:
-            species (festim.Species or str, optional): the species we want the pre-exponential
-                factor of the diffusion coefficient of. Only needed if D_0 is a dict.
+            species (festim.Species or str, optional): the species we want the
+                pre-exponential factor of the diffusion coefficient of. Only needed if
+                D_0 is a dict.
 
         Returns:
             float: the pre-exponential factor of the diffusion coefficient
         """
 
-        if isinstance(self.D_0, (float, int)):
+        if isinstance(self.D_0, float | int | fem.Function):
             return self.D_0
 
         elif isinstance(self.D_0, dict):

--- a/src/festim/material.py
+++ b/src/festim/material.py
@@ -111,7 +111,7 @@ class Material:
             float: the pre-exponential factor of the diffusion coefficient
         """
 
-        if isinstance(self.D_0, float | int | fem.Function):
+        if isinstance(self.D_0, float | int):
             return self.D_0
 
         elif isinstance(self.D_0, dict):

--- a/src/festim/material.py
+++ b/src/festim/material.py
@@ -1,9 +1,10 @@
+from typing import Optional
+
 import ufl
 from dolfinx import fem
 
-from typing import Optional
-
-import festim as F
+from festim import k_B
+from festim.helpers import as_fenics_constant
 
 
 class Material:
@@ -120,7 +121,7 @@ class Material:
             float: the activation energy of the diffusion coefficient
         """
 
-        if isinstance(self.E_D, (float, int)):
+        if isinstance(self.E_D, float | int):
             return self.E_D
 
         elif isinstance(self.E_D, dict):
@@ -148,7 +149,7 @@ class Material:
             the pre-exponential factor of the solubility coefficient
         """
 
-        if isinstance(self.K_S_0, (float, int)):
+        if isinstance(self.K_S_0, float | int):
             return self.K_S_0
 
         elif isinstance(self.K_S_0, dict):
@@ -176,7 +177,7 @@ class Material:
             the activation energy of the solubility coefficient
         """
 
-        if isinstance(self.E_K_S, (float, int)):
+        if isinstance(self.E_K_S, float | int):
             return self.E_K_S
 
         elif isinstance(self.E_K_S, dict):
@@ -210,16 +211,16 @@ class Material:
         # D_0 = self.get_D_0(species=species)
         # E_D = self.get_E_D(species=species)
 
-        # D_0 = F.as_fenics_constant(D_0, mesh)
-        # E_D = F.as_fenics_constant(E_D, mesh)
+        # D_0 = as_fenics_constant(D_0, mesh)
+        # E_D = as_fenics_constant(E_D, mesh)
 
-        # return D_0 * ufl.exp(-E_D / F.k_B / temperature)
+        # return D_0 * ufl.exp(-E_D / k_B / temperature)
 
-        if isinstance(self.D_0, (float, int)) and isinstance(self.E_D, (float, int)):
-            D_0 = F.as_fenics_constant(self.D_0, mesh)
-            E_D = F.as_fenics_constant(self.E_D, mesh)
+        if isinstance(self.D_0, float | int) and isinstance(self.E_D, float | int):
+            D_0 = as_fenics_constant(self.D_0, mesh)
+            E_D = as_fenics_constant(self.E_D, mesh)
 
-            return D_0 * ufl.exp(-E_D / F.k_B / temperature)
+            return D_0 * ufl.exp(-E_D / k_B / temperature)
 
         elif isinstance(self.D_0, dict) and isinstance(self.E_D, dict):
             # check D_0 and E_D have the same keys
@@ -231,18 +232,18 @@ class Material:
                 raise ValueError("species must be provided if D_0 and E_D are dicts")
 
             if species in self.D_0:
-                D_0 = F.as_fenics_constant(self.D_0[species], mesh)
+                D_0 = as_fenics_constant(self.D_0[species], mesh)
             elif species.name in self.D_0:
-                D_0 = F.as_fenics_constant(self.D_0[species.name], mesh)
+                D_0 = as_fenics_constant(self.D_0[species.name], mesh)
             else:
                 raise ValueError(f"{species} is not in D_0 keys")
 
             if species in self.E_D:
-                E_D = F.as_fenics_constant(self.E_D[species], mesh)
+                E_D = as_fenics_constant(self.E_D[species], mesh)
             elif species.name in self.E_D:
-                E_D = F.as_fenics_constant(self.E_D[species.name], mesh)
+                E_D = as_fenics_constant(self.E_D[species.name], mesh)
 
-            return D_0 * ufl.exp(-E_D / F.k_B / temperature)
+            return D_0 * ufl.exp(-E_D / k_B / temperature)
 
         else:
             raise ValueError("D_0 and E_D must be either floats or dicts")
@@ -264,18 +265,16 @@ class Material:
         # K_S_0 = self.get_K_S_0(species=species)
         # E_K_S = self.get_E_K_S(species=species)
 
-        # K_S_0 = F.as_fenics_constant(K_S_0, mesh)
-        # E_K_S = F.as_fenics_constant(E_K_S, mesh)
+        # K_S_0 = as_fenics_constant(K_S_0, mesh)
+        # E_K_S = as_fenics_constant(E_K_S, mesh)
 
-        # return K_S_0 * ufl.exp(-E_K_S / F.k_B / temperature)
+        # return K_S_0 * ufl.exp(-E_K_S / k_B / temperature)
 
-        if isinstance(self.K_S_0, (float, int)) and isinstance(
-            self.E_K_S, (float, int)
-        ):
-            K_S_0 = F.as_fenics_constant(self.K_S_0, mesh)
-            E_K_S = F.as_fenics_constant(self.E_K_S, mesh)
+        if isinstance(self.K_S_0, float | int) and isinstance(self.E_K_S, float | int):
+            K_S_0 = as_fenics_constant(self.K_S_0, mesh)
+            E_K_S = as_fenics_constant(self.E_K_S, mesh)
 
-            return K_S_0 * ufl.exp(-E_K_S / F.k_B / temperature)
+            return K_S_0 * ufl.exp(-E_K_S / k_B / temperature)
 
         elif isinstance(self.K_S_0, dict) and isinstance(self.E_K_S, dict):
             # check D_0 and E_D have the same keys
@@ -289,18 +288,18 @@ class Material:
                 )
 
             if species in self.K_S_0:
-                K_S_0 = F.as_fenics_constant(self.K_S_0[species], mesh)
+                K_S_0 = as_fenics_constant(self.K_S_0[species], mesh)
             elif species.name in self.K_S_0:
-                K_S_0 = F.as_fenics_constant(self.K_S_0[species.name], mesh)
+                K_S_0 = as_fenics_constant(self.K_S_0[species.name], mesh)
             else:
                 raise ValueError(f"{species} is not in K_S_0 keys")
 
             if species in self.E_K_S:
-                E_K_S = F.as_fenics_constant(self.E_K_S[species], mesh)
+                E_K_S = as_fenics_constant(self.E_K_S[species], mesh)
             elif species.name in self.E_K_S:
-                E_K_S = F.as_fenics_constant(self.E_K_S[species.name], mesh)
+                E_K_S = as_fenics_constant(self.E_K_S[species.name], mesh)
 
-            return K_S_0 * ufl.exp(-E_K_S / F.k_B / temperature)
+            return K_S_0 * ufl.exp(-E_K_S / k_B / temperature)
 
         else:
             raise ValueError("K_S_0 and E_K_S must be either floats or dicts")

--- a/src/festim/material.py
+++ b/src/festim/material.py
@@ -86,6 +86,19 @@ class Material:
         self.solubility_law = solubility_law
         self.D = D
 
+    @property
+    def D(self):
+        return self._D
+
+    @D.setter
+    def D(self, value):
+        if value is None:
+            self._D = None
+        elif isinstance(value, fem.Function):
+            self._D = value
+        else:
+            raise TypeError("D must be of type fem.Function")
+
     def get_D_0(self, species=None):
         """Returns the pre-exponential factor of the diffusion coefficient
 

--- a/src/festim/material.py
+++ b/src/festim/material.py
@@ -119,8 +119,9 @@ class Material:
         """Returns the activation energy of the diffusion coefficient
 
         Args:
-            species (festim.Species or str, optional): the species we want the activation
-                energy of the diffusion coefficient of. Only needed if E_D is a dict.
+            species (festim.Species or str, optional): the species we want the
+                activation energy of the diffusion coefficient of. Only needed if E_D is
+                a dict.
 
         Returns:
             float: the activation energy of the diffusion coefficient

--- a/test/test_material.py
+++ b/test/test_material.py
@@ -229,3 +229,16 @@ def test_get_diffusion_coefficient_returns_function_when_given_to_D():
     D_out = my_mat.get_diffusion_coefficient()
 
     assert isinstance(D_out, fem.Function)
+
+
+def test_error_raised_when_D_and_D_0_given():
+    """Test that a value error is raised when both D and D_0 are given"""
+
+    V = fem.functionspace(test_mesh.mesh, ("Lagrange", 1))
+    D_func = fem.Function(V)
+
+    with pytest.raises(
+        ValueError,
+        match="D_0 and D cannot be set at the same time. Please set only one of them.",
+    ):
+        F.Material(D=D_func, D_0=1)

--- a/test/test_material.py
+++ b/test/test_material.py
@@ -228,7 +228,7 @@ def test_get_diffusion_coefficient_returns_function_when_given_to_D():
     my_mat = F.Material(D=D)
     D_out = my_mat.get_diffusion_coefficient()
 
-    assert isinstance(D_out, fem.Function)
+    assert D_out == D
 
 
 def test_error_raised_when_D_and_D_0_given():

--- a/test/test_material.py
+++ b/test/test_material.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from dolfinx import fem
 
 import festim as F
 
@@ -198,3 +199,33 @@ def test_raises_TypeError_when_E_D_is_not_correct_type():
 
     with pytest.raises(TypeError, match="E_D must be either a float, int or a dict"):
         my_mat.get_E_D()
+
+
+@pytest.mark.parametrize(
+    "input_value",
+    [
+        1.0,
+        1,
+        "coucou",
+        lambda T: 1.0 + T,
+    ],
+)
+def test_raises_TypeError_when_D_is_not_correct_type(input_value):
+    """Test that a TypeError is raised when D is not an fem.Function"""
+
+    with pytest.raises(TypeError, match="D must be of type fem.Function"):
+        F.Material(D=input_value)
+
+
+def test_get_diffusion_coefficient_returns_function_when_given_to_D():
+    """Test that the diffusion coefficient is correctly defined when D is a
+    function"""
+
+    V = fem.functionspace(test_mesh.mesh, ("Lagrange", 1))
+    D = fem.Function(V)
+    D.x.array[:] = 2.0
+
+    my_mat = F.Material(D=D)
+    D_out = my_mat.get_diffusion_coefficient()
+
+    assert isinstance(D_out, fem.Function)


### PR DESCRIPTION
## Proposed changes

Fix for #988 and #742 

With this change the `D_0` and `E_D` arguments for the `festim.Material` class will be optional introducing a new parameter `D` where users can pass an `fem.Function` object instead of defining the individual components of fickian diffusion coefficient. This can allow for more complex diffusion regimes to be used as long as it is evaluated beforehand. 

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
