### PR TITLE
Fix transient csv writing for VolumeQuantity

### DIFF
--- a/src/festim/exports/volume_quantity.py
+++ b/src/festim/exports/volume_quantity.py
@@ -59,14 +59,13 @@ class VolumeQuantity:
         """If the filename doesnt exist yet, create it and write the header,
         then append the time and value to the file"""
 
-        if not os.path.isfile(self.filename):
-            if self.filename is not None:
-                if self._first_time_export:
-                    header = ["t(s)", f"{self.title}"]
-                    with open(self.filename, mode="w+", newline="") as file:
-                        writer = csv.writer(file)
-                        writer.writerow(header)
-                    self._first_time_export = False
-                with open(self.filename, mode="a", newline="") as file:
+        if self.filename is not None:
+            if self._first_time_export:
+                header = ["t(s)", f"{self.title}"]
+                with open(self.filename, mode="w+", newline="") as file:
                     writer = csv.writer(file)
-                    writer.writerow([t, self.value])
+                    writer.writerow(header)
+                self._first_time_export = False
+            with open(self.filename, mode="a", newline="") as file:
+                writer = csv.writer(file)
+                writer.writerow([t, self.value])


### PR DESCRIPTION
## Proposed changes

Noticed this line was causing the transient simulation to only export at the first timestep. This line is not in the `write` method of the SurfaceQuantity

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [ ] Black formatted
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
