### PR TITLE
Non convergence error + SNES div tol unlimited

### DIFF
--- a/src/festim/problem.py
+++ b/src/festim/problem.py
@@ -181,6 +181,7 @@ class ProblemBase:
                     "snes_atol": self.settings.atol,
                     "snes_rtol": self.settings.rtol,
                     "snes_max_it": self.settings.max_iterations,
+                    "snes_divergence_tolerance": "PETSC_UNLIMITED",
                     "ksp_type": "preonly",
                     "pc_type": "lu",
                     "pc_factor_mat_solver_type": linear_solver,

--- a/src/festim/problem.py
+++ b/src/festim/problem.py
@@ -251,7 +251,9 @@ class ProblemBase:
         elif Version(dolfinx.__version__) > Version("0.9.0"):
             _ = self.solver.solve()
             converged_reason = self.solver.solver.getConvergedReason()
-            assert converged_reason > 0
+            assert converged_reason > 0, (
+                f"Non-linear solver did not converge. Reason code: {converged_reason}. \n See https://petsc.org/release/manualpages/SNES/SNESConvergedReason/ for more information."
+            )
             nb_its = self.solver.solver.getIterationNumber()
 
         # post processing


### PR DESCRIPTION
## Proposed changes

This PR fixes an issue @hhy2022 found when upgrading the V&V book to FESTIM 2.0-beta.0 by removing the test on the SNES DIV TOL

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [ ] Black formatted
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

