### PR TITLE
Fix: `CustomQuantity` with immobile `Species`

### DIFF
--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -553,12 +553,19 @@ class HydrogenTransportProblem(problem.ProblemBase):
 
                 # NOTE we need to change our D_global approach
                 D_kwargs = {
-                    f"D_{sp.name}": self._species_to_D_global[sp] for sp in self.species
+                    f"D_{sp.name}": self._species_to_D_global[sp]
+                    for sp in self.species
+                    if sp.mobile  # immobile species don't have a D_global
                 }
                 kwargs.update(D_kwargs)
-                kwargs["D"] = {sp.name: D_kwargs[f"D_{sp.name}"] for sp in self.species}
+                kwargs["D"] = {
+                    sp.name: D_kwargs[f"D_{sp.name}"]
+                    for sp in self.species
+                    if sp.mobile
+                }
                 if len(self.species) == 1:
-                    kwargs["D"] = kwargs[f"D_{self.species[0].name}"]
+                    if self.species[0].mobile:
+                        kwargs["D"] = kwargs[f"D_{self.species[0].name}"]
                 kwargs["x"] = ufl.SpatialCoordinate(self.mesh.mesh)
                 export.ufl_expr = export.expr(**kwargs)
 

--- a/test/system_tests/test_misc.py
+++ b/test/system_tests/test_misc.py
@@ -623,7 +623,10 @@ def test_weak_dirichlet_penalty_is_dimensionless(
 
 
 def test_custom_quantity_with_immobile_species():
-    """Test that a CustomQuantity can be defined on an immobile species."""
+    """
+    Test that a CustomQuantity can be defined on an immobile species.
+    See issue #1211
+    """
     my_model = F.HydrogenTransportProblem()
     my_model.mesh = F.Mesh1D([1, 2, 3])
 

--- a/test/system_tests/test_misc.py
+++ b/test/system_tests/test_misc.py
@@ -622,12 +622,15 @@ def test_weak_dirichlet_penalty_is_dimensionless(
     )
 
 
-def test_custom_quantity_with_immobile_species():
+@pytest.mark.parametrize(
+    "model_class", [F.HydrogenTransportProblem, F.HydrogenTransportProblemDiscontinuous]
+)
+def test_custom_quantity_with_immobile_species(model_class):
     """
     Test that a CustomQuantity can be defined on an immobile species.
     See issue #1211
     """
-    my_model = F.HydrogenTransportProblem()
+    my_model = model_class()
     my_model.mesh = F.Mesh1D([1, 2, 3])
 
     mat = F.Material(D_0=1.0, E_D=0.0)
@@ -641,8 +644,12 @@ def test_custom_quantity_with_immobile_species():
     my_model.subdomains = [vol]
 
     T = F.Species(name="T", mobile=False)
+    T_mobile = F.Species(name="T_mobile", mobile=True)
+    if isinstance(my_model, F.HydrogenTransportProblemDiscontinuous):
+        T.subdomains = [vol]
+        T_mobile.subdomains = [vol]
 
-    my_model.species = [T]
+    my_model.species = [T, T_mobile]
 
     my_model.temperature = 300
 

--- a/test/system_tests/test_misc.py
+++ b/test/system_tests/test_misc.py
@@ -620,3 +620,46 @@ def test_weak_dirichlet_penalty_is_dimensionless(
     assert np.allclose(errors, errors[0], rtol=1e-8), (
         f"errors {errors} depend on the diffusion coefficient"
     )
+
+
+def test_custom_quantity_with_immobile_species():
+    """Test that a CustomQuantity can be defined on an immobile species."""
+    my_model = F.HydrogenTransportProblem()
+    my_model.mesh = F.Mesh1D([1, 2, 3])
+
+    mat = F.Material(D_0=1.0, E_D=0.0)
+
+    vol = F.VolumeSubdomain1D(
+        borders=[1, 3],
+        id=1,
+        material=mat,
+    )
+
+    my_model.subdomains = [vol]
+
+    T = F.Species(name="T", mobile=False)
+
+    my_model.species = [T]
+
+    my_model.temperature = 300
+
+    def quantity_expr(**kwargs):
+        return 1
+
+    outlet_total = F.CustomQuantity(
+        expr=quantity_expr,
+        subdomain=vol,
+        title="Total T outlet rate",
+    )
+
+    my_model.exports = [outlet_total]
+
+    my_model.settings = F.Settings(
+        atol=1e8,
+        rtol=1e-8,
+        max_iterations=30,
+        transient=False,
+    )
+
+    my_model.initialise()
+    my_model.run()


### PR DESCRIPTION
## Description

### Summary
This PR makes sure we only fetch `D_global` for species that are mobile to avoid raising a `KeyError`

### Related Issues
Fixes #1211 

### Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Code refactoring (no functional changes, no API changes)
- [ ] 📝 Documentation update
- [ ] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI configuration change

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] All existing tests pass locally (`pytest`)
- [x] I have added new tests that prove my fix is effective or that my feature works



## Code Quality Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My code follows the code style of this project (Ruff formatted: `ruff format .`)
- [x] My code passes linting checks (`ruff check .`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Documentation

<!-- Put an `x` in the boxes that apply -->

- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added docstrings to new functions/classes following the project conventions

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here -->
<!-- What will users need to change in their code? -->
<!-- Delete this section if not applicable -->

## Screenshots/Examples

<!-- If applicable, add screenshots or code examples to help explain your changes -->
<!-- This is especially useful for new features or bug fixes with visual components -->

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- Mention if this is a work in progress, needs specific review, or has known limitations -->
