### PR TITLE
Expose tolerance for milestone checks

### DIFF
--- a/src/festim/stepsize.py
+++ b/src/festim/stepsize.py
@@ -80,9 +80,7 @@ class Stepsize:
 
     @milestone_tolerance.setter
     def milestone_tolerance(self, value):
-        if value is None:
-            value = 1e-5  # np.isclose default
-        elif value <= 0:
+        if value <= 0:
             raise ValueError("milestone tolerance should be greater than zero")
 
         self._milestone_tolerance = value

--- a/src/festim/stepsize.py
+++ b/src/festim/stepsize.py
@@ -17,7 +17,8 @@ class Stepsize:
             If callable, has to be a function of `t`. Defaults to None.
         milestones (list, optional): list of times by which the simulation must
             pass. Defaults to an empty list.
-        milestone_tolerance (float, optional): relative tolerance passed to numpy.isclose (rtol) Defaults to 1e-5.
+        milestone_tolerance (float, optional): relative tolerance passed to
+            numpy.isclose (rtol). Defaults to 1e-5.
 
 
     Attributes:

--- a/src/festim/stepsize.py
+++ b/src/festim/stepsize.py
@@ -17,8 +17,7 @@ class Stepsize:
             If callable, has to be a function of `t`. Defaults to None.
         milestones (list, optional): list of times by which the simulation must
             pass. Defaults to an empty list.
-        milestone_tolerance (float, optional): relative tolerance for how closely
-            a time must align with a milestone to be triggered. Defaults to 1e-5.
+        milestone_tolerance (float, optional): relative tolerance passed to numpy.isclose (rtol) Defaults to 1e-5.
 
 
     Attributes:

--- a/src/festim/stepsize.py
+++ b/src/festim/stepsize.py
@@ -45,7 +45,7 @@ class Stepsize:
         target_nb_iterations=None,
         max_stepsize=None,
         milestones=None,
-        milestone_tolerance=None,
+        milestone_tolerance=1e-5,
     ) -> None:
         self.initial_value = initial_value
         self.growth_factor = growth_factor

--- a/src/festim/stepsize.py
+++ b/src/festim/stepsize.py
@@ -17,6 +17,8 @@ class Stepsize:
             If callable, has to be a function of `t`. Defaults to None.
         milestones (list, optional): list of times by which the simulation must
             pass. Defaults to an empty list.
+        milestone_tolerance (float, optional): relative tolerance for how closely
+            a time must align with a milestone to be triggered. Defaults to 1e-5.
 
 
     Attributes:
@@ -32,6 +34,8 @@ class Stepsize:
         max_stepsize (float, callable): Maximum stepsize.
         milestones (list): list of times by which the simulation must
             pass.
+        milestone_tolerance (float): relative tolerance for how closely a
+            time must align with a milestone to be triggered.
     """
 
     def __init__(
@@ -42,6 +46,7 @@ class Stepsize:
         target_nb_iterations=None,
         max_stepsize=None,
         milestones=None,
+        milestone_tolerance=None,
     ) -> None:
         self.initial_value = initial_value
         self.growth_factor = growth_factor
@@ -49,6 +54,7 @@ class Stepsize:
         self.target_nb_iterations = target_nb_iterations
         self.max_stepsize = max_stepsize
         self.milestones = milestones or []
+        self.milestone_tolerance = milestone_tolerance
 
         if milestones and (growth_factor is None or cutback_factor is None):
             raise ValueError(
@@ -68,6 +74,19 @@ class Stepsize:
             self._milestones = sorted(value)
         else:
             self._milestones = value
+
+    @property
+    def milestone_tolerance(self):
+        return self._milestone_tolerance
+
+    @milestone_tolerance.setter
+    def milestone_tolerance(self, value):
+        if value is None:
+            value = 1e-5  # np.isclose default
+        elif value <= 0:
+            raise ValueError("milestone tolerance should be greater than zero")
+
+        self._milestone_tolerance = value
 
     @property
     def adaptive(self):
@@ -143,7 +162,7 @@ class Stepsize:
         if next_milestone is not None:
             time_to_milestone = next_milestone - t
             if updated_value > time_to_milestone and not np.isclose(
-                t, next_milestone, atol=0
+                t, next_milestone, atol=0, rtol=self.milestone_tolerance
             ):
                 updated_value = time_to_milestone
 

--- a/test/test_stepsize.py
+++ b/test/test_stepsize.py
@@ -202,3 +202,42 @@ def test_milestones_without_adaptivity_raises_error():
         ValueError, match=r"Milestones are only relevant if the stepsize is adaptive."
     ):
         F.Stepsize(initial_value=2, milestones=[1, 2, 3])
+
+
+def test_milestone_tolerance_miss_tolerance():
+    """
+    This tests confirms that with a high rtol the milestone is missed
+    See issue #933
+    """
+
+    stepsize = F.Stepsize(
+        initial_value=1,
+        growth_factor=1.2,
+        cutback_factor=0.9,
+        target_nb_iterations=4,
+        milestones=[0.05, 0.1, 0.2, 0.5, 1],
+        milestone_tolerance=1e-10,
+    )
+
+    current_t = 0.499999
+    current_dt = 1
+    new_dt = stepsize.modify_value(value=current_dt, nb_iterations=4, t=current_t)
+
+    new_t = current_t + new_dt
+    assert np.isclose(new_t, 0.5), f"Expected new_t to be 0.5, but got {new_t}"
+
+
+def test_milestone_tolerance_setter():
+    """Checks that the milestone tolerance setter works correctly"""
+
+    stepsize = F.Stepsize(1)
+
+    # Test that setting a milestone tolerance <=0 raises a ValueError
+    with pytest.raises(
+        ValueError, match="milestone tolerance must be greater than zero"
+    ):
+        stepsize.milestone_tolerance = -1.0
+
+    # Test that setting the default milestone tolerance of 1e-5 works
+    stepsize.milestone_tolerance = 1e-5
+    assert stepsize.milestone_tolerance == 1e-5

--- a/test/test_stepsize.py
+++ b/test/test_stepsize.py
@@ -234,7 +234,7 @@ def test_milestone_tolerance_setter():
 
     # Test that setting a milestone tolerance <=0 raises a ValueError
     with pytest.raises(
-        ValueError, match="milestone tolerance must be greater than zero"
+        ValueError, match="milestone tolerance should be greater than zero"
     ):
         stepsize.milestone_tolerance = -1.0
 


### PR DESCRIPTION
## Description

Proposed fix for #933 (and my first attempt at a FESTIM codebase contribution!)

### Summary
<!-- Provide a clear and concise description of what this PR does -->

Adds a `milestone_tolerance` argument that allows the user to manually tune the relative tolerance (`rtol`) in the `np.isclose` check of whether the time is near a milestone. If none is specified, it passes the default of 1e-5. 

### Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

For large times, the default relative tolerance can miss specified milestones. Exposing `milestone_tolerance` to the user provides a mitigation strategy. 

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Code refactoring (no functional changes, no API changes)
- [ ] 📝 Documentation update
- [ ] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI configuration change

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [X] All existing tests pass locally (`pytest`)
- [ ] I have added new tests that prove my fix is effective or that my feature works

## Code Quality Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [X] My code follows the code style of this project (Ruff formatted: `ruff format .`)
- [X] My code passes linting checks (`ruff check .`)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas

I kept comments to a bare minimum to keep with the rest of the code style, I can add more explanation if needed

## Documentation

<!-- Put an `x` in the boxes that apply -->

- [ ] I have updated the documentation accordingly (if applicable)
- [X] I have added docstrings to new functions/classes following the project conventions

## Screenshots/Examples

<!-- If applicable, add screenshots or code examples to help explain your changes -->
<!-- This is especially useful for new features or bug fixes with visual components -->

Running the "[Simple Simulation](https://festim-workshop.readthedocs.io/en/festim2/content/applications/task01.html)" example (slightly modified, see below) with `initial_value=1e-3` and  `milestone_tolerance=1e-2` reproduces the bug described in #933 ; the `t=1` s milestone is missed: 

<img width="597" height="447" alt="image" src="https://github.com/user-attachments/assets/e0527a44-ac1d-42ae-824a-70ea73b1ba6d" />

Omitting `milestone_tolerance` causes fallback to the default 1e-5, successfully reproducing [the graph on the simple simulation page](https://festim-workshop.readthedocs.io/en/festim2/content/applications/task01.html#visualise). 

```python
import matplotlib.pyplot as plt
import numpy as np

import festim as F

model = F.HydrogenTransportProblem()
model.mesh = F.Mesh1D(vertices=np.linspace(0, 1, num=1001))

mat = F.Material(D_0=1, E_D=0.0)

volume_subdomain = F.VolumeSubdomain1D(id=1, borders=[0, 1], material=mat)
boundary_left = F.SurfaceSubdomain1D(id=1, x=0)
boundary_right = F.SurfaceSubdomain1D(id=2, x=1)
model.subdomains = [volume_subdomain, boundary_left, boundary_right]

H = F.Species("H")
model.species = [H]

model.temperature = 300

model.boundary_conditions = [
    F.FixedConcentrationBC(subdomain=boundary_left, value=1, species=H),
    F.FixedConcentrationBC(subdomain=boundary_right, value=0, species=H),
]

model.settings = F.Settings(atol=1e-10, rtol=1e-10, final_time=2)

model.settings.stepsize = F.Stepsize(
    initial_value=1.0e-3,
    growth_factor=1.1,
    cutback_factor=0.9,
    target_nb_iterations=4,
    milestones=[0.05, 0.1, 0.2, 0.5, 1],
)


profile = F.Profile1DExport(
    field=H, subdomain=volume_subdomain, times=model.settings.stepsize.milestones
)

model.exports = [
    F.VTXSpeciesExport(field=H, filename="h_concentration.bp"),
    profile,
]

model.initialise()
model.run()
x = model.mesh.mesh.geometry.x[:, 0]
for time, data in zip(profile.t, profile.data):
    plt.plot(x, data, label=f"{time} s")

plt.xlabel("x (m)")
plt.ylabel("Mobile concentration (H/m3)")
plt.legend()
plt.show()

```

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- Mention if this is a work in progress, needs specific review, or has known limitations -->
