### PR TITLE
fix repo branch in docs for suggested edits

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -103,7 +103,7 @@ html_theme_options = {
     "repository_url": "https://github.com/festim-dev/FESTIM",
     "use_repository_button": True,
     "use_edit_page_button": True,
-    "repository_branch": "main",
+    "repository_branch": "fenicsx",
     "path_to_docs": "./docs/source",
     "icon_links": [
         {


### PR DESCRIPTION
## Proposed changes

When users want to suggest edit on the FESTIM2 version of the documentation, it takes them to the `main` branch of the repo. This PR fixes it by replacing it by `fenicsx`

