### PR TITLE
Fix Nitsche weak Dirichlet BC formulation

### DIFF
--- a/src/festim/boundary_conditions/dirichlet_bc.py
+++ b/src/festim/boundary_conditions/dirichlet_bc.py
@@ -151,27 +151,30 @@ class DirichletBCBase:
         elif self.bc_expr is not None:
             self.value_fenics.interpolate(self.bc_expr)
 
-    def weak_formulation(
+    def numerical_flux(
         self,
         u: fem.Function | ufl.indexed.Indexed,
-        v: ufl.argument.Argument | ufl.indexed.Indexed,
-        ds: ufl.Measure,
+        D: ufl.core.expr.Expr | fem.Function | fem.Constant,
+        mesh,
     ) -> ufl.core.expr.Expr:
-        """
-        Returns the Nitsche weak formulation for the BC
-        This follows the dolfinx tutorial
-        https://jsdokken.com/dolfinx-tutorial/chapter1/nitsche.html
+        """Returns the numerical flux leaving the domain through the surface of the BC.
+
+        Nitsche's method only enforces ``u = value`` weakly, so ``u - value`` does not
+        vanish on the boundary and the raw gradient ``-D grad(u).n`` is not the quantity
+        the discrete scheme conserves. The conserved quantity is this numerical flux,
+        which includes the penalty contribution. Use it (rather than the raw gradient)
+        whenever the flux through a weakly enforced boundary feeds another equation, so
+        that the discrete balance is exact.
 
         Args:
             u: the solution function associated to the species for which the BC
                 is applied
-            v: the test function
-            ds: the surface measure
+            D: the diffusion coefficient of the species at this surface
+            mesh: the mesh the surface belongs to
 
         Returns:
-            the weak formulation
+            the numerical flux, positive when leaving the domain
         """
-        mesh = ds.ufl_domain()
         n = ufl.FacetNormal(mesh)
         h = ufl.Circumradius(mesh)  # FIXME this doesn't work for rectangles
         alpha = self.penalty
@@ -182,14 +185,43 @@ class DirichletBCBase:
             "value_fenics must be defined for weakly enforced Dirichlet BCs"
         )
 
-        form = -ufl.inner(n, ufl.grad(u)) * v * ds(self.subdomain.id)
+        return -D * ufl.inner(n, ufl.grad(u)) + alpha / h * (u - self.value_fenics)
 
-        form += (
-            +ufl.inner(n, ufl.grad(v)) * (u - self.value_fenics) * ds(self.subdomain.id)
-        )
-        form += (
-            -alpha / h * ufl.inner((u - self.value_fenics), v) * ds(self.subdomain.id)
-        )
+    def weak_formulation(
+        self,
+        u: fem.Function | ufl.indexed.Indexed,
+        v: ufl.argument.Argument | ufl.indexed.Indexed,
+        ds: ufl.Measure,
+        D: ufl.core.expr.Expr | fem.Function | fem.Constant,
+    ) -> ufl.core.expr.Expr:
+        """
+        Returns the symmetric Nitsche weak formulation for the BC
+        This follows the dolfinx tutorial
+        https://jsdokken.com/dolfinx-tutorial/chapter1/nitsche.html
+
+        Args:
+            u: the solution function associated to the species for which the BC
+                is applied
+            v: the test function
+            ds: the surface measure
+            D: the diffusion coefficient of the species at this surface. It multiplies
+                the consistency and symmetry terms, without which the scheme is only
+                consistent when ``D == 1``.
+
+        Returns:
+            the weak formulation
+        """
+        mesh = ds.ufl_domain()
+        n = ufl.FacetNormal(mesh)
+        ds_bc = ds(self.subdomain.id)
+
+        # consistency + penalty, grouped as the numerical flux so that the flux the
+        # scheme conserves is defined in a single place
+        form = self.numerical_flux(u, D, mesh) * v * ds_bc
+
+        # symmetry term, making the bilinear form symmetric (and the L2 error optimal)
+        form += -D * ufl.inner(n, ufl.grad(v)) * (u - self.value_fenics) * ds_bc
+
         return form
 
 

--- a/src/festim/boundary_conditions/dirichlet_bc.py
+++ b/src/festim/boundary_conditions/dirichlet_bc.py
@@ -23,7 +23,9 @@ class DirichletBCBase:
         value: The value of the boundary condition
         enforce_weakly: Whether to enforce the boundary condition weakly using Nitsche's
             method. Defaults to False.
-        penalty: The penalty parameter to use if ``enforce_weakly`` is True.
+        penalty: The dimensionless penalty parameter to use if ``enforce_weakly`` is
+            True. The Nitsche penalty term scales as ``penalty * D / h``, so a value of
+            order 10-100 is appropriate regardless of the material or the mesh size.
             Defaults to None
 
     Attributes:
@@ -185,7 +187,10 @@ class DirichletBCBase:
             "value_fenics must be defined for weakly enforced Dirichlet BCs"
         )
 
-        return -D * ufl.inner(n, ufl.grad(u)) + alpha / h * (u - self.value_fenics)
+        # the penalty scales with D/h, like the consistency term it has to dominate,
+        # which makes ``penalty`` a dimensionless parameter independent of the material
+        # and of the mesh size
+        return -D * ufl.inner(n, ufl.grad(u)) + alpha * D / h * (u - self.value_fenics)
 
     def weak_formulation(
         self,
@@ -235,7 +240,9 @@ class FixedConcentrationBC(DirichletBCBase):
         species: The name of the species
         enforce_weakly: Whether to enforce the boundary condition weakly using Nitsche's
             method. Defaults to False.
-        penalty: The penalty parameter to use if ``enforce_weakly`` is True.
+        penalty: The dimensionless penalty parameter to use if ``enforce_weakly`` is
+            True. The Nitsche penalty term scales as ``penalty * D / h``, so a value of
+            order 10-100 is appropriate regardless of the material or the mesh size.
             Defaults to None
 
     Attributes:

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -192,6 +192,7 @@ class HydrogenTransportProblem(problem.ProblemBase):
         self._temperature_as_function = None
         self._species_to_D_global = None
         self._species_to_D_global_expr = None
+        self._surface_to_volume = None
 
     @property
     def temperature(self):
@@ -571,6 +572,43 @@ class HydrogenTransportProblem(problem.ProblemBase):
             temperature_field.interpolate(temperature_expr)
             return temperature_field
 
+    def volume_subdomain_of_surface(
+        self, surface: _subdomain.SurfaceSubdomain
+    ) -> _subdomain.VolumeSubdomain:
+        """Returns the volume subdomain a surface subdomain belongs to.
+
+        The mapping is deduced from the mesh connectivity and the meshtags, and is
+        computed once then cached.
+
+        Args:
+            surface: the surface subdomain
+
+        Returns:
+            the volume subdomain the surface belongs to
+
+        Raises:
+            ValueError: if the surface cannot be mapped to a volume subdomain
+        """
+        if self._surface_to_volume is None:
+            mesh = self.mesh.mesh
+            tdim = mesh.topology.dim
+            mesh.topology.create_connectivity(tdim - 1, tdim)
+            self._surface_to_volume = _subdomain.map_surface_to_volume_subdomains(
+                ft=self.facet_meshtags,
+                ct=self.volume_meshtags,
+                facet_to_cell=mesh.topology.connectivity(tdim - 1, tdim),
+                volume_subdomains=self.volume_subdomains,
+                surface_subdomains=self.surface_subdomains,
+                comm=mesh.comm,
+            )
+
+        if surface not in self._surface_to_volume:
+            raise ValueError(
+                f"Surface subdomain {surface.id} could not be mapped to a volume "
+                "subdomain. Check that its id matches a tagged facet of the mesh."
+            )
+        return self._surface_to_volume[surface]
+
     def define_D_global(self, species):
         """Defines the global diffusion coefficient for a given species.
 
@@ -900,7 +938,12 @@ class HydrogenTransportProblem(problem.ProblemBase):
                 if bc.enforce_weakly:
                     u = bc.species.solution
                     v = bc.species.test_function
-                    self.formulation += bc.weak_formulation(u, v, self.ds)
+                    # D is set by the material of the volume the surface belongs to
+                    vol = self.volume_subdomain_of_surface(bc.subdomain)
+                    D = vol.material.get_diffusion_coefficient(
+                        self.mesh.mesh, self.temperature_fenics, bc.species
+                    )
+                    self.formulation += bc.weak_formulation(u, v, self.ds, D)
         for adv_term in self.advection_terms:
             # create vector functionspace based on the elements in the mesh
 
@@ -1561,10 +1604,18 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                     v = bc.species.subdomain_to_test_function[subdomain]
                     form -= bc.value_fenics * v * self.ds(bc.subdomain.id)
             if isinstance(bc, boundary_conditions.FixedConcentrationBC):
-                if bc.enforce_weakly:
+                # as for fluxes, only the subdomain owning the surface gets the term,
+                # and its material is the one setting D there
+                if (
+                    bc.enforce_weakly
+                    and subdomain == self.surface_to_volume[bc.subdomain]
+                ):
                     u = bc.species.subdomain_to_solution[subdomain]
                     v = bc.species.subdomain_to_test_function[subdomain]
-                    form += bc.weak_formulation(u, v, self.ds)
+                    D = subdomain.material.get_diffusion_coefficient(
+                        self.mesh.mesh, self.temperature_fenics, bc.species
+                    )
+                    form += bc.weak_formulation(u, v, self.ds, D)
 
         # add volumetric sources
         for source in self.sources:

--- a/test/system_tests/test_misc.py
+++ b/test/system_tests/test_misc.py
@@ -478,3 +478,123 @@ def test_MMS_weak_dirichlet(
     L2_error = error_L2(H_computed, H_analytical_np)
 
     assert L2_error < 2e-3
+
+
+def solve_weak_dirichlet_mms(
+    N: int,
+    D_0: float,
+    penalty: float,
+    model_class: type[F.HydrogenTransportProblem] = F.HydrogenTransportProblem,
+) -> float:
+    """Solves a 1D steady-state MMS problem with both Dirichlet BCs enforced weakly
+    and returns the L2 error.
+
+    Args:
+        N: the number of cells of the mesh
+        D_0: the pre-exponential factor of the diffusion coefficient
+        penalty: the Nitsche penalty parameter
+        model_class: the problem class to use
+
+    Returns:
+        the L2 error of the computed concentration
+    """
+
+    def u_exact(mod):
+        return lambda x: 1 + mod.sin(2 * mod.pi * x[0])
+
+    H_analytical_ufl = u_exact(ufl)
+    H_analytical_np = u_exact(np)
+
+    my_mesh = F.Mesh1D(np.linspace(0, 1, N + 1))
+    x = ufl.SpatialCoordinate(my_mesh.mesh)
+
+    my_model = model_class()
+    my_model.mesh = my_mesh
+
+    my_mat = F.Material(name="mat", D_0=D_0, E_D=0)
+    vol = F.VolumeSubdomain1D(id=1, borders=[0, 1], material=my_mat)
+    left = F.SurfaceSubdomain1D(id=1, x=0)
+    right = F.SurfaceSubdomain1D(id=2, x=1)
+    my_model.subdomains = [vol, left, right]
+
+    H = F.Species("H")
+    my_model.species = [H]
+    if isinstance(my_model, F.HydrogenTransportProblemDiscontinuous):
+        H.subdomains = [vol]
+
+    my_model.temperature = 500
+
+    my_model.boundary_conditions = [
+        F.FixedConcentrationBC(
+            subdomain=surf,
+            value=H_analytical_ufl,
+            species=H,
+            enforce_weakly=True,
+            penalty=penalty,
+        )
+        for surf in (left, right)
+    ]
+
+    # E_D = 0 so D is exactly D_0
+    f = -ufl.div(D_0 * ufl.grad(H_analytical_ufl(x)))
+    my_model.sources = [F.ParticleSource(value=f, volume=vol, species=H)]
+
+    my_model.settings = F.Settings(atol=1e-12, rtol=1e-12, transient=False)
+
+    my_model.initialise()
+    my_model.run()
+
+    if isinstance(my_model, F.HydrogenTransportProblemDiscontinuous):
+        H_computed = H.subdomain_to_post_processing_solution[vol]
+    else:
+        H_computed = H.post_processing_solution
+
+    return error_L2(H_computed, H_analytical_np)
+
+
+@pytest.mark.parametrize(
+    "model_class", [F.HydrogenTransportProblem, F.HydrogenTransportProblemDiscontinuous]
+)
+@pytest.mark.parametrize("D_0", [1.0, 0.01])
+def test_weak_dirichlet_convergence_rate(
+    model_class: type[F.HydrogenTransportProblem]
+    | type[F.HydrogenTransportProblemDiscontinuous],
+    D_0: float,
+):
+    """The weakly enforced Dirichlet BC must be consistent, ie. converge at the
+    optimal order 2 in L2 for P1 elements, for any diffusion coefficient.
+
+    ``D_0 != 1`` is the case that matters: omitting D from the Nitsche consistency
+    and symmetry terms leaves a scheme that is only consistent when D == 1, and drops
+    this rate to ~0.85 at D_0 = 0.01.
+    """
+    mesh_sizes = [20, 40, 80, 160]
+    errors = [
+        solve_weak_dirichlet_mms(N=N, D_0=D_0, penalty=100, model_class=model_class)
+        for N in mesh_sizes
+    ]
+
+    rates = np.log(np.array(errors[:-1]) / np.array(errors[1:])) / np.log(2)
+
+    assert np.all(rates > 1.8), f"convergence rates {rates} are not close to 2"
+
+
+@pytest.mark.parametrize(
+    "model_class", [F.HydrogenTransportProblem, F.HydrogenTransportProblemDiscontinuous]
+)
+def test_weak_dirichlet_insensitive_to_penalty(
+    model_class: type[F.HydrogenTransportProblem]
+    | type[F.HydrogenTransportProblemDiscontinuous],
+):
+    """A consistent Nitsche scheme converges to the same solution regardless of the
+    penalty value. With D missing from the consistency and symmetry terms, the error
+    instead swings by more than an order of magnitude across these penalties.
+    """
+    errors = [
+        solve_weak_dirichlet_mms(N=40, D_0=0.01, penalty=p, model_class=model_class)
+        for p in (10, 100, 1000)
+    ]
+
+    assert np.max(errors) / np.min(errors) < 2, (
+        f"errors {errors} depend too strongly on the penalty parameter"
+    )

--- a/test/system_tests/test_misc.py
+++ b/test/system_tests/test_misc.py
@@ -598,3 +598,25 @@ def test_weak_dirichlet_insensitive_to_penalty(
     assert np.max(errors) / np.min(errors) < 2, (
         f"errors {errors} depend too strongly on the penalty parameter"
     )
+
+
+@pytest.mark.parametrize(
+    "model_class", [F.HydrogenTransportProblem, F.HydrogenTransportProblemDiscontinuous]
+)
+def test_weak_dirichlet_penalty_is_dimensionless(
+    model_class: type[F.HydrogenTransportProblem]
+    | type[F.HydrogenTransportProblemDiscontinuous],
+):
+    """The Nitsche penalty scales as ``penalty * D / h``, so at a fixed ``penalty`` the
+    discrete problem is D * (a fixed unit problem) and the error does not depend on the
+    diffusion coefficient. This is what makes ``penalty`` a material-independent knob:
+    a value tuned on one material stays valid on another.
+    """
+    errors = [
+        solve_weak_dirichlet_mms(N=40, D_0=D_0, penalty=100, model_class=model_class)
+        for D_0 in (1e2, 1.0, 1e-4, 1e-10)
+    ]
+
+    assert np.allclose(errors, errors[0], rtol=1e-8), (
+        f"errors {errors} depend on the diffusion coefficient"
+    )


### PR DESCRIPTION


## Description

### Summary
The Nitsche terms in DirichletBCBase.weak_formulation omitted the diffusion coefficient from the consistency and symmetry terms, making the scheme consistent only when D == 1. At D = 0.01 the L2 convergence rate dropped to ~0.85 and the error varied by ~30x with the penalty parameter. The penalty term also carried a negative sign.

- weak_formulation now takes D and uses the symmetric Nitsche form
- the numerical flux (-D grad(u).n + alpha/h (u - g)), the quantity the discrete scheme actually conserves, is exposed as its own method for reuse by anything consuming the flux through a weakly enforced surface
- both call sites resolve D from the material of the volume subdomain owning the surface; the base class gains volume_subdomain_of_surface for that, mirroring surface_to_volume in the discontinuous class

The existing MMS test passes with the bugs present (D ~= 0.12 with alpha/h ~= 15000 brute-forces u -> g), so add tests that do not: a convergence-rate test at D_0 = 0.01 and a penalty-insensitivity test. Both now give order 2.000 and errors identical to 4 significant figures.

+ now the global penalty scales with both the mesh size (`h`) and the diffusivity (`D`) making the penalty more robust.

### Related Issues
Related to #996 

### Motivation and Context
While working on #1192 , Claude noticed there was an error in how we implemented the weak dirichlet BC as the diffusion coefficient was missing from it. This basically means the penalty has to be increased A LOT in order for the error to be low enough. Convergence was not great though

This is a problem for the enclosure support as we'll rely on weakly enforced Dirichlet BCs/.

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Code refactoring (no functional changes, no API changes)
- [ ] 📝 Documentation update
- [ ] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI configuration change

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] All existing tests pass locally (`pytest`)
- [x] I have added new tests that prove my fix is effective or that my feature works



## Code Quality Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My code follows the code style of this project (Ruff formatted: `ruff format .`)
- [x] My code passes linting checks (`ruff check .`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Documentation

<!-- Put an `x` in the boxes that apply -->

- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have added docstrings to new functions/classes following the project conventions

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here -->
<!-- What will users need to change in their code? -->
<!-- Delete this section if not applicable -->

## Screenshots/Examples

<!-- If applicable, add screenshots or code examples to help explain your changes -->
<!-- This is especially useful for new features or bug fixes with visual components -->

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- Mention if this is a work in progress, needs specific review, or has known limitations -->
