### PR TITLE
Qol unmarked cells

### DIFF
--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -41,7 +41,6 @@ from festim.helpers import (
     is_it_time_to_export,
     nmm_interpolate,
 )
-from festim.material import SolubilityLaw
 
 from .mesh import CoordinateSystem, Mesh
 

--- a/src/festim/mesh/mesh.py
+++ b/src/festim/mesh/mesh.py
@@ -180,6 +180,14 @@ class Mesh:
                     )
                 tags_volumes[:] = vol.id
 
+        # make sure there are no zeros in the tags_volumes
+        assert np.all(tags_volumes != 0), (
+            "All cells must be tagged with a non-zero value"
+            "This error can be caused by a volume subdomain not being defined"
+            "correctly, or by a mesh that is too coarse to capture the geometry"
+            "of the volume subdomains"
+        )
+
         volume_meshtags = meshtags(
             self._mesh, self.vdim, mesh_cell_indices, tags_volumes
         )

--- a/src/festim/problem.py
+++ b/src/festim/problem.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any
 
 from mpi4py import MPI
@@ -10,7 +11,6 @@ import ufl
 from dolfinx import fem
 from dolfinx.nls.petsc import NewtonSolver
 from packaging.version import Version
-import warnings
 
 import festim as F
 from festim.mesh.mesh import Mesh as _Mesh

--- a/src/festim/subdomain/volume_subdomain.py
+++ b/src/festim/subdomain/volume_subdomain.py
@@ -24,7 +24,7 @@ class VolumeSubdomain:
     Volume subdomain class
 
     Args:
-        id: the id of the volume subdomain
+        id: the id of the volume subdomain (> 0)
         submesh: the submesh of the volume subdomain
         cell_map: the cell map of the volume subdomain
         parent_mesh: the parent mesh of the volume subdomain
@@ -58,6 +58,7 @@ class VolumeSubdomain:
     def __init__(
         self, id, material, locator: Callable | None = None, name: str | None = None
     ):
+        assert id != 0, "Volume subdomain id cannot be 0"
         self.id = id
         self.material = material
         self.locator = locator

--- a/test/system_tests/test_io.py
+++ b/test/system_tests/test_io.py
@@ -19,7 +19,7 @@ def test_writing_and_reading_of_species_function_using_checkpoints(tmpdir):
     my_model.mesh = F.Mesh(mesh)
 
     my_mat = F.Material(name="mat", D_0=1, E_D=0)
-    vol = F.VolumeSubdomain(id=0, material=my_mat)
+    vol = F.VolumeSubdomain(id=1, material=my_mat)
     surf = F.SurfaceSubdomain(id=1)
     my_model.subdomains = [vol, surf]
 

--- a/test/system_tests/test_multi_material.py
+++ b/test/system_tests/test_multi_material.py
@@ -3,6 +3,7 @@ from mpi4py import MPI
 import dolfinx
 import dolfinx.fem.petsc
 import numpy as np
+import pytest
 import ufl
 
 import festim as F
@@ -396,3 +397,51 @@ def test_2_mats_particle_flux_bc(tmpdir):
 
     my_model.initialise()
     my_model.run()
+
+
+def test_all_cells_are_not_tagged():
+    """
+    Checks that an error is raised when not all cells are tagged with a non-zero value.
+    This can be caused by a volume subdomain not being defined correctly, or by a mesh
+    that is too coarse to capture the geometry of the volume subdomains.
+    """
+
+    my_model = F.HydrogenTransportProblemDiscontinuous()
+
+    mat = F.Material(D_0=1, E_D=0, K_S_0=1, E_K_S=0)
+
+    vol1 = F.VolumeSubdomain1D(id=1, borders=[0, 0.5], material=mat)
+    vol2 = F.VolumeSubdomain1D(id=2, borders=[0.5, 1], material=mat)
+
+    surf1 = F.SurfaceSubdomain1D(id=1, x=0)
+    surf2 = F.SurfaceSubdomain1D(id=2, x=1)
+
+    my_model.subdomains = [vol1, vol2, surf1, surf2]
+
+    my_model.surface_to_volume = {
+        surf1: vol1,
+        surf2: vol2,
+    }
+    my_model.interfaces = [F.Interface(id=3, subdomains=[vol1, vol2])]
+
+    my_model.mesh = F.Mesh1D(np.linspace(0, 1, 10))
+
+    my_model.species = [F.Species("H", subdomains=[vol1, vol2])]
+
+    my_model.boundary_conditions = [
+        F.FixedConcentrationBC(species=my_model.species[0], subdomain=surf1, value=1),
+    ]
+
+    my_model.temperature = 300
+
+    my_model.settings = F.Settings(transient=False, atol=1e-9, rtol=1e-9)
+
+    my_model.exports = [
+        F.AverageVolume(field=my_model.species[0], volume=vol1),
+        F.AverageVolume(field=my_model.species[0], volume=vol2),
+    ]
+
+    with pytest.raises(
+        AssertionError, match="All cells must be tagged with a non-zero value"
+    ):
+        my_model.initialise()

--- a/test/test_heat_transfer_problem.py
+++ b/test/test_heat_transfer_problem.py
@@ -484,7 +484,7 @@ def test_meshtags_from_xdmf(tmp_path, mesh):
 def test_raise_error_non_unique_vol_ids():
     """Test that an error is raised if the volume ids are not unique"""
     my_problem = F.HeatTransferProblem()
-    my_problem.mesh = F.Mesh1D(vertices=np.linspace(0, 1, 2000))
+    my_problem.mesh = F.Mesh1D(vertices=np.linspace(0, 1, 11))
     left = F.SurfaceSubdomain1D(id=1, x=0)
     right = F.SurfaceSubdomain1D(id=2, x=1)
     mat = F.Material(D_0=1, E_D=None)

--- a/test/test_initial_condition.py
+++ b/test/test_initial_condition.py
@@ -169,7 +169,7 @@ def test_checkpointing_single_species(tmpdir):
     my_problem.mesh = F.Mesh(mesh)
 
     mat = F.Material(D_0=1, E_D=0.1, name="dummy_mat")
-    vol = F.VolumeSubdomain(id=0, material=mat)
+    vol = F.VolumeSubdomain(id=1, material=mat)
     my_problem.subdomains = [vol]
 
     function_initial_value = F.read_function_from_file(
@@ -227,7 +227,7 @@ def test_checkpointing_multiple_species(tmpdir):
     my_problem.mesh = F.Mesh(mesh)
 
     mat = F.Material(D_0=1, E_D=0.1, name="dummy_mat")
-    vol = F.VolumeSubdomain(id=0, material=mat)
+    vol = F.VolumeSubdomain(id=1, material=mat)
     my_problem.subdomains = [vol]
 
     my_problem.initial_conditions = [

--- a/test/test_reaction.py
+++ b/test/test_reaction.py
@@ -1,10 +1,10 @@
 from mpi4py import MPI
 
+import numpy as np
 import pytest
 from dolfinx.fem import Function, functionspace
 from dolfinx.mesh import create_unit_cube
 from ufl import exp
-import numpy as np
 
 import festim as F
 

--- a/test/test_reaction.py
+++ b/test/test_reaction.py
@@ -401,7 +401,7 @@ mat = F.Material(D_0=1, E_D=0, K_S_0=1, E_K_S=0)
 vol1 = F.VolumeSubdomain1D(id=1, borders=[0, 0.5], material=mat)
 vol2 = F.VolumeSubdomain1D(id=2, borders=[0.5, 1], material=mat)
 my_model = F.HydrogenTransportProblemDiscontinuous()
-my_model.mesh = F.Mesh1D(np.linspace(0, 1, 100))
+my_model.mesh = F.Mesh1D(np.linspace(0, 1, 101))
 
 my_model.subdomains = [vol1, vol2]
 

--- a/test/test_subdomains.py
+++ b/test/test_subdomains.py
@@ -214,3 +214,23 @@ def test_name_setter():
 
     with pytest.raises(TypeError, match="Name must be a string"):
         F.VolumeSubdomain(id=1, material=None, name=1)
+
+
+def test_all_cells_are_not_tagged():
+    """
+    Checks that an error is raised when not all cells are tagged with a non-zero value.
+    This can be caused by a volume subdomain not being defined correctly, or by a mesh
+    that is too coarse to capture the geometry of the volume subdomains.
+    """
+
+    mat = F.Material(D_0=1, E_D=0, K_S_0=1, E_K_S=0)
+
+    vol1 = F.VolumeSubdomain1D(id=1, borders=[0, 0.5], material=mat)
+    vol2 = F.VolumeSubdomain1D(id=2, borders=[0.5, 1], material=mat)
+
+    mesh = F.Mesh1D(np.linspace(0, 1, 10))
+
+    with pytest.raises(
+        AssertionError, match="All cells must be tagged with a non-zero value"
+    ):
+        mesh.define_meshtags(surface_subdomains=[], volume_subdomains=[vol1, vol2])

--- a/test/test_subdomains.py
+++ b/test/test_subdomains.py
@@ -125,7 +125,7 @@ def test_ValueError_raised_when_id_not_found_in_volumes_subdomains():
 def test_ValueError_rasied_when_volume_ids_are_not_unique():
     """Checks"""
     my_test_model = F.HydrogenTransportProblem(
-        mesh=F.Mesh1D(np.linspace(0, 2, num=10)), species=[F.Species("H")]
+        mesh=F.Mesh1D(np.linspace(0, 2, num=11)), species=[F.Species("H")]
     )
 
     vol_1 = F.VolumeSubdomain1D(id=1, borders=[0, 1], material=None)


### PR DESCRIPTION
## Description

### Summary
Adds guardrails to let the user know when not all the cells are marked in a mesh

### Related Issues
Fixes #1101 

### Motivation and Context
Sometimes users may set volume subdomains that don't cover the whole mesh domain (eg. wrong locators, tolerance issues with coarse meshes...). The simulation won't necessarily crash, it's just that some cells will be ignored from the solve which can lead to "discontinuous" domains.

This PR adds errors if we detect that some cells are still unmarked after calling all the `VolumeSubdomain` locators (ie that there are still zeros in the volume tags).

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Code refactoring (no functional changes, no API changes)
- [ ] 📝 Documentation update
- [ ] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI configuration change

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] All existing tests pass locally (`pytest`)
- [x] I have added new tests that prove my fix is effective or that my feature works



## Code Quality Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My code follows the code style of this project (Ruff formatted: `ruff format .`)
- [x] My code passes linting checks (`ruff check .`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Documentation

<!-- Put an `x` in the boxes that apply -->

- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have added docstrings to new functions/classes following the project conventions

## Breaking Changes

id = 0 is no longer permitted though I'm not sure I've ever seen anyone do this

## Screenshots/Examples

<!-- If applicable, add screenshots or code examples to help explain your changes -->
<!-- This is especially useful for new features or bug fixes with visual components -->

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- Mention if this is a work in progress, needs specific review, or has known limitations -->
