### PR TITLE
`PointValue` in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       shell: bash -l {0}
       run: |
-        pip install pytest pytest-cov
+        pip install pytest pytest-cov ipyparallel
 
     - name: Run tests
       shell: bash -l {0}

--- a/festim/exports/derived_quantities/point_value.py
+++ b/festim/exports/derived_quantities/point_value.py
@@ -17,7 +17,7 @@ class PointValue(DerivedQuantity):
         title (str): the title of the derived quantity
         show_units (bool): show the units in the title in the derived quantities
             file
-        self.functiontion (dolfin.self.functiontion.self.functiontion.self.functiontion): the solution self.functiontion of
+        function (dolfin.function.function.Function): the solution function of
             the field
 
     .. note::

--- a/test/unit/test_exports/test_derived_quantities/test_point_value.py
+++ b/test/unit/test_exports/test_derived_quantities/test_point_value.py
@@ -35,10 +35,9 @@ def test_point_value_compute(mesh, x):
     assert produced == expected
 
 
-@pytest.fixture(scope="module", params=[1, 2])
-def cluster(request):
-    n_engines = request.param
-    cluster = ipp.Cluster(engines="mpi", n=n_engines, log_level=logging.ERROR)
+@pytest.fixture(scope="module")
+def cluster():
+    cluster = ipp.Cluster(engines="mpi", n=2, log_level=logging.ERROR)
     rc = cluster.start_and_connect_sync()
     yield rc
     cluster.stop_cluster_sync()

--- a/test/unit/test_exports/test_derived_quantities/test_point_value.py
+++ b/test/unit/test_exports/test_derived_quantities/test_point_value.py
@@ -1,6 +1,8 @@
 from festim import PointValue
 import fenics as f
 import pytest
+import logging
+import ipyparallel as ipp
 
 
 @pytest.mark.parametrize("field", ["solute", "T"])
@@ -20,7 +22,7 @@ def test_title(field):
 @pytest.mark.parametrize(
     "mesh,x", [(f.UnitIntervalMesh(10), 1), (f.UnitCubeMesh(10, 10, 10), (1, 0, 1))]
 )
-def test_point_compute(mesh, x):
+def test_point_value_compute(mesh, x):
     """Test that the point value export computes the correct value"""
     V = f.FunctionSpace(mesh, "P", 1)
     c = f.interpolate(f.Expression("x[0]", degree=1), V)
@@ -31,3 +33,37 @@ def test_point_compute(mesh, x):
     expected = c(x)
     produced = my_value.compute()
     assert produced == expected
+
+
+@pytest.fixture(scope="module", params=[1, 2])
+def cluster(request):
+    n_engines = request.param
+    cluster = ipp.Cluster(engines="mpi", n=n_engines, log_level=logging.ERROR)
+    rc = cluster.start_and_connect_sync()
+    yield rc
+    cluster.stop_cluster_sync()
+
+
+def test_point_value_compute_parallel(cluster):
+    """Testing that RuntimeError due to mesh partitioning is handled"""
+
+    def compute_value():
+        from festim import PointValue
+        import fenics as f
+
+        mesh = f.UnitSquareMesh(10, 10)
+        mesh.bounding_box_tree()
+
+        V = f.FunctionSpace(mesh, "P", 1)
+        c = f.interpolate(f.Expression("x[0] + x[1]", degree=1), V)
+
+        x = (0, 0)
+        my_value = PointValue("solute", x)
+        my_value.function = c
+
+        my_value.compute()
+
+    query = cluster[:].apply_async(compute_value)
+    query.wait()
+
+    assert query.successful(), query.error


### PR DESCRIPTION
## Proposed changes

This PR allows using the `PointValue` export in parallel. 

In the current FESTIM version, running a simulation with `PointValue` and `mpirun` results in `RuntimeError`:
```
*** Error:   Unable to evaluate function at point.
*** Reason:  The point is not inside the domain. Consider calling "Function::set_allow_extrapolation(true)" on this Function to allow extrapolation.
*** Where:   This error was encountered inside Function.cpp.
*** Process: 0
``` 

The fix is based on the [solution](https://fenicsproject.discourse.group/t/problem-with-evaluation-at-a-point-in-parallel/1188/6) provided on the FEniCS discourse. I checked the fix on 2 machines, but yet it might need additional testing. 

The dedicated test is made with `ipyparallel` according to [this FESTIM2 test](https://github.com/festim-dev/FESTIM/blob/0a262f04039fad1160a66947b83ddd89290da223/test/test_mesh.py#L175-L186). Let me know if it should be modified.

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
