### PR TITLE
Bump minor version of scifem. Use --no-build-isolation for installation

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,7 +4,7 @@ on: [pull_request, push]
 jobs:
   benchmark:
     runs-on: ubuntu-latest
-    container: dolfinx/dolfinx:v0.10.0
+    container: dolfinx/dolfinx:v0.11.0
 
     steps:
       - name: Checkout code
@@ -16,7 +16,7 @@ jobs:
 
       - name: Install local package and dependencies
         run: |
-          pip install .[test]
+          python3 -m pip install .[test] --no-build-isolation
 
       - name: Run benchmark
         run: |

--- a/.github/workflows/ci_conda.yml
+++ b/.github/workflows/ci_conda.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Install local package and dependencies
       shell: bash -l {0}
       run: |
+        python3 -m pip install scikit-build-core
         python3 -m pip install .[test] --no-build-isolation
 
     - name: Run tests

--- a/.github/workflows/ci_conda.yml
+++ b/.github/workflows/ci_conda.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install local package and dependencies
       shell: bash -l {0}
       run: |
-        python -m pip install .[test]
+        python3 -m pip install .[test] --no-build-isolation
 
     - name: Run tests
       shell: bash -l {0}

--- a/.github/workflows/ci_conda.yml
+++ b/.github/workflows/ci_conda.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Create Conda environment
       shell: bash -l {0}
       run: |
-        conda install -c conda-forge python pip fenics-dolfinx=${{ matrix.dolfinx }} scifem io4dolfinx pyvista
+        conda install -c conda-forge python pip fenics-dolfinx=${{ matrix.dolfinx }} scifem io4dolfinx pyvista nanobind
 
     - name: Install local package and dependencies
       shell: bash -l {0}

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -20,12 +20,12 @@ jobs:
 
       - name: Install local package and dependencies
         run: |
-          python -m pip install scipy pyvista  # scipy needed in scifem, can be removed when scifem adds it to their dependencies
-          python -m pip install .[test]
+          python -m pip install pyvista
+          python3 -m pip install .[test] --no-build-isolation
 
       - name: Overload io4dolfinx
       #   if: ${{ matrix.container_version == 'nightly' }}
-        run: python3 -m pip install git+https://github.com/scientificcomputing/io4dolfinx.git
+        run: python3 -m pip install git+https://github.com/scientificcomputing/io4dolfinx.git --no-build-isolation
 
       - name: Run tests
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ description = "Finite element simulations of hydrogen transport"
 readme = "README.md"
 requires-python = ">=3.9"
 license = "Apache-2.0"
-dependencies = ["tqdm", "scifem>=0.20.2", "io4dolfinx"]
+dependencies = ["tqdm", "scifem>=0.20.0", "io4dolfinx"]
 classifiers = [
     "Natural Language :: English",
     "Topic :: Scientific/Engineering",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ description = "Finite element simulations of hydrogen transport"
 readme = "README.md"
 requires-python = ">=3.9"
 license = "Apache-2.0"
-dependencies = ["tqdm", "scifem>=0.2.13", "io4dolfinx"]
+dependencies = ["tqdm", "scifem>=0.20.2", "io4dolfinx"]
 classifiers = [
     "Natural Language :: English",
     "Topic :: Scientific/Engineering",


### PR DESCRIPTION
Bump minor version of scifem to get scipy as dependency.
Use `--no-build-isolation` for installation of scifem.