### PR TITLE
Support for gas enclosures

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -7,6 +7,10 @@ API reference
     :members:
     :show-inheritance:
 
+.. automodule:: festim.enclosure
+    :members:
+    :show-inheritance:
+
 .. automodule:: festim.exports
     :members:
     :show-inheritance:

--- a/src/festim/__init__.py
+++ b/src/festim/__init__.py
@@ -9,6 +9,7 @@ except Exception:
 
 R = 8.314462618  # Gas constant J.mol-1.K-1
 k_B = 8.6173303e-5  # Boltzmann constant eV.K-1
+k_B_SI = 1.380649e-23  # Boltzmann constant J.K-1
 
 from .advection import AdvectionTerm, VelocityField
 from .boundary_conditions.dirichlet_bc import (
@@ -24,10 +25,20 @@ from .boundary_conditions.surface_reaction import SurfaceReactionBC
 from .coupled_heat_hydrogen_problem import (
     CoupledTransientHeatTransferHydrogenTransport,
 )
+from .enclosure.enclosure import Enclosure
+from .enclosure.gas_species import GasSpecies
+from .enclosure.openings import (
+    EnclosureConnection,
+    OpeningBase,
+    PrescribedFlowRate,
+    Pump,
+    Reservoir,
+)
 from .exports.average_surface import AverageSurface
 from .exports.average_volume import AverageVolume
 from .exports.custom_quantity import CustomQuantity
 from .exports.derived_quantity import DerivedQuantity
+from .exports.gas_pressure import GasPressure
 from .exports.maximum_surface import MaximumSurface
 from .exports.maximum_volume import MaximumVolume
 from .exports.minimum_surface import MinimumSurface

--- a/src/festim/boundary_conditions/surface_reaction.py
+++ b/src/festim/boundary_conditions/surface_reaction.py
@@ -3,6 +3,7 @@ from dolfinx import fem
 
 from festim import k_B
 from festim.boundary_conditions import ParticleFluxBC
+from festim.enclosure.gas_species import GasSpecies
 
 
 class SurfaceReactionBCpartial(ParticleFluxBC):
@@ -22,7 +23,10 @@ class SurfaceReactionBCpartial(ParticleFluxBC):
 
     Args:
         reactant (list): list of F.Species objects representing the reactants
-        gas_pressure (float, callable): the partial pressure of the product species
+        gas_pressure (float, callable or F.GasSpecies): the partial pressure of
+            the product species. If a F.GasSpecies is given, the pressure is an
+            unknown of the problem and the reaction feeds the mass balance of
+            the enclosure that species belongs to.
         k_r0 (float): the pre-exponential factor of the forward reaction rate
         E_kr (float): the activation energy of the forward reaction rate (eV)
         k_d0 (float): the pre-exponential factor of the backward reaction rate
@@ -53,7 +57,10 @@ class SurfaceReactionBCpartial(ParticleFluxBC):
     def create_value_fenics(self, mesh, temperature, t: fem.Constant):
         kr = self.k_r0 * ufl.exp(-self.E_kr / (k_B * temperature))
         kd = self.k_d0 * ufl.exp(-self.E_kd / (k_B * temperature))
-        if callable(self.gas_pressure):
+        if isinstance(self.gas_pressure, GasSpecies):
+            # the pressure is an unknown of the problem, living in an enclosure
+            gas_pressure = self.gas_pressure.solution
+        elif callable(self.gas_pressure):
             gas_pressure = self.gas_pressure(t=t)
         else:
             gas_pressure = self.gas_pressure
@@ -95,7 +102,10 @@ class SurfaceReactionBC:
 
     Args:
         reactant (list): list of F.Species objects representing the reactants
-        gas_pressure (float, callable): the partial pressure of the product species
+        gas_pressure (float, callable or F.GasSpecies): the partial pressure of
+            the product species. If a F.GasSpecies is given, the pressure is an
+            unknown of the problem and the reaction feeds the mass balance of
+            the enclosure that species belongs to.
         k_r0 (float): the pre-exponential factor of the forward reaction rate
         E_kr (float): the activation energy of the forward reaction rate (eV)
         k_d0 (float): the pre-exponential factor of the backward reaction rate

--- a/src/festim/enclosure/__init__.py
+++ b/src/festim/enclosure/__init__.py
@@ -1,0 +1,19 @@
+from .enclosure import Enclosure
+from .gas_species import GasSpecies
+from .openings import (
+    EnclosureConnection,
+    OpeningBase,
+    PrescribedFlowRate,
+    Pump,
+    Reservoir,
+)
+
+__all__ = [
+    "Enclosure",
+    "EnclosureConnection",
+    "GasSpecies",
+    "OpeningBase",
+    "PrescribedFlowRate",
+    "Pump",
+    "Reservoir",
+]

--- a/src/festim/enclosure/_utils.py
+++ b/src/festim/enclosure/_utils.py
@@ -1,0 +1,22 @@
+import dolfinx
+from packaging.version import Version
+
+MINIMUM_DOLFINX_VERSION = "0.11"
+
+
+def check_dolfinx_version_for_enclosures():
+    """Checks that the installed version of dolfinx supports real function spaces.
+
+    Enclosure pressures are unknowns living in a real function space (a single global
+    degree of freedom). Real function spaces are only available from dolfinx 0.11.
+
+    Raises:
+        NotImplementedError: if the installed dolfinx is older than 0.11
+    """
+    if Version(dolfinx.__version__) < Version(MINIMUM_DOLFINX_VERSION):
+        raise NotImplementedError(
+            f"Gas enclosures require dolfinx >= {MINIMUM_DOLFINX_VERSION} (found "
+            f"{dolfinx.__version__}). Enclosure pressures are solved in a real "
+            "function space, which is not implemented in older versions of dolfinx. "
+            "Please upgrade dolfinx, or remove the enclosures from your model."
+        )

--- a/src/festim/enclosure/enclosure.py
+++ b/src/festim/enclosure/enclosure.py
@@ -171,6 +171,7 @@ class Enclosure:
             function_space: a function space on the parent mesh
             t: the time, as a fenics Constant
         """
+        # NOTE could we have so guards to make sure temperature cannot be a function of space or temperature?
         self.temperature.convert_input_value(function_space=function_space, t=t)
         for opening in self.openings:
             opening.convert_input_values_to_fenics_objects(

--- a/src/festim/enclosure/enclosure.py
+++ b/src/festim/enclosure/enclosure.py
@@ -1,0 +1,189 @@
+from collections.abc import Callable
+
+from festim import k_B_SI
+from festim.enclosure.gas_species import GasSpecies
+from festim.enclosure.openings import OpeningBase
+from festim.helpers import Value
+from festim.subdomain.surface_subdomain import SurfaceSubdomain
+
+
+class Enclosure:
+    """A gas enclosure in contact with the model through one or more surfaces.
+
+    The partial pressure of each gas species in the enclosure is an unknown of the
+    problem, solved together with the transport problem. For each species, the pressure
+    evolves as:
+
+    .. math::
+
+        \\frac{dP}{dt} = \\frac{k_B T}{V} \\left( \\sum_\\Gamma A_\\Gamma
+        \\int_\\Gamma \\varphi \\, dS + \\sum_\\text{openings} Q \\right)
+
+    where :math:`\\varphi` is the rate of particles entering the gas from the solid,
+    :math:`Q` the flow rate through the openings, and :math:`A_\\Gamma` the physical
+    area of each contact surface (see ``surfaces``).
+
+    Args:
+        volume: the volume of the enclosure (m3)
+        species: the gas species in the enclosure
+        temperature: the temperature of the gas (K). Can be a callable of time. This is
+            independent of the temperature of the transport problem.
+        surfaces: the surfaces in contact with the enclosure, as a dict mapping each
+            :py:class:`festim.SurfaceSubdomain` to its physical area. The area is what
+            turns the flux through the surface into a number of particles per second,
+            and the mesh only provides it in 3D:
+
+            - **1D**: a surface is a point and carries no extent, so the area is the
+              area of the membrane facing the enclosure, in m2. Required.
+            - **2D**: a surface is a line, so the area is the out-of-plane depth of the
+              model, in m. Required.
+            - **3D**: the mesh already measures the area, so pass 1.0. A plain list of
+              surfaces is accepted in 3D and means an area of 1.0 for each.
+
+            An enclosure with no contact surfaces is allowed (it then only exchanges
+            through its openings).
+        openings: the openings of the enclosure (see :py:class:`festim.Pump`,
+            :py:class:`festim.Reservoir`, :py:class:`festim.PrescribedFlowRate`,
+            :py:class:`festim.EnclosureConnection`)
+        gas_constant: the constant relating pressure to particle density
+            (:math:`P = n k T`). Defaults to :py:data:`festim.k_B_SI` (J/K), which
+            matches FESTIM's convention of concentrations in particles/m3. Pass
+            :py:data:`festim.R` (J/mol/K) if working in mol/m3.
+        name: a name given to the enclosure
+
+    Attributes:
+        volume: the volume of the enclosure (m3)
+        species: the gas species in the enclosure
+        temperature: the temperature of the gas, wrapped in a
+            :py:class:`festim.helpers.Value`
+        surfaces: a dict mapping each contact surface to its physical area
+        openings: the openings of the enclosure
+        gas_constant: the constant relating pressure to particle density
+        name: a name given to the enclosure
+
+    Examples:
+
+        .. testsetup:: Enclosure
+
+            import festim as F
+
+        .. testcode:: Enclosure
+
+            H2 = F.GasSpecies(name="H2", initial_pressure=1e5)
+            my_enclosure = F.Enclosure(
+                volume=1e-3,
+                species=[H2],
+                temperature=500,
+                openings=[F.Pump(pumping_speed=1e-4)],
+            )
+    """
+
+    def __init__(
+        self,
+        volume: float,
+        species: list[GasSpecies],
+        temperature: float | Callable,
+        surfaces: dict[SurfaceSubdomain, float] | list[SurfaceSubdomain] | None = None,
+        openings: list[OpeningBase] | None = None,
+        gas_constant: float = k_B_SI,
+        name: str | None = None,
+    ):
+        self.volume = volume
+        self.species = species
+        self.temperature = Value(temperature)
+        self.surfaces = surfaces
+        self.openings = openings or []
+        self.gas_constant = gas_constant
+        self.name = name
+
+        for gas_species in self.species:
+            gas_species.enclosure = self
+
+    def __repr__(self) -> str:
+        return f"Enclosure({self.name})" if self.name else "Enclosure"
+
+    @property
+    def volume(self) -> float:
+        return self._volume
+
+    @volume.setter
+    def volume(self, value):
+        if value <= 0:
+            raise ValueError(f"Enclosure volume must be positive, got {value}")
+        self._volume = value
+
+    @property
+    def surfaces(self) -> dict[SurfaceSubdomain, float]:
+        return self._surfaces
+
+    @surfaces.setter
+    def surfaces(self, value):
+        if value is None:
+            value = {}
+        # a plain list means "no areas given"; only valid in 3D, where the mesh
+        # measures the area itself. Checked against the mesh in the problem class.
+        self.areas_given = isinstance(value, dict)
+        if not self.areas_given:
+            value = dict.fromkeys(value, 1.0)
+        for surface, area in value.items():
+            if not isinstance(surface, SurfaceSubdomain):
+                raise TypeError(
+                    "surfaces must map festim.SurfaceSubdomain objects to their area, "
+                    f"got a key of type {type(surface)}"
+                )
+            if area <= 0:
+                raise ValueError(
+                    f"The area of surface {surface.id} must be positive, got {area}"
+                )
+        self._surfaces = value
+
+    @property
+    def species(self) -> list[GasSpecies]:
+        return self._species
+
+    @species.setter
+    def species(self, value):
+        if not value:
+            raise ValueError("Enclosure must have at least one GasSpecies")
+        if not isinstance(value, list | tuple):
+            raise TypeError("species must be a list of GasSpecies")
+        for gas_species in value:
+            if not isinstance(gas_species, GasSpecies):
+                raise TypeError(
+                    f"species must be a list of GasSpecies, got {type(gas_species)}"
+                )
+        self._species = list(value)
+
+    @property
+    def thermal_energy(self):
+        """The quantity relating pressure to particle density (:math:`P = n k T`).
+
+        Returns ``gas_constant * T`` as a fenics object once the problem has been
+        initialised.
+        """
+        return self.gas_constant * self.temperature.fenics_object
+
+    def convert_input_values_to_fenics_objects(self, function_space, t):
+        """Converts the user input values of the enclosure and its openings to fenics
+        objects.
+
+        Args:
+            function_space: a function space on the parent mesh
+            t: the time, as a fenics Constant
+        """
+        self.temperature.convert_input_value(function_space=function_space, t=t)
+        for opening in self.openings:
+            opening.convert_input_values_to_fenics_objects(
+                function_space=function_space, t=t
+            )
+
+    def update_time_dependent_values(self, t: float):
+        """Updates the time-dependent values of the enclosure and its openings.
+
+        Args:
+            t: the time
+        """
+        if self.temperature.explicit_time_dependent:
+            self.temperature.update(t=t)
+        for opening in self.openings:
+            opening.update(t=t)

--- a/src/festim/enclosure/gas_species.py
+++ b/src/festim/enclosure/gas_species.py
@@ -1,0 +1,89 @@
+import basix.ufl
+from dolfinx import fem
+
+from festim.enclosure._utils import check_dolfinx_version_for_enclosures
+
+
+class GasSpecies:
+    """A gas species living in a :py:class:`festim.Enclosure`.
+
+    The partial pressure of the species in the enclosure is an unknown of the problem,
+    represented by a real function space (one global degree of freedom).
+
+    Args:
+        name: a name given to the species
+        initial_pressure: the partial pressure at t=0 (Pa)
+
+    Attributes:
+        name: a name given to the species
+        initial_pressure: the partial pressure at t=0 (Pa)
+        enclosure: the enclosure this species belongs to. Set by
+            :py:class:`festim.Enclosure`
+        function_space: the real function space holding the pressure
+        solution: the pressure at the current timestep
+        prev_solution: the pressure at the previous timestep
+        test_function: the test function of the real function space
+        F: the variational formulation of the pressure balance
+
+    Examples:
+
+        .. testsetup:: GasSpecies
+
+            from festim import Enclosure, GasSpecies
+
+        .. testcode:: GasSpecies
+
+            H2 = GasSpecies(name="H2", initial_pressure=1e5)
+            my_enclosure = Enclosure(volume=1e-3, species=[H2], temperature=500)
+    """
+
+    def __init__(self, name: str, initial_pressure: float = 0.0):
+        self.name = name
+        self.initial_pressure = initial_pressure
+
+        self.enclosure = None
+        self.function_space = None
+        self.solution = None
+        self.prev_solution = None
+        self.test_function = None
+        self.F = None
+
+    def __repr__(self) -> str:
+        return f"GasSpecies({self.name})"
+
+    @property
+    def pressure(self):
+        """The pressure as a fenics object, to be used in boundary conditions."""
+        return self.solution
+
+    @property
+    def value(self) -> float:
+        """The current pressure as a float (Pa), collected across all MPI processes."""
+        if self.solution is None:
+            raise ValueError(
+                f"The pressure of {self.name} is not available before initialise() "
+                "is called on the problem."
+            )
+        self.solution.x.scatter_forward()
+        comm = self.function_space.mesh.comm
+        # a real function space has a single global dof, owned by one process only
+        nb_owned = self.function_space.dofmap.index_map.size_local
+        local = self.solution.x.array[:nb_owned]
+        candidate = float(local[0]) if len(local) else None
+        for value in comm.allgather(candidate):
+            if value is not None:
+                return value
+        raise RuntimeError(f"No process owns the pressure dof of {self.name}")
+
+
+def create_real_function_space(mesh) -> fem.FunctionSpace:
+    """Creates a real function space (one global degree of freedom) on a mesh.
+
+    Args:
+        mesh: the dolfinx mesh
+
+    Returns:
+        the real function space
+    """
+    check_dolfinx_version_for_enclosures()
+    return fem.functionspace(mesh, basix.ufl.real_element(mesh.basix_cell(), ()))

--- a/src/festim/enclosure/openings.py
+++ b/src/festim/enclosure/openings.py
@@ -1,0 +1,254 @@
+from collections.abc import Callable
+
+from festim.helpers import Value
+
+
+class OpeningBase:
+    """Base class for enclosure openings.
+
+    An opening lets gas in or out of an enclosure, modifying its mass balance.
+    Subclasses implement :py:meth:`molar_flow_rate`.
+
+    Args:
+        species: the gas species this opening applies to. If None, the opening applies
+            to every species in the enclosure.
+
+    Attributes:
+        species: the gas species this opening applies to, or None for all of them
+    """
+
+    def __init__(self, species=None):
+        if species is None or isinstance(species, list | tuple):
+            self.species = species
+        else:
+            self.species = [species]
+
+    def applies_to(self, gas_species) -> bool:
+        """Whether this opening acts on a given gas species."""
+        if self.species is None:
+            return True
+        return gas_species in self.species
+
+    @property
+    def _values(self) -> list[Value]:
+        """The Value objects held by this opening. Used to convert user input to fenics
+        objects and to update time-dependent values."""
+        return []
+
+    def convert_input_values_to_fenics_objects(self, function_space, t):
+        """Converts the user input values to fenics objects.
+
+        Args:
+            function_space: a function space on the parent mesh. Only its mesh is used,
+                since opening parameters are scalars.
+            t: the time, as a fenics Constant
+        """
+        for value in self._values:
+            value.convert_input_value(function_space=function_space, t=t)
+
+    def update(self, t: float):
+        for value in self._values:
+            if value.explicit_time_dependent:
+                value.update(t=t)
+
+    def molar_flow_rate(self, gas_species, enclosure):
+        """The flow rate of particles into the enclosure (particles/s).
+
+        A positive value means particles entering the enclosure.
+
+        Args:
+            gas_species: the gas species this rate is computed for
+            enclosure: the enclosure the opening belongs to
+
+        Returns:
+            a ufl expression for the flow rate
+        """
+        raise NotImplementedError
+
+
+class Pump(OpeningBase):
+    """An opening to vacuum with a given pumping speed.
+
+    The flow rate out of the enclosure is ``S * P / (k * T)``, giving an exponential
+    decay of the pressure ``P(t) = P_0 * exp(-S * t / V)`` for a closed enclosure.
+
+    Args:
+        pumping_speed: the pumping speed (m3/s). Can be a callable of time.
+        species: the gas species this pump applies to. If None, applies to all of them.
+
+    Examples:
+
+        .. testsetup:: Pump
+
+            from festim import Enclosure, GasSpecies, Pump
+
+        .. testcode:: Pump
+
+            H2 = GasSpecies(name="H2", initial_pressure=1e5)
+            my_enclosure = Enclosure(
+                volume=1e-3,
+                species=[H2],
+                temperature=500,
+                openings=[Pump(pumping_speed=1e-4)],
+            )
+    """
+
+    def __init__(self, pumping_speed: float | Callable, species=None):
+        super().__init__(species=species)
+        self.pumping_speed = Value(pumping_speed)
+
+    @property
+    def _values(self) -> list[Value]:
+        return [self.pumping_speed]
+
+    def molar_flow_rate(self, gas_species, enclosure):
+        speed = self.pumping_speed.fenics_object
+        return -speed * gas_species.solution / enclosure.thermal_energy
+
+
+class Reservoir(OpeningBase):
+    """An opening to an external reservoir held at a given pressure.
+
+    The flow rate into the enclosure is ``C * (P_ext - P) / (k * T)``, giving
+    ``P(t) = P_ext + (P_0 - P_ext) * exp(-C * t / V)`` for an enclosure with no other
+    exchange.
+
+    Args:
+        conductance: the conductance of the opening (m3/s). Can be a callable of time.
+        pressure: the pressure of the reservoir (Pa). Can be a callable of time.
+        species: the gas species this opening applies to. If None, applies to all.
+
+    Examples:
+
+        .. testsetup:: Reservoir
+
+            from festim import Enclosure, GasSpecies, Reservoir
+
+        .. testcode:: Reservoir
+
+            H2 = GasSpecies(name="H2", initial_pressure=1e5)
+            my_enclosure = Enclosure(
+                volume=1e-3,
+                species=[H2],
+                temperature=500,
+                openings=[Reservoir(conductance=1e-4, pressure=1e3)],
+            )
+    """
+
+    def __init__(
+        self, conductance: float | Callable, pressure: float | Callable, species=None
+    ):
+        super().__init__(species=species)
+        self.conductance = Value(conductance)
+        self.pressure = Value(pressure)
+
+    @property
+    def _values(self) -> list[Value]:
+        return [self.conductance, self.pressure]
+
+    def molar_flow_rate(self, gas_species, enclosure):
+        conductance = self.conductance.fenics_object
+        pressure = self.pressure.fenics_object
+        return (
+            conductance * (pressure - gas_species.solution) / enclosure.thermal_energy
+        )
+
+
+class PrescribedFlowRate(OpeningBase):
+    """An opening with a directly imposed flow rate, independent of the pressure.
+
+    Args:
+        flow_rate: the flow rate of particles into the enclosure (particles/s). A
+            negative value removes particles. Can be a callable of time.
+        species: the gas species this opening applies to. If None, applies to all.
+
+    Examples:
+
+        .. testsetup:: PrescribedFlowRate
+
+            from festim import Enclosure, GasSpecies, PrescribedFlowRate
+
+        .. testcode:: PrescribedFlowRate
+
+            H2 = GasSpecies(name="H2")
+            my_enclosure = Enclosure(
+                volume=1e-3,
+                species=[H2],
+                temperature=500,
+                openings=[PrescribedFlowRate(flow_rate=1e18, species=H2)],
+            )
+    """
+
+    def __init__(self, flow_rate: float | Callable, species=None):
+        super().__init__(species=species)
+        self.flow_rate = Value(flow_rate)
+
+    @property
+    def _values(self) -> list[Value]:
+        return [self.flow_rate]
+
+    def molar_flow_rate(self, gas_species, enclosure):
+        return self.flow_rate.fenics_object
+
+
+class EnclosureConnection(OpeningBase):
+    """An opening connecting two enclosures, coupling their pressures.
+
+    The flow rate into the enclosure holding ``species[0]`` is
+    ``C * (P_1 - P_0) / (k * T)``, and the opposite for the other side.
+
+    The connection only needs to be declared in the ``openings`` of one of the two
+    enclosures: the mirrored term is added to the partner enclosure automatically when
+    the problem is initialised.
+
+    Args:
+        conductance: the conductance of the connection (m3/s). Can be a callable of
+            time.
+        species: a tuple of the two gas species being connected, one in each enclosure
+
+    Examples:
+
+        .. testsetup:: EnclosureConnection
+
+            from festim import Enclosure, EnclosureConnection, GasSpecies
+
+        .. testcode:: EnclosureConnection
+
+            H2_a = GasSpecies(name="H2", initial_pressure=1e5)
+            H2_b = GasSpecies(name="H2", initial_pressure=0)
+            connection = EnclosureConnection(conductance=1e-4, species=(H2_a, H2_b))
+            enclosure_a = Enclosure(
+                volume=1e-3, species=[H2_a], temperature=500, openings=[connection]
+            )
+            enclosure_b = Enclosure(volume=2e-3, species=[H2_b], temperature=500)
+    """
+
+    def __init__(self, conductance: float | Callable, species):
+        if not isinstance(species, list | tuple) or len(species) != 2:
+            raise ValueError(
+                "EnclosureConnection needs exactly two gas species, one in each "
+                "connected enclosure, eg. species=(H2_a, H2_b)"
+            )
+        super().__init__(species=list(species))
+        self.conductance = Value(conductance)
+
+    @property
+    def _values(self) -> list[Value]:
+        return [self.conductance]
+
+    def _partner(self, gas_species):
+        """The gas species on the other side of the connection."""
+        if gas_species is self.species[0]:
+            return self.species[1]
+        elif gas_species is self.species[1]:
+            return self.species[0]
+        raise ValueError(f"{gas_species} is not connected by {self}")
+
+    def molar_flow_rate(self, gas_species, enclosure):
+        other = self._partner(gas_species)
+        conductance = self.conductance.fenics_object
+        return (
+            conductance
+            * (other.solution - gas_species.solution)
+            / enclosure.thermal_energy
+        )

--- a/src/festim/exports/__init__.py
+++ b/src/festim/exports/__init__.py
@@ -2,6 +2,7 @@ from .average_surface import AverageSurface
 from .average_volume import AverageVolume
 from .custom_quantity import CustomQuantity
 from .derived_quantity import DerivedQuantity
+from .gas_pressure import GasPressure
 from .maximum_surface import MaximumSurface
 from .maximum_volume import MaximumVolume
 from .minimum_surface import MinimumSurface
@@ -28,6 +29,7 @@ __all__ = [
     "CustomQuantity",
     "DerivedQuantity",
     "ExportBaseClass",
+    "GasPressure",
     "MaximumSurface",
     "MaximumVolume",
     "MinimumSurface",

--- a/src/festim/exports/gas_pressure.py
+++ b/src/festim/exports/gas_pressure.py
@@ -1,0 +1,56 @@
+from festim.enclosure.gas_species import GasSpecies
+from festim.exports.derived_quantity import DerivedQuantity
+
+
+class GasPressure(DerivedQuantity):
+    """Exports the partial pressure of a gas species in an enclosure over time.
+
+    Args:
+        field: the gas species to export the pressure of
+        filename: name of the file to which the pressure is exported
+
+    Attributes:
+        field: the gas species to export the pressure of
+        filename: name of the file to which the pressure is exported
+        t: list of time values
+        data: list of pressure values (Pa)
+        value: the pressure at the last computed timestep (Pa)
+
+    Examples:
+
+        .. testsetup:: GasPressure
+
+            import festim as F
+
+        .. testcode:: GasPressure
+
+            H2 = F.GasSpecies(name="H2", initial_pressure=1e5)
+            my_enclosure = F.Enclosure(volume=1e-3, species=[H2], temperature=500)
+            my_export = F.GasPressure(field=H2, filename="pressure.csv")
+    """
+
+    def __init__(self, field: GasSpecies, filename: str | None = None) -> None:
+        super().__init__(filename=filename)
+        self.field = field
+        self.value = None
+
+    @property
+    def field(self) -> GasSpecies:
+        return self._field
+
+    @field.setter
+    def field(self, value):
+        if not isinstance(value, GasSpecies):
+            raise TypeError(f"field must be a festim.GasSpecies, got {type(value)}")
+        self._field = value
+
+    @property
+    def title(self) -> str:
+        enclosure = self.field.enclosure
+        suffix = f" ({enclosure.name})" if enclosure and enclosure.name else ""
+        return f"{self.field.name} pressure{suffix} (Pa)"
+
+    def compute(self):
+        """Computes the pressure of the gas species and appends it to ``data``."""
+        self.value = self.field.value
+        self.data.append(self.value)

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -1658,6 +1658,23 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
 
         mesh_dim = self.mesh.mesh.topology.dim
         all_gas_species = self.gas_species
+
+        # A GasSpecies carries exactly one pressure unknown and one backref to its
+        # enclosure, so it cannot belong to two of them. Sharing one silently corrupts
+        # the model (the backref points to the last enclosure, and the species gets two
+        # pressure blocks sharing one solution). Catch it explicitly.
+        seen = set()
+        for gas_species in all_gas_species:
+            if id(gas_species) in seen:
+                enclosures = [e for e in self.enclosures if gas_species in e.species]
+                names = ", ".join(str(e) for e in enclosures)
+                raise ValueError(
+                    f"{gas_species} belongs to more than one enclosure ({names}). A "
+                    "GasSpecies has a single partial pressure and can live in only one "
+                    "enclosure; create a separate GasSpecies for each enclosure."
+                )
+            seen.add(id(gas_species))
+
         for enclosure in self.enclosures:
             for surface in enclosure.surfaces:
                 if surface not in self.surface_subdomains:

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -9,6 +9,7 @@ import dolfinx
 import io4dolfinx
 import numpy as np
 import numpy.typing as npt
+import scifem
 import tqdm.auto
 import ufl
 from dolfinx import fem
@@ -31,6 +32,11 @@ from festim import (
     subdomain as _subdomain,
 )
 from festim.advection import AdvectionTerm
+from festim.enclosure._utils import check_dolfinx_version_for_enclosures
+from festim.enclosure.enclosure import Enclosure as _Enclosure
+from festim.enclosure.gas_species import GasSpecies as _GasSpecies
+from festim.enclosure.gas_species import create_real_function_space
+from festim.enclosure.openings import EnclosureConnection
 from festim.helpers import (
     KSPMonitor,
     SnesMonitor,
@@ -304,6 +310,12 @@ class HydrogenTransportProblem(problem.ProblemBase):
         self._element_immobile = value
 
     def initialise(self):
+        if getattr(self, "enclosures", None):
+            raise NotImplementedError(
+                f"Gas enclosures are not supported by {self.__class__.__name__}. Use "
+                "festim.HydrogenTransportProblemDiscontinuous instead, which solves a "
+                "blocked system the enclosure pressures can be added to."
+            )
         self.create_species_from_traps()
         self.define_function_spaces(element_degree=self.settings.element_degree)
         self.define_meshtags_and_measures()
@@ -1115,6 +1127,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         exports=None,
         traps=None,
         interfaces: list[_subdomain.Interface] | None = None,
+        enclosures: list[_Enclosure] | None = None,
         petsc_options: dict | None = None,
     ):
         """Class for a multi-material hydrogen transport problem For other arguments see
@@ -1123,6 +1136,8 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         Args:
             interfaces (list, optional): list of interfaces (``festim.Interface``
                 objects). Defaults to None.
+            enclosures (list, optional): list of gas enclosures (``festim.Enclosure``
+                objects). Requires dolfinx >= 0.11. Defaults to None.
             surface_to_volume (dict, optional): correspondance dictionary linking
                 each ``festim.SurfaceSubdomain`` objects to a ``festim.VolumeSubdomain``
                 object). Defaults to None.
@@ -1152,9 +1167,30 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
             petsc_options=petsc_options,
         )
         self.interfaces = interfaces or []
+        self.enclosures = enclosures or []
         self.surface_to_volume = {}
         self.subdomain_to_species = {}  # maps subdomain to species defined in it
         self.subdomain_to_V_CG1 = {}
+        self._total_volume = None
+
+    @property
+    def enclosures(self) -> list[_Enclosure]:
+        return self._enclosures
+
+    @enclosures.setter
+    def enclosures(self, value):
+        value = value or []
+        if value:
+            # fail early and with a clear message rather than deep inside the
+            # function space creation
+            check_dolfinx_version_for_enclosures()
+        self._enclosures = value
+
+    @property
+    def gas_species(self):
+        """All the gas species across all the enclosures. Defines the ordering of the
+        pressure blocks in the solver."""
+        return [gs for enclosure in self.enclosures for gs in enclosure.species]
 
     @property
     def method_interface(self):
@@ -1233,6 +1269,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
             interface.parent_mesh = self.mesh.mesh
 
         self.create_species_from_traps()
+        self.link_enclosures()
 
         self.t = fem.Constant(self.mesh.mesh, 0.0)
         if self.settings.transient:
@@ -1246,6 +1283,8 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
 
         for subdomain in self.volume_subdomains:
             self.define_function_spaces(subdomain)
+
+        self.define_enclosure_function_spaces()
 
         # create global DG function spaces of degree 0 and 1
         element_DG0 = basix.ufl.element(
@@ -1264,6 +1303,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         self.V_DG_1 = fem.functionspace(self.mesh.mesh, element_DG1)
 
         self.define_temperature()
+        self.convert_enclosure_input_values_to_fenics_objects()
         self.convert_source_input_values_to_fenics_objects()
         self.convert_advection_term_to_fenics_objects()
         self.define_boundary_conditions()
@@ -1273,6 +1313,9 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         for subdomain in self.volume_subdomains:
             self.create_subdomain_formulation(subdomain)
             subdomain.u.name = f"u_{subdomain.id}"
+
+        for gas_species in self.gas_species:
+            self.create_enclosure_formulation(gas_species)
 
         self.create_formulation()
         self.create_solver()
@@ -1382,6 +1425,13 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                 condition.volume.u_n.sub(idx).interpolate(
                     condition.expr_fenics, cells1=entities
                 )
+
+        for gas_species in self.gas_species:
+            gas_species.prev_solution.x.array[:] = gas_species.initial_pressure
+            # also seed the current solution: it is the initial guess of the first
+            # Newton solve, and some coupling laws (eg. Sieverts' sqrt(P)) are not
+            # differentiable at P=0
+            gas_species.solution.x.array[:] = gas_species.initial_pressure
 
     def define_function_spaces(
         self, subdomain: _subdomain.VolumeSubdomain, element_degree=1
@@ -1590,6 +1640,208 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         # store the form in the subdomain object
         subdomain.F = form
 
+    def link_enclosures(self):
+        """Validates the enclosures and resolves the links between them, their surfaces
+        and the boundary conditions coupled to them.
+
+        This runs before any fenics object is created.
+        """
+        if not self.enclosures:
+            return
+
+        if self.mesh.coordinate_system != CoordinateSystem.CARTESIAN:
+            raise NotImplementedError(
+                "Enclosures are only supported for cartesian coordinate systems, not "
+                f"{self.mesh.coordinate_system!s}. The surface integrals of the "
+                "pressure balance would need the appropriate metric factors."
+            )
+
+        mesh_dim = self.mesh.mesh.topology.dim
+        all_gas_species = self.gas_species
+        for enclosure in self.enclosures:
+            for surface in enclosure.surfaces:
+                if surface not in self.surface_subdomains:
+                    raise ValueError(
+                        f"Surface {surface.id} of {enclosure} is not in the subdomains "
+                        "of the model"
+                    )
+            # The flux through a surface is per unit area, so turning it into a number
+            # of particles per second needs the physical area of that surface. Only a 3D
+            # mesh measures that area itself: in 1D a surface is a point and in 2D a
+            # line, so the missing extent has to come from the user.
+            if enclosure.surfaces and not enclosure.areas_given and mesh_dim < 3:
+                missing = (
+                    "area (m2) of the surface"
+                    if mesh_dim == 1
+                    else ("out-of-plane depth (m) of the model")
+                )
+                raise ValueError(
+                    f"{enclosure} is attached to surfaces on a {mesh_dim}D mesh, so "
+                    "the areas of those surfaces cannot be taken from the mesh and "
+                    "must be given: pass surfaces as a dict mapping each surface to "
+                    f"the {missing}, eg. surfaces={{my_surface: 1e-4}}."
+                )
+            # a connection only needs declaring on one side: mirror it onto the partner
+            for opening in enclosure.openings:
+                if not isinstance(opening, EnclosureConnection):
+                    continue
+                for gas_species in opening.species:
+                    if gas_species not in all_gas_species:
+                        raise ValueError(
+                            f"{gas_species} is connected by an EnclosureConnection but "
+                            "does not belong to any enclosure of the model"
+                        )
+                    partner = gas_species.enclosure
+                    if opening not in partner.openings:
+                        partner.openings.append(opening)
+
+        # let the boundary conditions know which gas species they are coupled to
+        for bc in self._unpacked_bcs:
+            pressure = getattr(bc, "gas_pressure", None)
+            if pressure is None:
+                pressure = getattr(bc, "pressure", None)
+            if isinstance(pressure, _GasSpecies):
+                if pressure not in all_gas_species:
+                    raise ValueError(
+                        f"{bc} is coupled to {pressure}, which does not belong to any "
+                        "enclosure of the model"
+                    )
+                bc._gas_species = pressure
+
+    def define_enclosure_function_spaces(self):
+        """Creates a real function space, a solution and a previous solution for each
+        gas species of each enclosure.
+
+        The real function spaces live on the parent mesh: every form of the blocked
+        system is integrated over the parent mesh, with submesh functions pulled in via
+        ``entity_maps``.
+        """
+        if not self.enclosures:
+            return
+
+        mesh = self.mesh.mesh
+        for gas_species in self.gas_species:
+            V = create_real_function_space(mesh)
+            gas_species.function_space = V
+            gas_species.solution = fem.Function(V)
+            gas_species.prev_solution = fem.Function(V)
+            gas_species.test_function = ufl.TestFunction(V)
+            gas_species.solution.name = f"P_{gas_species.name}"
+
+        # The pressure balance is a 0D equation, but its test function is a single
+        # global constant, so every term of it must be written as an integral. The
+        # scalar terms are therefore spread over a region and divided by the measure of
+        # that region, which recovers the bare scalar: for constant f,
+        # int_R f/|R| q dR == f. The region is the enclosure's contact surfaces where it
+        # has some (that is where the physics is, and it keeps assembly on the boundary
+        # facets), and the whole domain for an enclosure that only has openings.
+        one = fem.Constant(mesh, 1.0)
+        self._total_volume = scifem.assemble_scalar(fem.form(one * self.dx))
+        for enclosure in self.enclosures:
+            enclosure._contact_measure = sum(
+                scifem.assemble_scalar(fem.form(one * self.ds(surface.id)))
+                for surface in enclosure.surfaces
+            )
+
+    def convert_enclosure_input_values_to_fenics_objects(self):
+        """Converts the user input values of the enclosures and their openings to fenics
+        objects."""
+        for enclosure in self.enclosures:
+            # opening parameters are scalars, so any function space on the parent mesh
+            # will do here
+            enclosure.convert_input_values_to_fenics_objects(
+                function_space=self.V_DG_0, t=self.t
+            )
+
+    def gas_production_rates(self, surface, gas_species):
+        """The rates at which particles of a gas species are produced at a surface, in
+        particles/s/m2, positive when entering the gas.
+
+        Args:
+            surface: the surface subdomain
+            gas_species: the gas species
+
+        Yields:
+            ufl expressions for each contribution at that surface
+        """
+        for bc in self.boundary_conditions:
+            if bc.subdomain is not surface:
+                continue
+            if (
+                isinstance(bc, boundary_conditions.SurfaceReactionBC)
+                and bc.gas_pressure is gas_species
+            ):
+                # value_fenics is the rate at which the solid gains particles, so the
+                # gas loses them. Taken once per reaction, not once per reactant: the
+                # partials share the same expression and differ only in which species
+                # of the solid they apply to.
+                yield -bc.flux_bcs[0].value_fenics
+
+    def create_enclosure_formulation(self, gas_species):
+        """Creates the variational formulation of the pressure balance of a gas species
+        and stores it in ``gas_species.F``.
+
+        Args:
+            gas_species: the gas species
+        """
+        enclosure = gas_species.enclosure
+        P = gas_species.solution
+        P_n = gas_species.prev_solution
+        q = gas_species.test_function
+        kT = enclosure.thermal_energy
+
+        # see define_enclosure_function_spaces: a scalar term of this 0D equation is
+        # spread over a region and divided by the measure of that region
+        if enclosure.surfaces:
+            regions = [self.ds(surface.id) for surface in enclosure.surfaces]
+            measure_of_regions = enclosure._contact_measure
+        else:
+            regions = [self.dx]
+            measure_of_regions = self._total_volume
+
+        def as_integral(scalar):
+            return sum(scalar / measure_of_regions * q * region for region in regions)
+
+        form = 0
+
+        if self.settings.transient:
+            form += as_integral((P - P_n) / self.dt)
+
+        for surface, area in enclosure.surfaces.items():
+            for rate in self.gas_production_rates(surface, gas_species):
+                # rate is per unit area, so the physical area of the surface turns it
+                # into particles per second. This integral is already over the surface
+                # and must not be normalised.
+                form -= kT / enclosure.volume * area * rate * q * self.ds(surface.id)
+
+        for opening in enclosure.openings:
+            if not opening.applies_to(gas_species):
+                continue
+            flow_rate = opening.molar_flow_rate(gas_species, enclosure)
+            form -= as_integral(kT / enclosure.volume * flow_rate)
+
+        # The pressure is only determined if it appears in its own balance. In a
+        # transient problem the time derivative always puts it there. In steady state it
+        # only appears through something that depends on it: a surface reaction coupled
+        # to this species, or a pressure-dependent opening (Pump, Reservoir,
+        # EnclosureConnection). A PrescribedFlowRate alone does not, and neither does an
+        # enclosure with no coupling at all.
+        determined = isinstance(
+            form, ufl.Form
+        ) and P in ufl.algorithms.extract_coefficients(form)
+        if not determined:
+            raise ValueError(
+                f"The pressure of {gas_species} in {enclosure} is undetermined: it "
+                "does not appear in its own mass balance, so the problem has no unique "
+                "solution. This happens in steady state when nothing in the balance "
+                "depends on the pressure. Give the enclosure a surface with a "
+                "SurfaceReactionBC coupled to this species, or a pressure-dependent "
+                "opening (Pump, Reservoir or EnclosureConnection), or run a transient "
+                "simulation."
+            )
+
+        gas_species.F = form
+
     def create_formulation(self):
         """Takes all the formulations for each subdomain and adds the interface
         conditions.
@@ -1621,20 +1873,29 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
             subdomain_0.F += F_0
             subdomain_1.F += F_1
 
+        # the unknowns of the blocked system: one block per volume subdomain, plus one
+        # block per gas species (the pressure of that species in its enclosure)
+        all_forms = [subdomain.F for subdomain in self.volume_subdomains] + [
+            gas_species.F for gas_species in self.gas_species
+        ]
+        all_unknowns = [subdomain.u for subdomain in self.volume_subdomains] + [
+            gas_species.solution for gas_species in self.gas_species
+        ]
+
         J = []
         # this is the symbolic differentiation of the Jacobian
-        for subdomain1 in self.volume_subdomains:
+        for form in all_forms:
             jac = []
-            for subdomain2 in self.volume_subdomains:
+            for unknown in all_unknowns:
                 jac.append(
-                    ufl.derivative(subdomain1.F, subdomain2.u),
+                    ufl.derivative(form, unknown),
                 )
             J.append(jac)
         # compile jacobian (J) and residual (F)
         entity_maps = [sd.cell_map for sd in self.volume_subdomains]
 
         self.forms = dolfinx.fem.form(
-            [subdomain.F for subdomain in self.volume_subdomains],
+            all_forms,
             entity_maps=entity_maps,
             jit_options={
                 "cffi_extra_compile_args": ["-O3", "-march=native"],
@@ -1657,7 +1918,8 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
 
         self.solver = NonlinearProblem(
             self.forms,
-            [subdomain.u for subdomain in self.volume_subdomains],
+            [subdomain.u for subdomain in self.volume_subdomains]
+            + [gas_species.solution for gas_species in self.gas_species],
             bcs=self.bc_forms,
             J=self.J,
             petsc_options=petsc_options,
@@ -1882,6 +2144,9 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                 entity_maps = [sd.cell_map for sd in self.volume_subdomains]
                 export.compute(measure, entity_maps=entity_maps)
 
+            elif isinstance(export, exports.GasPressure):
+                export.compute()
+
             if isinstance(export, exports.DerivedQuantity):
                 # update export data
                 export.t.append(float(self.t))
@@ -1917,6 +2182,9 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
     def update_time_dependent_values(self):
         super().update_time_dependent_values()
 
+        for enclosure in self.enclosures:
+            enclosure.update_time_dependent_values(t=float(self.t))
+
         # update sub_T if temperature is given as a function
         if self.temperature_time_dependent:
             if isinstance(self.temperature_fenics, fem.Function):
@@ -1951,6 +2219,8 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         # update previous solution
         for subdomain in self.volume_subdomains:
             subdomain.u_n.x.array[:] = subdomain.u.x.array[:]
+        for gas_species in self.gas_species:
+            gas_species.prev_solution.x.array[:] = gas_species.solution.x.array[:]
 
         # adapt stepsize
         if self.settings.stepsize.adaptive:

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -13,6 +13,7 @@ import scifem
 import tqdm.auto
 import ufl
 from dolfinx import fem
+from dolfinx.fem.petsc import NonlinearProblem
 from packaging.version import Version
 
 from festim import (
@@ -1723,6 +1724,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                         f"{bc} is coupled to {pressure}, which does not belong to any "
                         "enclosure of the model"
                     )
+                # NOTE: is this still needed?
                 bc._gas_species = pressure
 
     def define_enclosure_function_spaces(self):
@@ -1737,6 +1739,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
             return
 
         mesh = self.mesh.mesh
+        # NOTE: we could define the Gas Species real element on a submesh
         for gas_species in self.gas_species:
             V = create_real_function_space(mesh)
             gas_species.function_space = V
@@ -1770,7 +1773,8 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                 function_space=self.V_DG_0, t=self.t
             )
 
-    def gas_production_rates(self, surface, gas_species):
+    # NOTE: what are the alternative naming for "production rate"?
+    def gas_production_rates(self, surface, gas_species: _GasSpecies):
         """The rates at which particles of a gas species are produced at a surface, in
         particles/s/m2, positive when entering the gas.
 
@@ -1794,7 +1798,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                 # of the solid they apply to.
                 yield -bc.flux_bcs[0].value_fenics
 
-    def create_enclosure_formulation(self, gas_species):
+    def create_enclosure_formulation(self, gas_species: _GasSpecies):
         """Creates the variational formulation of the pressure balance of a gas species
         and stores it in ``gas_species.F``.
 
@@ -1929,7 +1933,6 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         )
 
     def create_solver(self):
-        from dolfinx.fem.petsc import NonlinearProblem
 
         petsc_options = self.get_petsc_options()
 

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -1739,7 +1739,13 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
             return
 
         mesh = self.mesh.mesh
-        # NOTE: we could define the Gas Species real element on a submesh
+        # The real space is defined on the parent mesh. It could instead live on a
+        # submesh of the contact facets (as in the scifem demo), but that is a
+        # code-structure choice, not a performance one: a real space has a single
+        # global dof either way, and the pressure's Jacobian coupling is already
+        # surface-local (its sparsity comes from the ds integration measure, not from
+        # the mesh the space is defined on). A submesh would only add entity_map
+        # bookkeeping.
         for gas_species in self.gas_species:
             V = create_real_function_space(mesh)
             gas_species.function_space = V

--- a/test/markers.py
+++ b/test/markers.py
@@ -1,0 +1,25 @@
+"""Pytest markers for features that depend on the installed dolfinx version."""
+
+import dolfinx
+import pytest
+from packaging.version import Version
+
+from festim.enclosure._utils import MINIMUM_DOLFINX_VERSION
+
+_supports_real_spaces = Version(dolfinx.__version__) >= Version(MINIMUM_DOLFINX_VERSION)
+
+requires_dolfinx_011 = pytest.mark.skipif(
+    not _supports_real_spaces,
+    reason=(
+        f"Gas enclosures require dolfinx >= {MINIMUM_DOLFINX_VERSION} (real function "
+        f"spaces), found {dolfinx.__version__}"
+    ),
+)
+
+requires_dolfinx_010 = pytest.mark.skipif(
+    _supports_real_spaces,
+    reason=(
+        f"Tests the rejection path for dolfinx < {MINIMUM_DOLFINX_VERSION}, found "
+        f"{dolfinx.__version__}"
+    ),
+)

--- a/test/system_tests/test_enclosures.py
+++ b/test/system_tests/test_enclosures.py
@@ -264,6 +264,96 @@ def test_closed_enclosure_conserves_particles(length, area):
     assert H2.value < P0
 
 
+def test_enclosure_on_2d_mesh_conserves_particles():
+    """A closed enclosure on a 2D mesh, facing one wall through a surface reaction.
+
+    This is the 2D counterpart of the conservation test. It matters because a 2D contact
+    surface is a line with real extent (unlike 1D, where a facet is a point of measure
+    1), so both the domain-measure normalisation and the out-of-plane depth are
+    genuinely non-trivial here.
+
+    The wall has length ``Ly = 2`` (so ``|Gamma| = 2``, not 1), and the enclosure area
+    is the out-of-plane depth ``0.5`` (not 1). Conservation is
+    ``depth * int(c) dx + 2*P*V/(k*T)``. Parameters are kept well scaled so Newton
+    converges from the cold start (a stiff cold start is a solver issue independent of
+    the enclosure; see the discontinuous solver's behaviour with a zero initial field).
+    """
+    Lx, Ly, depth = 1.0, 2.0, 0.5
+    V_enc, T = 3.0, 500.0
+    c0 = 1.0
+    k_d0, k_r0 = 1e-3, 1e-3
+    dt, final_time = 0.5, 200.0
+
+    mesh = dolfinx.mesh.create_rectangle(
+        MPI.COMM_WORLD,
+        [np.array([0.0, 0.0]), np.array([Lx, Ly])],
+        [24, 24],
+        dolfinx.mesh.CellType.triangle,
+    )
+    my_model = F.HydrogenTransportProblemDiscontinuous()
+    my_model.mesh = F.Mesh(mesh=mesh)
+    material = F.Material(name="mat", D_0=1.0, E_D=0.0)
+    volume = F.VolumeSubdomain(id=1, material=material)
+    right = F.SurfaceSubdomain(id=2, locator=lambda x: np.isclose(x[0], Lx))
+    my_model.subdomains = [volume, right]
+    H = F.Species("H", subdomains=[volume])
+    my_model.species = [H]
+    my_model.temperature = T
+
+    H2 = F.GasSpecies(name="H2", initial_pressure=0.0)
+    my_model.enclosures = [
+        F.Enclosure(volume=V_enc, species=[H2], temperature=T, surfaces={right: depth})
+    ]
+    my_model.boundary_conditions = [
+        F.SurfaceReactionBC(
+            reactant=[H, H],
+            gas_pressure=H2,
+            k_r0=k_r0,
+            E_kr=0.0,
+            k_d0=k_d0,
+            E_kd=0.0,
+            subdomain=right,
+        )
+    ]
+    my_model.initial_conditions = [
+        F.InitialConcentration(value=c0, species=H, volume=volume)
+    ]
+    my_model.settings = F.Settings(
+        atol=1e-10,
+        rtol=1e-10,
+        transient=True,
+        final_time=final_time,
+        stepsize=F.Stepsize(dt),
+    )
+    my_model.show_progress_bar = False
+    my_model.initialise()
+
+    # |Gamma| is the length of the wall, not 1
+    assert my_model.enclosures[0]._contact_measure == pytest.approx(Ly)
+
+    def total_hydrogen_atoms():
+        c = H.subdomain_to_post_processing_solution[volume]
+        in_solid = depth * mesh.comm.allreduce(
+            dolfinx.fem.assemble_scalar(
+                dolfinx.fem.form(c * ufl.dx(domain=volume.submesh))
+            ),
+            op=MPI.SUM,
+        )
+        in_gas = 2.0 * H2.value * V_enc / (F.k_B_SI * T)
+        return in_solid + in_gas
+
+    # the slab starts uniformly loaded and the gas empty
+    initial_inventory = depth * c0 * (Lx * Ly)
+
+    while my_model.t.value < final_time:
+        my_model.iterate()
+        assert total_hydrogen_atoms() == pytest.approx(initial_inventory, rel=1e-10)
+
+    # a meaningful fraction must have crossed into the gas, else the test is vacuous
+    in_gas = 2.0 * H2.value * V_enc / (F.k_B_SI * T)
+    assert in_gas / initial_inventory > 0.1
+
+
 def test_steady_state_closed_enclosure_reaches_surface_equilibrium():
     """A closed enclosure at steady state is determined by its contact surface alone.
 

--- a/test/system_tests/test_enclosures.py
+++ b/test/system_tests/test_enclosures.py
@@ -1,0 +1,324 @@
+from mpi4py import MPI
+
+import dolfinx
+import pytest
+import ufl
+
+import festim as F
+
+from ..markers import requires_dolfinx_011
+
+pytestmark = requires_dolfinx_011
+
+
+def make_model(n=16, enclosures=None, final_time=20.0, dt=1.0):
+    """A 1D slab with a single material and no boundary conditions, to which enclosures
+    can be attached. The species field is decoupled unless a coupling BC is given."""
+    mesh = dolfinx.mesh.create_unit_interval(MPI.COMM_WORLD, n)
+    my_model = F.HydrogenTransportProblemDiscontinuous()
+    my_model.mesh = F.Mesh(mesh=mesh)
+
+    material = F.Material(name="mat", D_0=1e-9, E_D=0.0)
+    volume = F.VolumeSubdomain1D(id=1, borders=[0.0, 1.0], material=material)
+    left = F.SurfaceSubdomain1D(id=1, x=0.0)
+    right = F.SurfaceSubdomain1D(id=2, x=1.0)
+    my_model.subdomains = [volume, left, right]
+
+    H = F.Species("H", subdomains=[volume])
+    my_model.species = [H]
+    my_model.temperature = 500.0
+    my_model.enclosures = enclosures or []
+    my_model.settings = F.Settings(
+        atol=1e-10,
+        rtol=1e-10,
+        transient=True,
+        final_time=final_time,
+        stepsize=F.Stepsize(dt),
+    )
+    my_model.show_progress_bar = False
+    return my_model, volume, left, right, H
+
+
+def backward_euler_decay(P0, rate, dt, nsteps):
+    """The exact solution of the backward-Euler discretisation of dP/dt = -rate*P.
+
+    Asserting against this rather than exp(-rate*t) isolates the enclosure coupling
+    from the time discretisation error.
+    """
+    return P0 * (1 + rate * dt) ** (-nsteps)
+
+
+@pytest.mark.parametrize("n", [8, 16, 32, 128])
+def test_pump_exponential_decay(n):
+    """A closed enclosure pumped at speed S decays as P(t) = P0*exp(-S*t/V).
+
+    Parameterised over mesh sizes: the pressure lives in a real function space, whose
+    single global dof is independent of the mesh, so the answer must be too.
+    """
+    P0, S, V = 1e5, 1e-4, 1e-3
+    dt, final_time = 1.0, 20.0
+
+    H2 = F.GasSpecies(name="H2", initial_pressure=P0)
+    enclosure = F.Enclosure(
+        volume=V, species=[H2], temperature=500.0, openings=[F.Pump(pumping_speed=S)]
+    )
+    my_model, *_ = make_model(n=n, enclosures=[enclosure], final_time=final_time, dt=dt)
+    my_model.initialise()
+    my_model.run()
+
+    nsteps = round(final_time / dt)
+    expected = backward_euler_decay(P0, S / V, dt, nsteps)
+    assert H2.value == pytest.approx(expected, rel=1e-8)
+
+
+def test_reservoir_relaxes_to_external_pressure():
+    """An enclosure connected to a reservoir relaxes as
+    P(t) = P_ext + (P0 - P_ext)*exp(-C*t/V)."""
+    P0, P_ext, C, V = 1e5, 1e3, 1e-4, 1e-3
+    dt, final_time = 1.0, 20.0
+
+    H2 = F.GasSpecies(name="H2", initial_pressure=P0)
+    enclosure = F.Enclosure(
+        volume=V,
+        species=[H2],
+        temperature=500.0,
+        openings=[F.Reservoir(conductance=C, pressure=P_ext)],
+    )
+    my_model, *_ = make_model(enclosures=[enclosure], final_time=final_time, dt=dt)
+    my_model.initialise()
+    my_model.run()
+
+    nsteps = round(final_time / dt)
+    # same backward-Euler solution, shifted by the reservoir pressure
+    expected = P_ext + backward_euler_decay(P0 - P_ext, C / V, dt, nsteps)
+    assert H2.value == pytest.approx(expected, rel=1e-8)
+
+
+def test_prescribed_flow_rate_is_linear():
+    """A constant flow rate Q into a closed enclosure gives P(t) = P0 + Q*k*T*t/V,
+    which backward Euler integrates exactly."""
+    P0, Q, V, T = 1e3, 1e18, 1e-3, 500.0
+    final_time = 20.0
+
+    H2 = F.GasSpecies(name="H2", initial_pressure=P0)
+    enclosure = F.Enclosure(
+        volume=V,
+        species=[H2],
+        temperature=T,
+        openings=[F.PrescribedFlowRate(flow_rate=Q)],
+    )
+    my_model, *_ = make_model(enclosures=[enclosure], final_time=final_time, dt=1.0)
+    my_model.initialise()
+    my_model.run()
+
+    expected = P0 + Q * F.k_B_SI * T * final_time / V
+    assert H2.value == pytest.approx(expected, rel=1e-8)
+
+
+def test_time_dependent_pumping_speed():
+    """A pumping speed given as a callable of t is updated during the time loop."""
+    P0, V = 1e5, 1e-3
+    dt, final_time = 1.0, 5.0
+
+    H2 = F.GasSpecies(name="H2", initial_pressure=P0)
+    enclosure = F.Enclosure(
+        volume=V,
+        species=[H2],
+        temperature=500.0,
+        openings=[F.Pump(pumping_speed=lambda t: 1e-5 * t)],
+    )
+    my_model, *_ = make_model(enclosures=[enclosure], final_time=final_time, dt=dt)
+    my_model.initialise()
+    my_model.run()
+
+    # backward Euler with a speed re-evaluated at each new time
+    expected = P0
+    for step in range(1, round(final_time / dt) + 1):
+        expected /= 1 + (1e-5 * step * dt) / V * dt
+    assert H2.value == pytest.approx(expected, rel=1e-8)
+
+
+def test_enclosure_connection_two_boxes():
+    """Two connected enclosures equalise: their difference decays as
+    exp(-C*(1/V1 + 1/V2)*t) and the volume-weighted mean is conserved.
+
+    This exercises the off-diagonal pressure-pressure Jacobian block.
+    """
+    P1_0, P2_0 = 1e5, 0.0
+    V1, V2, C = 1e-3, 2e-3, 1e-4
+    dt, final_time = 1.0, 20.0
+
+    H2_a = F.GasSpecies(name="H2_a", initial_pressure=P1_0)
+    H2_b = F.GasSpecies(name="H2_b", initial_pressure=P2_0)
+    connection = F.EnclosureConnection(conductance=C, species=(H2_a, H2_b))
+    enclosure_a = F.Enclosure(
+        volume=V1, species=[H2_a], temperature=500.0, openings=[connection]
+    )
+    # deliberately declared only on side a: the mirror is added automatically
+    enclosure_b = F.Enclosure(volume=V2, species=[H2_b], temperature=500.0)
+
+    my_model, *_ = make_model(
+        enclosures=[enclosure_a, enclosure_b], final_time=final_time, dt=dt
+    )
+    my_model.initialise()
+
+    # the pressure-pressure coupling block must exist
+    nb_volumes = len(my_model.volume_subdomains)
+    assert my_model.J[nb_volumes][nb_volumes + 1] is not None
+
+    my_model.run()
+
+    P1, P2 = H2_a.value, H2_b.value
+
+    nsteps = round(final_time / dt)
+    # the difference obeys d(P1-P2)/dt = -C*(1/V1 + 1/V2)*(P1-P2)
+    expected_diff = backward_euler_decay(P1_0 - P2_0, C * (1 / V1 + 1 / V2), dt, nsteps)
+    assert P1 - P2 == pytest.approx(expected_diff, rel=1e-8)
+
+    # particles are conserved, so the volume-weighted mean does not move
+    assert P1 * V1 + P2 * V2 == pytest.approx(P1_0 * V1 + P2_0 * V2, rel=1e-8)
+
+
+@pytest.mark.parametrize("length", [1.0, 2.0])
+def test_closed_enclosure_conserves_particles(length):
+    """A closed enclosure exchanging with a slab through a surface reaction 2H <-> H2
+    must conserve hydrogen atoms exactly at every timestep.
+
+    Nothing leaves the system, so ``int(c_H) dx + 2*P*V/(k*T)`` is invariant. This is
+    exact (to Newton tolerance) rather than approximate, because the same UFL
+    expression drives both the species residual and the pressure residual. It is the
+    sharpest check available on the sign conventions and on the factor of 2 from the
+    diatomic stoichiometry.
+
+    ``length`` is parameterised, and 1.0 is deliberately not the only case: the pressure
+    test function is a global constant, so a volume term assembles to ``|Omega| * f``
+    while a surface term does not pick up that factor. The residual divides its volume
+    terms by ``|Omega|`` to compensate, and on a unit domain that division is a no-op --
+    so a unit-only test passes even if the normalisation is missing entirely.
+    """
+    V_enc, T, P0 = 1e-3, 500.0, 1e5
+    k_d0, k_r0 = 1e15, 1e-25
+    dt, final_time = 5.0, 200.0
+
+    mesh = dolfinx.mesh.create_interval(MPI.COMM_WORLD, 40, [0.0, length])
+    my_model = F.HydrogenTransportProblemDiscontinuous()
+    my_model.mesh = F.Mesh(mesh=mesh)
+    material = F.Material(name="mat", D_0=1e-6, E_D=0.0)
+    volume = F.VolumeSubdomain1D(id=1, borders=[0.0, length], material=material)
+    left = F.SurfaceSubdomain1D(id=1, x=0.0)
+    right = F.SurfaceSubdomain1D(id=2, x=length)
+    my_model.subdomains = [volume, left, right]
+    H = F.Species("H", subdomains=[volume])
+    my_model.species = [H]
+    my_model.temperature = T
+
+    H2 = F.GasSpecies(name="H2", initial_pressure=P0)
+    my_model.enclosures = [
+        F.Enclosure(volume=V_enc, species=[H2], temperature=T, surfaces=[right])
+    ]
+    my_model.boundary_conditions = [
+        F.SurfaceReactionBC(
+            reactant=[H, H],
+            gas_pressure=H2,
+            k_r0=k_r0,
+            E_kr=0.0,
+            k_d0=k_d0,
+            E_kd=0.0,
+            subdomain=right,
+        )
+    ]
+    my_model.initial_conditions = [
+        F.InitialConcentration(value=0.0, species=H, volume=volume)
+    ]
+    my_model.settings = F.Settings(
+        atol=1e-8,
+        rtol=1e-10,
+        transient=True,
+        final_time=final_time,
+        stepsize=F.Stepsize(dt),
+    )
+    my_model.show_progress_bar = False
+    my_model.initialise()
+
+    def total_hydrogen_atoms():
+        c = H.subdomain_to_post_processing_solution[volume]
+        in_solid = mesh.comm.allreduce(
+            dolfinx.fem.assemble_scalar(dolfinx.fem.form(c * ufl.dx)), op=MPI.SUM
+        )
+        # 2 atoms per H2 molecule
+        in_gas = 2.0 * H2.value * V_enc / (F.k_B_SI * T)
+        return in_solid + in_gas
+
+    my_model.post_processing()
+    initial_inventory = total_hydrogen_atoms()
+
+    while my_model.t.value < final_time:
+        my_model.iterate()
+        assert total_hydrogen_atoms() == pytest.approx(initial_inventory, rel=1e-12)
+
+    # the gas must actually have been absorbed, otherwise the test is vacuous
+    assert H2.value < P0
+
+
+def test_steady_state_closed_enclosure_reaches_surface_equilibrium():
+    """A closed enclosure at steady state is determined by its contact surface alone.
+
+    Steady state forces zero net flux through the surface, so the surface reaction is at
+    equilibrium: kd*P = kr*c^2. With c fixed at the left of the slab and no other flux,
+    c is uniform, giving the analytic P = kr*c0^2/kd. No opening is needed.
+    """
+    T, c0 = 500.0, 1e20
+    k_d0, k_r0 = 1e15, 1e-25
+
+    mesh = dolfinx.mesh.create_unit_interval(MPI.COMM_WORLD, 20)
+    my_model = F.HydrogenTransportProblemDiscontinuous()
+    my_model.mesh = F.Mesh(mesh=mesh)
+    material = F.Material(name="mat", D_0=1e-6, E_D=0.0)
+    volume = F.VolumeSubdomain1D(id=1, borders=[0.0, 1.0], material=material)
+    left = F.SurfaceSubdomain1D(id=1, x=0.0)
+    right = F.SurfaceSubdomain1D(id=2, x=1.0)
+    my_model.subdomains = [volume, left, right]
+    H = F.Species("H", subdomains=[volume])
+    my_model.species = [H]
+    my_model.temperature = T
+
+    H2 = F.GasSpecies(name="H2", initial_pressure=1e5)
+    my_model.enclosures = [
+        F.Enclosure(volume=1e-3, species=[H2], temperature=T, surfaces=[right])
+    ]
+    my_model.boundary_conditions = [
+        F.FixedConcentrationBC(subdomain=left, value=c0, species=H),
+        F.SurfaceReactionBC(
+            reactant=[H, H],
+            gas_pressure=H2,
+            k_r0=k_r0,
+            E_kr=0.0,
+            k_d0=k_d0,
+            E_kd=0.0,
+            subdomain=right,
+        ),
+    ]
+    my_model.settings = F.Settings(atol=1e-8, rtol=1e-10, transient=False)
+    my_model.show_progress_bar = False
+    my_model.initialise()
+    my_model.run()
+
+    assert H2.value == pytest.approx(k_r0 * c0**2 / k_d0, rel=1e-8)
+
+
+def test_gas_pressure_export():
+    """The GasPressure export records the pressure over time."""
+    P0, S, V = 1e5, 1e-4, 1e-3
+    H2 = F.GasSpecies(name="H2", initial_pressure=P0)
+    enclosure = F.Enclosure(
+        volume=V, species=[H2], temperature=500.0, openings=[F.Pump(pumping_speed=S)]
+    )
+    my_model, *_ = make_model(enclosures=[enclosure], final_time=5.0, dt=1.0)
+    export = F.GasPressure(field=H2)
+    my_model.exports = [export]
+    my_model.initialise()
+    my_model.run()
+
+    assert len(export.data) == len(export.t) == 5
+    assert export.data == sorted(export.data, reverse=True)  # pumped down
+    assert export.data[-1] == pytest.approx(H2.value)

--- a/test/system_tests/test_enclosures.py
+++ b/test/system_tests/test_enclosures.py
@@ -1,6 +1,7 @@
 from mpi4py import MPI
 
 import dolfinx
+import numpy as np
 import pytest
 import ufl
 
@@ -179,22 +180,24 @@ def test_enclosure_connection_two_boxes():
     assert P1 * V1 + P2 * V2 == pytest.approx(P1_0 * V1 + P2_0 * V2, rel=1e-8)
 
 
-@pytest.mark.parametrize("length", [1.0, 2.0])
-def test_closed_enclosure_conserves_particles(length):
+@pytest.mark.parametrize("length, area", [(1.0, 1.0), (2.0, 0.25)])
+def test_closed_enclosure_conserves_particles(length, area):
     """A closed enclosure exchanging with a slab through a surface reaction 2H <-> H2
     must conserve hydrogen atoms exactly at every timestep.
 
-    Nothing leaves the system, so ``int(c_H) dx + 2*P*V/(k*T)`` is invariant. This is
-    exact (to Newton tolerance) rather than approximate, because the same UFL
-    expression drives both the species residual and the pressure residual. It is the
-    sharpest check available on the sign conventions and on the factor of 2 from the
-    diatomic stoichiometry.
+    Nothing leaves the system, so ``A*int(c_H) dx + 2*P*V/(k*T)`` is invariant, where
+    ``A`` is the area of the membrane facing the enclosure (in 1D the model is per unit
+    area, so the solid inventory has to be scaled by it). This is exact (to Newton
+    tolerance) rather than approximate, because the same UFL expression drives both the
+    species residual and the pressure residual. It is the sharpest check available on
+    the sign conventions, on the factor of 2 from the diatomic stoichiometry, and on
+    the area factor.
 
-    ``length`` is parameterised, and 1.0 is deliberately not the only case: the pressure
-    test function is a global constant, so a volume term assembles to ``|Omega| * f``
-    while a surface term does not pick up that factor. The residual divides its volume
-    terms by ``|Omega|`` to compensate, and on a unit domain that division is a no-op --
-    so a unit-only test passes even if the normalisation is missing entirely.
+    ``(1.0, 1.0)`` is deliberately not the only case. The pressure test function is a
+    global constant, so a term spread over a region assembles to ``|region| * f`` and
+    has to be divided by that measure, and the flux has to be multiplied by the physical
+    area. Both factors are exactly 1 in the unit case, so a unit-only test would pass
+    even with the normalisation and the area dropped entirely.
     """
     V_enc, T, P0 = 1e-3, 500.0, 1e5
     k_d0, k_r0 = 1e15, 1e-25
@@ -214,7 +217,7 @@ def test_closed_enclosure_conserves_particles(length):
 
     H2 = F.GasSpecies(name="H2", initial_pressure=P0)
     my_model.enclosures = [
-        F.Enclosure(volume=V_enc, species=[H2], temperature=T, surfaces=[right])
+        F.Enclosure(volume=V_enc, species=[H2], temperature=T, surfaces={right: area})
     ]
     my_model.boundary_conditions = [
         F.SurfaceReactionBC(
@@ -242,7 +245,8 @@ def test_closed_enclosure_conserves_particles(length):
 
     def total_hydrogen_atoms():
         c = H.subdomain_to_post_processing_solution[volume]
-        in_solid = mesh.comm.allreduce(
+        # the 1D model is per unit area, so scale the inventory by the membrane area
+        in_solid = area * mesh.comm.allreduce(
             dolfinx.fem.assemble_scalar(dolfinx.fem.form(c * ufl.dx)), op=MPI.SUM
         )
         # 2 atoms per H2 molecule
@@ -284,7 +288,9 @@ def test_steady_state_closed_enclosure_reaches_surface_equilibrium():
 
     H2 = F.GasSpecies(name="H2", initial_pressure=1e5)
     my_model.enclosures = [
-        F.Enclosure(volume=1e-3, species=[H2], temperature=T, surfaces=[right])
+        # the area does not affect the steady-state equilibrium: zero net flux forces
+        # kd*P = kr*c^2 whatever the area scaling
+        F.Enclosure(volume=1e-3, species=[H2], temperature=T, surfaces={right: 0.5})
     ]
     my_model.boundary_conditions = [
         F.FixedConcentrationBC(subdomain=left, value=c0, species=H),
@@ -304,6 +310,100 @@ def test_steady_state_closed_enclosure_reaches_surface_equilibrium():
     my_model.run()
 
     assert H2.value == pytest.approx(k_r0 * c0**2 / k_d0, rel=1e-8)
+
+
+def test_enclosure_in_contact_with_two_materials():
+    """One enclosure touching both ends of a two-material slab.
+
+    The two contact surfaces sit on different submeshes, so the single pressure form has
+    to pull each surface's concentration from a different submesh via ``entity_maps``.
+    This also exercises the multi-surface paths: the contact measure is a sum over
+    surfaces, and the scalar terms are spread across both of them.
+
+    Conservation is checked over both materials at once, so it fails if either surface
+    is dropped from the balance.
+    """
+    area = 0.25
+    V_enc, T, P0 = 1e-3, 500.0, 1e5
+    k_d0, k_r0 = 1e15, 1e-25
+    dt, final_time = 5.0, 200.0
+
+    vertices = np.concatenate((np.linspace(0, 0.5, 30), np.linspace(0.5, 1.0, 30)))
+    my_model = F.HydrogenTransportProblemDiscontinuous()
+    my_model.mesh = F.Mesh1D(vertices)
+    material_left = F.Material(D_0=1e-6, E_D=0.0, K_S_0=1, E_K_S=0)
+    material_right = F.Material(D_0=2e-6, E_D=0.0, K_S_0=1, E_K_S=0)
+    vol_left = F.VolumeSubdomain1D(id=1, borders=[0, 0.5], material=material_left)
+    vol_right = F.VolumeSubdomain1D(id=2, borders=[0.5, 1.0], material=material_right)
+    left = F.SurfaceSubdomain1D(id=1, x=0)
+    right = F.SurfaceSubdomain1D(id=2, x=1)
+    my_model.subdomains = [vol_left, vol_right, left, right]
+    my_model.interfaces = [
+        F.Interface(id=3, subdomains=[vol_left, vol_right], penalty_term=1000)
+    ]
+    H = F.Species("H", subdomains=[vol_left, vol_right])
+    my_model.species = [H]
+    my_model.temperature = T
+
+    H2 = F.GasSpecies(name="H2", initial_pressure=P0)
+    # left belongs to vol_left's submesh, right to vol_right's
+    my_model.enclosures = [
+        F.Enclosure(
+            volume=V_enc,
+            species=[H2],
+            temperature=T,
+            surfaces={left: area, right: area},
+        )
+    ]
+    my_model.boundary_conditions = [
+        F.SurfaceReactionBC(
+            reactant=[H, H],
+            gas_pressure=H2,
+            k_r0=k_r0,
+            E_kr=0.0,
+            k_d0=k_d0,
+            E_kd=0.0,
+            subdomain=surface,
+        )
+        for surface in (left, right)
+    ]
+    my_model.initial_conditions = [
+        F.InitialConcentration(value=0.0, species=H, volume=volume)
+        for volume in (vol_left, vol_right)
+    ]
+    my_model.settings = F.Settings(
+        atol=1e-8,
+        rtol=1e-10,
+        transient=True,
+        final_time=final_time,
+        stepsize=F.Stepsize(dt),
+    )
+    my_model.show_progress_bar = False
+    my_model.initialise()
+
+    # two point facets in 1D
+    assert my_model.enclosures[0]._contact_measure == pytest.approx(2.0)
+
+    def total_hydrogen_atoms():
+        in_solid = 0.0
+        for volume in (vol_left, vol_right):
+            c = H.subdomain_to_post_processing_solution[volume]
+            in_solid += my_model.mesh.mesh.comm.allreduce(
+                dolfinx.fem.assemble_scalar(
+                    dolfinx.fem.form(c * ufl.dx(domain=volume.submesh))
+                ),
+                op=MPI.SUM,
+            )
+        return area * in_solid + 2.0 * H2.value * V_enc / (F.k_B_SI * T)
+
+    my_model.post_processing()
+    initial_inventory = total_hydrogen_atoms()
+
+    while my_model.t.value < final_time:
+        my_model.iterate()
+        assert total_hydrogen_atoms() == pytest.approx(initial_inventory, rel=1e-12)
+
+    assert H2.value < P0
 
 
 def test_gas_pressure_export():

--- a/test/test_enclosure.py
+++ b/test/test_enclosure.py
@@ -1,0 +1,340 @@
+import re
+
+from mpi4py import MPI
+
+import dolfinx
+import numpy as np
+import pytest
+import ufl
+
+import festim as F
+
+from .markers import requires_dolfinx_010, requires_dolfinx_011
+
+
+def make_gas_species(**kwargs):
+    return F.GasSpecies(name=kwargs.pop("name", "H2"), **kwargs)
+
+
+def make_enclosure(**kwargs):
+    kwargs.setdefault("volume", 1e-3)
+    kwargs.setdefault("species", [make_gas_species()])
+    kwargs.setdefault("temperature", 500.0)
+    return F.Enclosure(**kwargs)
+
+
+def make_model(enclosures=None, transient=True):
+    mesh = dolfinx.mesh.create_unit_interval(MPI.COMM_WORLD, 8)
+    my_model = F.HydrogenTransportProblemDiscontinuous()
+    my_model.mesh = F.Mesh(mesh=mesh)
+    material = F.Material(name="mat", D_0=1e-9, E_D=0.0)
+    volume = F.VolumeSubdomain1D(id=1, borders=[0.0, 1.0], material=material)
+    left = F.SurfaceSubdomain1D(id=1, x=0.0)
+    right = F.SurfaceSubdomain1D(id=2, x=1.0)
+    my_model.subdomains = [volume, left, right]
+    my_model.species = [F.Species("H", subdomains=[volume])]
+    my_model.temperature = 500.0
+    my_model.enclosures = enclosures or []
+    my_model.settings = F.Settings(
+        atol=1e-10,
+        rtol=1e-10,
+        transient=transient,
+        final_time=1.0,
+        stepsize=F.Stepsize(1.0) if transient else None,
+    )
+    my_model.show_progress_bar = False
+    return my_model, volume, left, right
+
+
+class TestConstruction:
+    def test_backref_is_set(self):
+        H2 = make_gas_species()
+        enclosure = make_enclosure(species=[H2])
+        assert H2.enclosure is enclosure
+
+    def test_negative_volume_raises(self):
+        with pytest.raises(ValueError, match="volume must be positive"):
+            make_enclosure(volume=-1.0)
+
+    def test_empty_species_raises(self):
+        with pytest.raises(ValueError, match="at least one GasSpecies"):
+            make_enclosure(species=[])
+
+    def test_wrong_species_type_raises(self):
+        with pytest.raises(TypeError, match="list of GasSpecies"):
+            make_enclosure(species=[F.Species("H")])
+
+    def test_gas_constant_defaults_to_boltzmann_si(self):
+        assert make_enclosure().gas_constant == F.k_B_SI
+
+    def test_gas_constant_can_be_molar(self):
+        assert make_enclosure(gas_constant=F.R).gas_constant == F.R
+
+    def test_pressure_unavailable_before_initialise(self):
+        with pytest.raises(ValueError, match="not available before initialise"):
+            _ = make_gas_species().value
+
+
+class TestEnclosureConnection:
+    def test_needs_exactly_two_species(self):
+        H2 = make_gas_species()
+        with pytest.raises(ValueError, match="exactly two gas species"):
+            F.EnclosureConnection(conductance=1e-4, species=(H2,))
+
+    def test_partner_lookup(self):
+        a, b = make_gas_species(name="a"), make_gas_species(name="b")
+        connection = F.EnclosureConnection(conductance=1e-4, species=(a, b))
+        assert connection._partner(a) is b
+        assert connection._partner(b) is a
+
+    def test_partner_lookup_rejects_unrelated_species(self):
+        a, b = make_gas_species(name="a"), make_gas_species(name="b")
+        connection = F.EnclosureConnection(conductance=1e-4, species=(a, b))
+        with pytest.raises(ValueError, match="not connected by"):
+            connection._partner(make_gas_species(name="c"))
+
+    @requires_dolfinx_011
+    def test_species_must_belong_to_an_enclosure(self):
+        a, b = make_gas_species(name="a"), make_gas_species(name="b")
+        connection = F.EnclosureConnection(conductance=1e-4, species=(a, b))
+        # b is never put in an enclosure
+        enclosure_a = make_enclosure(species=[a], openings=[connection])
+        my_model, *_ = make_model(enclosures=[enclosure_a])
+        with pytest.raises(ValueError, match="does not belong to any enclosure"):
+            my_model.initialise()
+
+    @requires_dolfinx_011
+    def test_connection_is_mirrored_onto_partner(self):
+        a, b = make_gas_species(name="a"), make_gas_species(name="b")
+        connection = F.EnclosureConnection(conductance=1e-4, species=(a, b))
+        enclosure_a = make_enclosure(species=[a], openings=[connection])
+        enclosure_b = make_enclosure(species=[b])
+        assert connection not in enclosure_b.openings
+
+        my_model, *_ = make_model(enclosures=[enclosure_a, enclosure_b])
+        my_model.initialise()
+        assert connection in enclosure_b.openings
+
+    @requires_dolfinx_011
+    def test_mirroring_is_idempotent(self):
+        """Declaring the connection on both sides must not double the flow."""
+        a, b = make_gas_species(name="a"), make_gas_species(name="b")
+        connection = F.EnclosureConnection(conductance=1e-4, species=(a, b))
+        enclosure_a = make_enclosure(species=[a], openings=[connection])
+        enclosure_b = make_enclosure(species=[b], openings=[connection])
+        my_model, *_ = make_model(enclosures=[enclosure_a, enclosure_b])
+        my_model.initialise()
+        assert enclosure_b.openings.count(connection) == 1
+
+
+class TestOpenings:
+    def test_applies_to_all_species_by_default(self):
+        H2, HD = make_gas_species(name="H2"), make_gas_species(name="HD")
+        pump = F.Pump(pumping_speed=1e-4)
+        assert pump.applies_to(H2)
+        assert pump.applies_to(HD)
+
+    def test_applies_to_named_species_only(self):
+        H2, HD = make_gas_species(name="H2"), make_gas_species(name="HD")
+        pump = F.Pump(pumping_speed=1e-4, species=H2)
+        assert pump.applies_to(H2)
+        assert not pump.applies_to(HD)
+
+    @pytest.mark.parametrize(
+        "opening, time_dependent",
+        [
+            (F.Pump(pumping_speed=1e-4), False),
+            (F.Pump(pumping_speed=lambda t: 1e-4 * t), True),
+            (F.Reservoir(conductance=1e-4, pressure=1e3), False),
+            (F.Reservoir(conductance=1e-4, pressure=lambda t: 1e3 * t), True),
+            (F.PrescribedFlowRate(flow_rate=1e18), False),
+            (F.PrescribedFlowRate(flow_rate=lambda t: 1e18 * t), True),
+        ],
+    )
+    def test_time_dependence_detection(self, opening, time_dependent):
+        assert any(v.explicit_time_dependent for v in opening._values) == time_dependent
+
+
+@requires_dolfinx_011
+class TestOpeningSigns:
+    """The sign convention: molar_flow_rate is positive when particles enter."""
+
+    def _initialised(self, opening):
+        H2 = make_gas_species(initial_pressure=1e5)
+        enclosure = make_enclosure(species=[H2], openings=[opening])
+        my_model, *_ = make_model(enclosures=[enclosure])
+        my_model.initialise()
+        return H2, enclosure, my_model
+
+    def _assemble(self, expr, my_model):
+        return dolfinx.fem.assemble_scalar(
+            dolfinx.fem.form(
+                expr
+                / my_model._total_volume
+                * dolfinx.fem.Constant(my_model.mesh.mesh, 1.0)
+                * my_model.dx
+            )
+        )
+
+    def test_pump_removes_particles(self):
+        H2, enclosure, my_model = self._initialised(F.Pump(pumping_speed=1e-4))
+        rate = self._assemble(
+            enclosure.openings[0].molar_flow_rate(H2, enclosure), my_model
+        )
+        assert rate < 0
+
+    def test_reservoir_at_higher_pressure_adds_particles(self):
+        H2, enclosure, my_model = self._initialised(
+            F.Reservoir(conductance=1e-4, pressure=1e6)  # above the 1e5 enclosure
+        )
+        rate = self._assemble(
+            enclosure.openings[0].molar_flow_rate(H2, enclosure), my_model
+        )
+        assert rate > 0
+
+    def test_reservoir_at_lower_pressure_removes_particles(self):
+        H2, enclosure, my_model = self._initialised(
+            F.Reservoir(conductance=1e-4, pressure=1e3)
+        )
+        rate = self._assemble(
+            enclosure.openings[0].molar_flow_rate(H2, enclosure), my_model
+        )
+        assert rate < 0
+
+
+@requires_dolfinx_011
+class TestValidation:
+    def test_surface_not_in_subdomains_raises(self):
+        stray = F.SurfaceSubdomain1D(id=99, x=0.5)
+        H2 = make_gas_species()
+        enclosure = make_enclosure(species=[H2], surfaces=[stray])
+        my_model, *_ = make_model(enclosures=[enclosure])
+        with pytest.raises(ValueError, match="is not in the subdomains"):
+            my_model.initialise()
+
+    def test_steady_state_enclosure_with_nothing_coupled_raises(self):
+        """Steady state with no surfaces and no openings: the pressure never appears in
+        its own balance, so it is undetermined."""
+        H2 = make_gas_species()
+        enclosure = make_enclosure(species=[H2])
+        my_model, *_ = make_model(enclosures=[enclosure], transient=False)
+        with pytest.raises(ValueError, match="undetermined"):
+            my_model.initialise()
+
+    def test_steady_state_with_prescribed_flow_rate_only_raises(self):
+        """A PrescribedFlowRate is an opening, but its rate does not depend on the
+        pressure, so in steady state the pressure is still undetermined."""
+        H2 = make_gas_species()
+        enclosure = make_enclosure(
+            species=[H2], openings=[F.PrescribedFlowRate(flow_rate=1e18)]
+        )
+        my_model, *_ = make_model(enclosures=[enclosure], transient=False)
+        with pytest.raises(ValueError, match="undetermined"):
+            my_model.initialise()
+
+    @pytest.mark.parametrize(
+        "opening",
+        [F.Pump(pumping_speed=1e-4), F.Reservoir(conductance=1e-4, pressure=1e3)],
+    )
+    def test_steady_state_with_pressure_dependent_opening_is_accepted(self, opening):
+        """A Pump or Reservoir rate depends on the pressure, so it determines it."""
+        H2 = make_gas_species()
+        enclosure = make_enclosure(species=[H2], openings=[opening])
+        my_model, *_ = make_model(enclosures=[enclosure], transient=False)
+        my_model.initialise()  # must not raise
+
+    def test_transient_closed_enclosure_is_accepted(self):
+        """In transient the time derivative always determines the pressure."""
+        H2 = make_gas_species()
+        enclosure = make_enclosure(species=[H2])
+        my_model, *_ = make_model(enclosures=[enclosure], transient=True)
+        my_model.initialise()  # must not raise
+
+    def test_base_problem_rejects_enclosures(self):
+        H2 = make_gas_species()
+        my_model = F.HydrogenTransportProblem()
+        my_model.enclosures = [make_enclosure(species=[H2])]
+        with pytest.raises(NotImplementedError, match="Discontinuous"):
+            my_model.initialise()
+
+    def test_cylindrical_coordinates_raise(self):
+        H2 = make_gas_species()
+        my_model, *_ = make_model(enclosures=[make_enclosure(species=[H2])])
+        my_model.mesh = F.Mesh1D(
+            vertices=np.linspace(0, 1, 9), coordinate_system="cylindrical"
+        )
+        with pytest.raises(NotImplementedError, match="cartesian"):
+            my_model.initialise()
+
+
+@requires_dolfinx_011
+class TestSurfaceReactionCoupling:
+    def test_gas_pressure_accepts_gas_species(self):
+        H2 = make_gas_species(initial_pressure=1e5)
+        my_model, _volume, _left, right = make_model()
+        enclosure = make_enclosure(species=[H2], surfaces=[right])
+        my_model.enclosures = [enclosure]
+        H = my_model.species[0]
+        my_model.boundary_conditions = [
+            F.SurfaceReactionBC(
+                reactant=[H, H],
+                gas_pressure=H2,
+                k_r0=1e-4,
+                E_kr=0.0,
+                k_d0=1e-4,
+                E_kd=0.0,
+                subdomain=right,
+            )
+        ]
+        my_model.initialise()
+        # the reaction flux must depend on the pressure unknown
+        value = my_model.boundary_conditions[0].flux_bcs[0].value_fenics
+        assert H2.solution in ufl.algorithms.extract_coefficients(value)
+
+    def test_enclosure_residual_depends_on_the_species(self):
+        """The pressure balance must see the solid, otherwise the coupling is one-way
+        and the gas would never gain the particles the solid loses."""
+        H2 = make_gas_species(initial_pressure=1e5)
+        my_model, volume, _left, right = make_model()
+        my_model.enclosures = [make_enclosure(species=[H2], surfaces=[right])]
+        H = my_model.species[0]
+        my_model.boundary_conditions = [
+            F.SurfaceReactionBC(
+                reactant=[H, H],
+                gas_pressure=H2,
+                k_r0=1e-4,
+                E_kr=0.0,
+                k_d0=1e-4,
+                E_kd=0.0,
+                subdomain=right,
+            )
+        ]
+        my_model.initialise()
+        coefficients = ufl.algorithms.extract_coefficients(H2.F)
+        assert volume.u in coefficients
+
+
+class TestGasPressureExport:
+    def test_field_must_be_gas_species(self):
+        with pytest.raises(TypeError, match=re.escape("must be a festim.GasSpecies")):
+            F.GasPressure(field=F.Species("H"))
+
+    def test_title(self):
+        H2 = make_gas_species(name="H2")
+        make_enclosure(species=[H2], name="plenum")
+        assert F.GasPressure(field=H2).title == "H2 pressure (plenum) (Pa)"
+
+    def test_title_without_enclosure_name(self):
+        H2 = make_gas_species(name="H2")
+        make_enclosure(species=[H2])
+        assert F.GasPressure(field=H2).title == "H2 pressure (Pa)"
+
+
+@requires_dolfinx_010
+def test_enclosures_rejected_on_old_dolfinx():
+    """On dolfinx < 0.11 the feature must fail early with a helpful message."""
+    H2 = F.GasSpecies(name="H2")
+    enclosure = F.Enclosure(volume=1e-3, species=[H2], temperature=500.0)
+    my_model = F.HydrogenTransportProblemDiscontinuous()
+    with pytest.raises(NotImplementedError, match=re.escape("require dolfinx >= 0.11")):
+        my_model.enclosures = [enclosure]

--- a/test/test_enclosure.py
+++ b/test/test_enclosure.py
@@ -204,10 +204,45 @@ class TestOpeningSigns:
 
 @requires_dolfinx_011
 class TestValidation:
+    def test_area_required_on_1d_mesh(self):
+        """In 1D a surface is a point, so the mesh cannot supply the area of the
+        membrane facing the enclosure and the user must give it."""
+        H2 = make_gas_species()
+        my_model, _volume, _left, right = make_model()
+        # a plain list means no areas were given
+        my_model.enclosures = [make_enclosure(species=[H2], surfaces=[right])]
+        with pytest.raises(ValueError, match="areas of those surfaces"):
+            my_model.initialise()
+
+    def test_area_given_as_dict_is_accepted_on_1d_mesh(self):
+        H2 = make_gas_species()
+        my_model, _volume, _left, right = make_model()
+        my_model.enclosures = [make_enclosure(species=[H2], surfaces={right: 1e-4})]
+        my_model.initialise()  # must not raise
+
+    def test_surfaceless_enclosure_needs_no_area(self):
+        """An enclosure that only has openings never integrates a flux, so there is no
+        area to supply."""
+        H2 = make_gas_species()
+        enclosure = make_enclosure(species=[H2], openings=[F.Pump(pumping_speed=1e-4)])
+        my_model, *_ = make_model(enclosures=[enclosure])
+        my_model.initialise()  # must not raise
+
+    def test_negative_area_raises(self):
+        H2 = make_gas_species()
+        right = F.SurfaceSubdomain1D(id=2, x=1.0)
+        with pytest.raises(ValueError, match="area of surface 2 must be positive"):
+            make_enclosure(species=[H2], surfaces={right: -1.0})
+
+    def test_surfaces_keys_must_be_surface_subdomains(self):
+        H2 = make_gas_species()
+        with pytest.raises(TypeError, match="SurfaceSubdomain"):
+            make_enclosure(species=[H2], surfaces={"right": 1.0})
+
     def test_surface_not_in_subdomains_raises(self):
         stray = F.SurfaceSubdomain1D(id=99, x=0.5)
         H2 = make_gas_species()
-        enclosure = make_enclosure(species=[H2], surfaces=[stray])
+        enclosure = make_enclosure(species=[H2], surfaces={stray: 1.0})
         my_model, *_ = make_model(enclosures=[enclosure])
         with pytest.raises(ValueError, match="is not in the subdomains"):
             my_model.initialise()
@@ -272,7 +307,7 @@ class TestSurfaceReactionCoupling:
     def test_gas_pressure_accepts_gas_species(self):
         H2 = make_gas_species(initial_pressure=1e5)
         my_model, _volume, _left, right = make_model()
-        enclosure = make_enclosure(species=[H2], surfaces=[right])
+        enclosure = make_enclosure(species=[H2], surfaces={right: 1.0})
         my_model.enclosures = [enclosure]
         H = my_model.species[0]
         my_model.boundary_conditions = [
@@ -296,7 +331,7 @@ class TestSurfaceReactionCoupling:
         and the gas would never gain the particles the solid loses."""
         H2 = make_gas_species(initial_pressure=1e5)
         my_model, volume, _left, right = make_model()
-        my_model.enclosures = [make_enclosure(species=[H2], surfaces=[right])]
+        my_model.enclosures = [make_enclosure(species=[H2], surfaces={right: 1.0})]
         H = my_model.species[0]
         my_model.boundary_conditions = [
             F.SurfaceReactionBC(

--- a/test/test_enclosure.py
+++ b/test/test_enclosure.py
@@ -247,6 +247,16 @@ class TestValidation:
         with pytest.raises(ValueError, match="is not in the subdomains"):
             my_model.initialise()
 
+    def test_same_gas_species_in_two_enclosures_raises(self):
+        """A GasSpecies has a single pressure unknown, so it cannot live in two
+        enclosures. Sharing one would otherwise silently corrupt the model."""
+        H2 = make_gas_species()
+        enclosure_a = make_enclosure(species=[H2])
+        enclosure_b = make_enclosure(species=[H2])
+        my_model, *_ = make_model(enclosures=[enclosure_a, enclosure_b])
+        with pytest.raises(ValueError, match="belongs to more than one enclosure"):
+            my_model.initialise()
+
     def test_steady_state_enclosure_with_nothing_coupled_raises(self):
         """Steady state with no surfaces and no openings: the pressure never appears in
         its own balance, so it is undetermined."""


### PR DESCRIPTION
## Description

### Summary
This PR introduces gas enclosures to FESTIM! 🎉 

### Related Issues
Fixes #996 

### Motivation and Context
FESTIM can impose a gas pressure on a surface, but only as *input* — `SievertsBC.pressure`, `HenrysBC.pressure`, and `SurfaceReactionBC.gas_pressure` all accept `float | callable(t)` and nothing else. There is no way to let the pressure of a gas volume *evolve* in response to what permeates through the wall.

This adds that: an `Enclosure` (a 0D gas volume) whose pressure is a genuine unknown, solved implicitly and monolithically with the transport problem, coupled to the solid through the surfaces in contact with it, and optionally exchanging gas with the outside through openings. The reference case is the TMAP verification in issue #996: a slab with a perfect sink on one side and Henry's law on the other, with `dP/dt = φ·A·k·T/V`.

The enabling technology is the **real element** (one global DOF), native in dolfinx 0.11. The alternative — an explicit/staggered update of P between timesteps — is what we are deliberately avoiding; real elements put the pressure ODE directly into the variational form so Newton sees the full coupling.

**Scope: `HydrogenTransportProblemDiscontinuous` only.** The base `HydrogenTransportProblem` is expected to be retired in favour of the Discontinuous class's blocked system, so enclosures are not worth building for it. The base class raises a clear `NotImplementedError` if given enclosures.

**Limits** Right now this PR only includes "flux coupling" between enclosures and surfaces via `SurfaceReactionBC.gas_pressure`. "concentration coupling" via `SievertsBC.pressure`, `HenrysBC.pressure` will probably come in a separate PR for simplicity.

<img width="1050" height="1050" alt="image" src="https://github.com/user-attachments/assets/d377462d-1f9f-4d8e-83b7-0e2dece3b00b" />

## Usage
<details>
  <summary>Click to expand</summary>
  
  ```python
  """Gas enclosure coupled to a slab through a surface reaction.
  
  A 1D slab is initially loaded with hydrogen. Its right surface faces a gas enclosure
  that starts under vacuum. Hydrogen diffuses to that surface, recombines into H2
  (2H <-> H2), and fills the enclosure, so the partial pressure builds up over time.
  
  The pressure is a genuine unknown of the problem, solved together with the transport
  problem, so the reaction sees the pressure it has itself created: as P rises,
  dissociation (kd * P) pushes back against recombination (kr * c^2) until the surface
  reaches equilibrium.
  
  Run with:
  
      python example_enclosure.py
  
  Requires dolfinx >= 0.11 (the enclosure pressure lives in a real function space).
  """
  
  import numpy as np
  from mpi4py import MPI
  
  import dolfinx
  import matplotlib.pyplot as plt
  
  import festim as F
  
  # ---------------------------------------------------------------------------
  # Parameters
  # ---------------------------------------------------------------------------
  L = 1e-3  # slab thickness (m)
  AREA = 1e-2  # area of the membrane facing the enclosure (m2)
  VOLUME = 1e-5  # volume of the enclosure (m3)
  TEMPERATURE = 600.0  # K
  
  c_0 = 1e21  # initial concentration in the slab (m-3)
  D_0, E_D = 1e-7, 0.2  # diffusion coefficient
  
  k_r0, E_kr = 1e-26, 0.0  # recombination: 2H -> H2
  k_d0, E_kd = 1e14, 0.0  # dissociation: H2 -> 2H
  
  final_time = 5000.0
  stepsize = 25.0
  
  # ---------------------------------------------------------------------------
  # Model
  # ---------------------------------------------------------------------------
  my_model = F.HydrogenTransportProblemDiscontinuous()
  my_model.mesh = F.Mesh1D(np.linspace(0, L, num=200))
  
  material = F.Material(name="tungsten", D_0=D_0, E_D=E_D)
  slab = F.VolumeSubdomain1D(id=1, borders=[0, L], material=material)
  left = F.SurfaceSubdomain1D(id=1, x=0)
  right = F.SurfaceSubdomain1D(id=2, x=L)
  my_model.subdomains = [slab, left, right]
  
  H = F.Species("H", subdomains=[slab])
  my_model.species = [H]
  my_model.temperature = TEMPERATURE
  
  # The gas species whose partial pressure is the unknown, and the enclosure it lives in.
  # The slab is 1D, so its right surface is a point and carries no area: the area of the
  # membrane facing the enclosure has to be given explicitly.
  H2 = F.GasSpecies(name="H2", initial_pressure=0.0)
  enclosure = F.Enclosure(
      volume=VOLUME,
      species=[H2],
      temperature=TEMPERATURE,
      surfaces={right: AREA},
      name="plenum",
  )
  my_model.enclosures = [enclosure]
  
  # The reaction that couples the two: passing the GasSpecies (rather than a float) is
  # what makes the pressure an unknown instead of an imposed value.
  my_model.boundary_conditions = [
      F.SurfaceReactionBC(
          reactant=[H, H],
          gas_pressure=H2,
          k_r0=k_r0,
          E_kr=E_kr,
          k_d0=k_d0,
          E_kd=E_kd,
          subdomain=right,
      )
  ]
  
  my_model.initial_conditions = [
      F.InitialConcentration(value=c_0, species=H, volume=slab)
  ]
  
  # ---------------------------------------------------------------------------
  # Post-processing
  # ---------------------------------------------------------------------------
  pressure = F.GasPressure(field=H2, filename="enclosure_pressure.csv")
  inventory = F.TotalVolume(field=H, volume=slab)
  my_model.exports = [pressure, inventory]
  
  my_model.settings = F.Settings(
      atol=1e10,
      rtol=1e-10,
      transient=True,
      final_time=final_time,
      stepsize=F.Stepsize(stepsize),
  )
  
  my_model.initialise()
  my_model.run()
  
  # ---------------------------------------------------------------------------
  # Results
  # ---------------------------------------------------------------------------
  # Nothing leaves the system, so every H atom lost by the slab ends up in the gas as
  # half an H2 molecule. This is exact, not approximate: the same expression drives the
  # surface flux and the pressure balance.
  t = np.array(pressure.t)
  P = np.array(pressure.data)
  in_solid = AREA * np.array(inventory.data)
  in_gas = 2.0 * P * VOLUME / (F.k_B_SI * TEMPERATURE)
  total = in_solid + in_gas
  
  print(f"final pressure          : {P[-1]:.4e} Pa")
  print(f"H atoms in slab, start  : {in_solid[0]:.4e}")
  print(f"H atoms in slab, end    : {in_solid[-1]:.4e}")
  print(f"H atoms in gas, end     : {in_gas[-1]:.4e}")
  print(
      f"inventory drift         : {abs(total[-1] - total[0]) / total[0]:.2e} (relative)"
  )
  
  fig, (ax_p, ax_n) = plt.subplots(2, 1, figsize=(7, 7), sharex=True)
  
  ax_p.plot(t, P, color="tab:red")
  ax_p.set_ylabel("H2 partial pressure (Pa)")
  ax_p.set_title("Enclosure filling from a slab through 2H <-> H2")
  ax_p.grid(alpha=0.3)
  
  ax_n.plot(t, in_solid, label="in the slab")
  ax_n.plot(t, in_gas, label="in the enclosure")
  ax_n.plot(t, total, "k--", label="total (conserved)")
  ax_n.set_xlabel("time (s)")
  ax_n.set_ylabel("H atoms")
  ax_n.legend()
  ax_n.grid(alpha=0.3)
  
  fig.tight_layout()
  fig.savefig("enclosure_pressure.png", dpi=150)
  print("\nwrote enclosure_pressure.png and enclosure_pressure.csv")
  
  ```
</details>


## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Code refactoring (no functional changes, no API changes)
- [ ] 📝 Documentation update
- [ ] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI configuration change

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] All existing tests pass locally (`pytest`)
- [ ] I have added new tests that prove my fix is effective or that my feature works



## Code Quality Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [ ] My code follows the code style of this project (Ruff formatted: `ruff format .`)
- [ ] My code passes linting checks (`ruff check .`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

## Documentation

<!-- Put an `x` in the boxes that apply -->

- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added docstrings to new functions/classes following the project conventions

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here -->
<!-- What will users need to change in their code? -->
<!-- Delete this section if not applicable -->

## Screenshots/Examples

<!-- If applicable, add screenshots or code examples to help explain your changes -->
<!-- This is especially useful for new features or bug fixes with visual components -->

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- Mention if this is a work in progress, needs specific review, or has known limitations -->
