### PR TITLE
Fix VolumeSubdomain type hinting in docstrings/imports of Reaction and Trap classes

### DIFF
--- a/src/festim/reaction.py
+++ b/src/festim/reaction.py
@@ -6,33 +6,33 @@ from ufl.core.expr import Expr
 from festim import k_B as _k_B
 from festim.species import ImplicitSpecies as _ImplicitSpecies
 from festim.species import Species as _Species
-from festim.subdomain.volume_subdomain import VolumeSubdomain1D as VS1D
+from festim.subdomain.volume_subdomain import VolumeSubdomain
 
 
 class Reaction:
     """A reaction between two species, with a forward and backward rate.
 
-    Arguments:
+    Args:
         reactant (Union[F.Species, F.ImplicitSpecies], List[Union[F.Species,
-        F.ImplicitSpecies]]): The reactant.
+            F.ImplicitSpecies]]): The reactant.
         product (Optional[Union[F.Species, List[F.Species]]]): The product.
         k_0 (float): The forward rate constant pre-exponential factor.
         E_k (float): The forward rate constant activation energy.
         p_0 (float): The backward rate constant pre-exponential factor.
         E_p (float): The backward rate constant activation energy.
-        volume (F.VolumeSubdomain1D): The volume subdomain where the reaction
-        takes place.
+        volume (F.VolumeSubdomain): The volume subdomain where the reaction
+            takes place.
 
     Attributes:
         reactant (Union[F.Species, F.ImplicitSpecies], List[Union[F.Species,
-        F.ImplicitSpecies]]): The reactant.
+            F.ImplicitSpecies]]): The reactant.
         product (Optional[Union[F.Species, List[F.Species]]]): The product.
         k_0 (float): The forward rate constant pre-exponential factor.
         E_k (float): The forward rate constant activation energy.
         p_0 (float): The backward rate constant pre-exponential factor.
         E_p (float): The backward rate constant activation energy.
-        volume (F.VolumeSubdomain1D): The volume subdomain where the reaction
-        takes place.
+        volume (F.VolumeSubdomain): The volume subdomain where the reaction
+            takes place.
 
     Examples:
 
@@ -64,7 +64,7 @@ class Reaction:
         reactant: _Species | _ImplicitSpecies | list[_Species | _ImplicitSpecies],
         k_0: float,
         E_k: float,
-        volume: VS1D,
+        volume: VolumeSubdomain,
         product: Union[_Species, list[_Species]] | None = [],
         p_0: float | None = None,
         E_p: float | None = None,

--- a/src/festim/trap.py
+++ b/src/festim/trap.py
@@ -16,7 +16,7 @@ class Trap(_Species):
         E_k (float): the trapping rate constant activation energy (eV)
         p_0 (float): the detrapping rate constant pre-exponential factor (s-1)
         E_p (float): the detrapping rate constant activation energy (eV)
-        volume (F.VolumeSubdomain1D): The volume subdomain where the trap is.
+        volume (F.VolumeSubdomain): The volume subdomain where the trap is.
 
     Attributes:
         name (str, optional): a name given to the trap. Defaults to None.
@@ -25,7 +25,7 @@ class Trap(_Species):
         E_k (float): the trapping rate constant activation energy (eV)
         p_0 (float): the detrapping rate constant pre-exponential factor (s-1)
         E_p (float): the detrapping rate constant activation energy (eV)
-        volume (F.VolumeSubdomain1D): The volume subdomain where the trap is.
+        volume (F.VolumeSubdomain): The volume subdomain where the trap is.
         trapped_concentration (_Species): The immobile trapped concentration
         trap_reaction (_Reaction): The reaction for trapping the mobile conc.
         empty_trap_sites (F.ImplicitSpecies): The implicit species for the


### PR DESCRIPTION
## Description

### Summary
Updates type-hints in the docstrings for the `Reaction` and `Trap` classes to point to the dimension-agnostic `VolumeSubdomain`, rather than `VolumeSubdomain1D` subclass. In addition, it changes the import in `reaction.py` from `VolumeSubdomain1D` to the base class (`VolumeSubdomain`).

### Related Issues
Fixes #1199 

### Motivation and Context


## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Code refactoring (no functional changes, no API changes)
- [X] 📝 Documentation update
- [ ] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI configuration change

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [X] All existing tests pass locally (`pytest`)
- [ ] I have added new tests that prove my fix is effective or that my feature works

(@jhdark do you think a unit test would be helpful for enforcing import of VolumeSubdomain or is that too stringent?)

## Code Quality Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [X] My code follows the code style of this project (Ruff formatted: `ruff format .`)
- [X] My code passes linting checks (`ruff check .`)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas

## Documentation

<!-- Put an `x` in the boxes that apply -->

- [X] I have updated the documentation accordingly (if applicable)
- [X] I have added docstrings to new functions/classes following the project conventions