### PR TITLE
Export at specific times

### DIFF
--- a/src/festim/__init__.py
+++ b/src/festim/__init__.py
@@ -34,7 +34,7 @@ from .exports.surface_quantity import SurfaceQuantity
 from .exports.total_surface import TotalSurface
 from .exports.total_volume import TotalVolume
 from .exports.volume_quantity import VolumeQuantity
-from .exports.vtx import VTXSpeciesExport, VTXTemperatureExport
+from .exports.vtx import VTXSpeciesExport, VTXTemperatureExport, ExportBaseClass
 from .exports.xdmf import XDMFExport
 from .heat_transfer_problem import HeatTransferProblem
 from .helpers import (


### PR DESCRIPTION
## Proposed changes

fix for #985 @JonathanGSDUFOUR 

With this change, users can define specific times to export a VTX export option. The times given are added to milestones if not in there already to ensure the simulation hits the provided times.

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [ ] Black formatted
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
