### PR TITLE
Fix: prevent duplicate exports by popping matched time in is_it_time_…

### DIFF
--- a/src/festim/helpers.py
+++ b/src/festim/helpers.py
@@ -324,7 +324,11 @@ def is_it_time_to_export(
 ) -> bool:
     """
     Checks if the exported field should be written to a file or not based on the
-    current time and the times in `export.times`
+    current time and the times in `export.times'
+    
+    After a successful match, the corresponding time is removed from the list to
+    prevent multiple exports for the same target time.
+
 
     Args:
         current_time: the current simulation time
@@ -337,12 +341,14 @@ def is_it_time_to_export(
     """
     if times is None:
         return True
-
-    for time in times:
+    
+    for i, time in enumerate(times):
         if np.isclose(time, current_time, atol=atol, rtol=rtol):
+            times.pop(i)  # consume the time so it is not exported again
             return True
 
     return False
+
 
 
 _residual0 = 0


### PR DESCRIPTION
## Description

### Summary
<!-- Provide a clear and concise description of what this PR does -->
This PR updates `is_it_time_to_export` so that when a timestep matches a desired export time (within the `np.isclose` tolerances), the corresponding entry in `times` is popped. This prevents repeated exports for the same target time.

### Related Issues
<!-- Link any related issues here using #issue_number or "Fixes #issue_number" -->
<!-- Example: Fixes #123, Related to #456 -->

### Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Previously, multiple consecutive timesteps inside the tolerance window could all return `True`, causing repeated exports for a single requested export time, especially at high simulation times where the relative tolerance (`rtol`) allows larger absolute differences. This change ensures a 1‑to‑1 mapping between requested and actual exports, provided the simulation reaches timesteps sufficiently close to the target times.

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Code refactoring (no functional changes, no API changes)
- [ ] 📝 Documentation update
- [ ] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI configuration change

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] All existing tests pass locally (`pytest`)
- [ ] I have added new tests that prove my fix is effective or that my feature works

## Code Quality Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [ ] My code follows the code style of this project (Ruff formatted: `ruff format .`)
- [ ] My code passes linting checks (`ruff check .`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Documentation

<!-- Put an `x` in the boxes that apply -->

- [] I have updated the documentation accordingly (if applicable)
- [x] I have added docstrings to new functions/classes following the project conventions

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here -->
<!-- What will users need to change in their code? -->
<!-- Delete this section if not applicable -->

## Screenshots/Examples

<!-- If applicable, add screenshots or code examples to help explain your changes -->
<!-- This is especially useful for new features or bug fixes with visual components -->

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- Mention if this is a work in progress, needs specific review, or has known limitations -->

Even though duplicates are now removed, very large simulation times can still cause the matched timestep to be several seconds away from the desired export time. Exposing tolerances (e.g. reducing `rtol`) cannot fully solve this issue: tightening `rtol` only delays it and may prevent matching early in the simulation, while relying on a small `atol` may fail when the timestep becomes larger near an export event.

If precise export timings are required, one way to mitigate this limitation is to use a small `atol` and ensure that the desired export times are included in the solver’s milestones so that the simulation visits them closely enough.
