### PR TITLE
Improved default PETSc options behaviour

### DIFF
--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -1679,6 +1679,19 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
             else:
                 petsc_options = self.petsc_options
 
+            if (
+                "snes_atol" in petsc_options
+                or "snes_rtol" in petsc_options
+                or "snes_max_it" in petsc_options
+            ):
+                warnings.warn(
+                    "You have set one of the following PETSc options: snes_atol, "
+                    "snes_rtol or snes_max_it. These options will be overwritten by "
+                    "the values in festim.Settings (atol, rtol and max_iterations) to "
+                    "ensure consistency between different versions of dolfinx. If you "
+                    "want to set these options manually, please set them in "
+                    "festim.Settings and not in the petsc_options dictionary."
+                )
             petsc_options.update(
                 {
                     "snes_atol": self.settings.atol,

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -1675,36 +1675,17 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
             from dolfinx.fem.petsc import NonlinearProblem
 
             if self.petsc_options is None:
-                # taken from https://github.com/FEniCS/dolfinx/blob/5fcb988c5b0f46b8f9183bc844d8f533a2130d6a/python/demo/demo_cahn-hilliard.py#L279C1-L286C28
-                use_superlu = (
-                    PETSc.IntType == np.int64
-                )  # or PETSc.ScalarType == np.complex64
-                sys = PETSc.Sys()  # type: ignore
-                if sys.hasExternalPackage("mumps") and not use_superlu:
-                    linear_solver = "mumps"
-                elif sys.hasExternalPackage("superlu_dist"):
-                    linear_solver = "superlu_dist"
-                else:
-                    linear_solver = "petsc"
+                petsc_options = festim.problem.get_default_petsc_options()
+            else:
+                petsc_options = self.petsc_options
 
-                petsc_options = {
-                    "snes_type": "newtonls",
-                    "snes_linesearch_type": "none",
-                    "snes_stol": np.sqrt(np.finfo(dolfinx.default_real_type).eps)
-                    * 1e-2,
-                    # TODO : make atol and rtol callable
+            petsc_options.update(
+                {
                     "snes_atol": self.settings.atol,
                     "snes_rtol": self.settings.rtol,
                     "snes_max_it": self.settings.max_iterations,
-                    "snes_divergence_tolerance": "PETSC_UNLIMITED",
-                    "ksp_type": "preonly",
-                    "pc_type": "lu",
-                    "pc_factor_mat_solver_type": linear_solver,
-                    "snes_error_if_not_converged": True,
-                    "ksp_error_if_not_converged": True,
                 }
-            else:
-                petsc_options = self.petsc_options
+            )
 
             self.solver = NonlinearProblem(
                 self.forms,

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -1674,32 +1674,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         elif Version(dolfinx.__version__) > Version("0.9.0"):
             from dolfinx.fem.petsc import NonlinearProblem
 
-            petsc_options = festim.problem.get_default_petsc_options()
-
-            # Update default PETSc options with user-provided options, if any
-            if self.petsc_options:
-                petsc_options.update(self.petsc_options)
-
-            if (
-                "snes_atol" in self.petsc_options
-                or "snes_rtol" in self.petsc_options
-                or "snes_max_it" in self.petsc_options
-            ):
-                warnings.warn(
-                    "You have set one of the following PETSc options: snes_atol, "
-                    "snes_rtol or snes_max_it. These options will be overwritten by "
-                    "the values in festim.Settings (atol, rtol and max_iterations) to "
-                    "ensure consistency between different versions of dolfinx. If you "
-                    "want to set these options manually, please set them in "
-                    "festim.Settings and not in the petsc_options dictionary."
-                )
-            petsc_options.update(
-                {
-                    "snes_atol": self.settings.atol,
-                    "snes_rtol": self.settings.rtol,
-                    "snes_max_it": self.settings.max_iterations,
-                }
-            )
+            petsc_options = self.get_petsc_options()
 
             self.solver = NonlinearProblem(
                 self.forms,

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -1674,15 +1674,16 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         elif Version(dolfinx.__version__) > Version("0.9.0"):
             from dolfinx.fem.petsc import NonlinearProblem
 
-            if self.petsc_options is None:
-                petsc_options = festim.problem.get_default_petsc_options()
-            else:
-                petsc_options = self.petsc_options
+            petsc_options = festim.problem.get_default_petsc_options()
+
+            # Update default PETSc options with user-provided options, if any
+            if self.petsc_options:
+                petsc_options.update(self.petsc_options)
 
             if (
-                "snes_atol" in petsc_options
-                or "snes_rtol" in petsc_options
-                or "snes_max_it" in petsc_options
+                "snes_atol" in self.petsc_options
+                or "snes_rtol" in self.petsc_options
+                or "snes_max_it" in self.petsc_options
             ):
                 warnings.warn(
                     "You have set one of the following PETSc options: snes_atol, "

--- a/src/festim/problem.py
+++ b/src/festim/problem.py
@@ -160,14 +160,16 @@ class ProblemBase:
         elif Version(dolfinx.__version__) > Version("0.9.0"):
             from dolfinx.fem.petsc import NonlinearProblem
 
-            if self.petsc_options is None:
-                petsc_options = get_default_petsc_options()
-            else:
-                petsc_options = self.petsc_options
+            petsc_options = get_default_petsc_options()
+
+            # Update default PETSc options with user-provided options, if any
+            if self.petsc_options:
+                petsc_options.update(self.petsc_options)
+
             if (
-                "snes_atol" in petsc_options
-                or "snes_rtol" in petsc_options
-                or "snes_max_it" in petsc_options
+                "snes_atol" in self.petsc_options
+                or "snes_rtol" in self.petsc_options
+                or "snes_max_it" in self.petsc_options
             ):
                 warnings.warn(
                     "You have set one of the following PETSc options: snes_atol, "

--- a/src/festim/problem.py
+++ b/src/festim/problem.py
@@ -10,6 +10,7 @@ import ufl
 from dolfinx import fem
 from dolfinx.nls.petsc import NewtonSolver
 from packaging.version import Version
+import warnings
 
 import festim as F
 from festim.mesh.mesh import Mesh as _Mesh
@@ -163,7 +164,19 @@ class ProblemBase:
                 petsc_options = get_default_petsc_options()
             else:
                 petsc_options = self.petsc_options
-
+            if (
+                "snes_atol" in petsc_options
+                or "snes_rtol" in petsc_options
+                or "snes_max_it" in petsc_options
+            ):
+                warnings.warn(
+                    "You have set one of the following PETSc options: snes_atol, "
+                    "snes_rtol or snes_max_it. These options will be overwritten by "
+                    "the values in festim.Settings (atol, rtol and max_iterations) to "
+                    "ensure consistency between different versions of dolfinx. If you "
+                    "want to set these options manually, please set them in "
+                    "festim.Settings and not in the petsc_options dictionary."
+                )
             petsc_options.update(
                 {
                     "snes_atol": self.settings.atol,

--- a/src/festim/problem.py
+++ b/src/festim/problem.py
@@ -119,6 +119,45 @@ class ProblemBase:
                 form = self.create_dirichletbc_form(bc)
                 self.bc_forms.append(form)
 
+    def get_petsc_options(self) -> dict[str, Any]:
+        """
+        Gets the PETSc options to pass to the NewtonProblem solver. Default
+        options are updated with user-provided options, if any.
+
+        Returns:
+            the petsc options to pass to the NewtonProblem solver.
+        """
+        petsc_options = get_default_petsc_options()
+
+        # Update default PETSc options with user-provided options, if any
+        if self.petsc_options:
+            petsc_options.update(self.petsc_options)
+
+        if self.petsc_options:
+            if (
+                "snes_atol" in self.petsc_options
+                or "snes_rtol" in self.petsc_options
+                or "snes_max_it" in self.petsc_options
+            ):
+                warnings.warn(
+                    "You have set one of the following PETSc options: snes_atol, "
+                    "snes_rtol or snes_max_it. These options will be overwritten by "
+                    "the values in festim.Settings (atol, rtol and max_iterations) to "
+                    "ensure consistency between different versions of dolfinx. If you "
+                    "want to set these options manually, please set them in "
+                    "festim.Settings and not in the petsc_options dictionary."
+                )
+
+        petsc_options.update(
+            {
+                "snes_atol": self.settings.atol,
+                "snes_rtol": self.settings.rtol,
+                "snes_max_it": self.settings.max_iterations,
+            }
+        )
+
+        return petsc_options
+
     def create_solver(self):
         """Creates the solver of the model"""
 
@@ -160,33 +199,7 @@ class ProblemBase:
         elif Version(dolfinx.__version__) > Version("0.9.0"):
             from dolfinx.fem.petsc import NonlinearProblem
 
-            petsc_options = get_default_petsc_options()
-
-            # Update default PETSc options with user-provided options, if any
-            if self.petsc_options:
-                petsc_options.update(self.petsc_options)
-
-            if (
-                "snes_atol" in self.petsc_options
-                or "snes_rtol" in self.petsc_options
-                or "snes_max_it" in self.petsc_options
-            ):
-                warnings.warn(
-                    "You have set one of the following PETSc options: snes_atol, "
-                    "snes_rtol or snes_max_it. These options will be overwritten by "
-                    "the values in festim.Settings (atol, rtol and max_iterations) to "
-                    "ensure consistency between different versions of dolfinx. If you "
-                    "want to set these options manually, please set them in "
-                    "festim.Settings and not in the petsc_options dictionary."
-                )
-            petsc_options.update(
-                {
-                    "snes_atol": self.settings.atol,
-                    "snes_rtol": self.settings.rtol,
-                    "snes_max_it": self.settings.max_iterations,
-                }
-            )
-
+            petsc_options = self.get_petsc_options()
             self.solver = NonlinearProblem(
                 self.formulation,
                 self.u,

--- a/src/festim/problem.py
+++ b/src/festim/problem.py
@@ -160,36 +160,17 @@ class ProblemBase:
             from dolfinx.fem.petsc import NonlinearProblem
 
             if self.petsc_options is None:
-                # taken from https://github.com/FEniCS/dolfinx/blob/5fcb988c5b0f46b8f9183bc844d8f533a2130d6a/python/demo/demo_cahn-hilliard.py#L279C1-L286C28
-                use_superlu = (
-                    PETSc.IntType == np.int64
-                )  # or PETSc.ScalarType == np.complex64
-                sys = PETSc.Sys()  # type: ignore
-                if sys.hasExternalPackage("mumps") and not use_superlu:
-                    linear_solver = "mumps"
-                elif sys.hasExternalPackage("superlu_dist"):
-                    linear_solver = "superlu_dist"
-                else:
-                    linear_solver = "petsc"
+                petsc_options = get_default_petsc_options()
+            else:
+                petsc_options = self.petsc_options
 
-                petsc_options = {
-                    "snes_type": "newtonls",
-                    "snes_linesearch_type": "none",
-                    "snes_stol": np.sqrt(np.finfo(dolfinx.default_real_type).eps)
-                    * 1e-2,
-                    # TODO : make atol and rtol callable
+            petsc_options.update(
+                {
                     "snes_atol": self.settings.atol,
                     "snes_rtol": self.settings.rtol,
                     "snes_max_it": self.settings.max_iterations,
-                    "snes_divergence_tolerance": "PETSC_UNLIMITED",
-                    "ksp_type": "preonly",
-                    "pc_type": "lu",
-                    "pc_factor_mat_solver_type": linear_solver,
-                    "snes_error_if_not_converged": True,
-                    "ksp_error_if_not_converged": True,
                 }
-            else:
-                petsc_options = self.petsc_options
+            )
 
             self.solver = NonlinearProblem(
                 self.formulation,
@@ -285,3 +266,31 @@ class ProblemBase:
         for source in self.sources:
             if source.value.explicit_time_dependent:
                 source.value.update(t=t)
+
+
+# DEFAULT PETSC OPTIONS
+
+# taken from https://github.com/FEniCS/dolfinx/blob/5fcb988c5b0f46b8f9183bc844d8f533a2130d6a/python/demo/demo_cahn-hilliard.py#L279C1-L286C28
+use_superlu = PETSc.IntType == np.int64  # or PETSc.ScalarType == np.complex64
+sys = PETSc.Sys()  # type: ignore
+if sys.hasExternalPackage("mumps") and not use_superlu:
+    linear_solver = "mumps"
+elif sys.hasExternalPackage("superlu_dist"):
+    linear_solver = "superlu_dist"
+else:
+    linear_solver = "petsc"
+_DEFAULT_PETSC_OPTS = {
+    "snes_type": "newtonls",
+    "snes_linesearch_type": "none",
+    "snes_stol": np.sqrt(np.finfo(dolfinx.default_real_type).eps) * 1e-2,
+    "snes_divergence_tolerance": "PETSC_UNLIMITED",
+    "ksp_type": "preonly",
+    "pc_type": "lu",
+    "pc_factor_mat_solver_type": linear_solver,
+    "snes_error_if_not_converged": True,
+    "ksp_error_if_not_converged": True,
+}
+
+
+def get_default_petsc_options():
+    return _DEFAULT_PETSC_OPTS.copy()


### PR DESCRIPTION
## Description

### Summary
This PR refactors the way we treat petsc options.

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔨 Code refactoring (no functional changes, no API changes)
- [ ] 📝 Documentation update
- [ ] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI configuration change

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] All existing tests pass locally (`pytest`)
- [ ] I have added new tests that prove my fix is effective or that my feature works



## Code Quality Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My code follows the code style of this project (Ruff formatted: `ruff format .`)
- [x] My code passes linting checks (`ruff check .`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Documentation

<!-- Put an `x` in the boxes that apply -->

- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added docstrings to new functions/classes following the project conventions

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here -->
<!-- What will users need to change in their code? -->
<!-- Delete this section if not applicable -->

## Screenshots/Examples

<!-- If applicable, add screenshots or code examples to help explain your changes -->
<!-- This is especially useful for new features or bug fixes with visual components -->

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- Mention if this is a work in progress, needs specific review, or has known limitations -->
