### PR TITLE
Fix del problem

### DIFF
--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -1882,7 +1882,8 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
     def __del__(self):
         for export in self.exports:
             if isinstance(export, exports.ExportBaseClass):
-                export.writer.close()
+                if hasattr(export, "writer") and export.writer is not None:
+                    export.writer.close()
 
 
 class HydrogenTransportProblemDiscontinuousChangeVar(HydrogenTransportProblem):

--- a/test/system_tests/test_misc.py
+++ b/test/system_tests/test_misc.py
@@ -236,3 +236,12 @@ def test_temp_dependent_bc_mixed_domain_temperature_as_function():
         H.subdomain_to_post_processing_solution[top_domain].x.array[:].max()
     )
     assert np.isclose(computed_value, expected_value)
+
+
+def test_del():
+    """Test that deleting a model with exports works fine (no segfault)"""
+    my_model = F.HydrogenTransportProblemDiscontinuous()
+    H = F.Species("H")
+    my_model.exports = [F.VTXSpeciesExport(filename="h.bp", field=H)]
+
+    my_model.__del__()


### PR DESCRIPTION
## Proposed changes

we recently added a `__del__` method to `HydrogenTransportProblemDiscontinuous` for properly closing the VTX writers when the execution was ended abruptly.

However, sometimes these writers won't even created yet, so we were trying to close something that didn't exist, leading to the error message always being:

```
Traceback (most recent call last):
  File "/home/remidm/FESTIM/src/festim/hydrogen_transport_problem.py", line 1886, in __del__
AttributeError: 'VTXSpeciesExport' object has no attribute 'writer'
```

This PR fixes it by first checking if the export _has_ a writer or not

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


