### PR TITLE
Codim: fix for the flux conservation bug across internal interfaces

### DIFF
--- a/src/festim/helpers.py
+++ b/src/festim/helpers.py
@@ -45,6 +45,7 @@ def as_mapped_function(
     temperature: fem.Function | fem.Constant | ufl.core.expr.Expr | None = None,
     species_dependent_value: dict[str, "Species"] | None = None,
     subdomain: "VolumeSubdomain | None" = None,
+    mesh: dolfinx.mesh.Mesh | None = None,
 ) -> ufl.core.expr.Expr:
     """Maps a user given callable function to the mesh, time, temperature or the
     concentration of other species within festim as needed.
@@ -74,6 +75,10 @@ def as_mapped_function(
         kwargs["x"] = x
     if "T" in arguments:
         kwargs["T"] = temperature
+    if "x" in arguments:
+        # the spatial coordinate must come from the mesh the integral is assembled
+        # over, which is not always the mesh the unknown lives on
+        kwargs["x"] = ufl.SpatialCoordinate(mesh or function_space.mesh)
 
     for name, species in (species_dependent_value or {}).items():
         # only pass the species the callable actually declares, as done above for
@@ -286,6 +291,7 @@ class Value:
         temperature: fem.Function | fem.Constant | ufl.core.expr.Expr | None = None,
         up_to_ufl_expr: bool | None = False,
         subdomain: "VolumeSubdomain | None" = None,
+        mesh: dolfinx.mesh.Mesh | None = None,
     ):
         """Converts a user given value to a relevent fenics object depending on the type
         of the value provided.
@@ -299,7 +305,17 @@ class Value:
             subdomain: the volume subdomain on which the value is evaluated. Only needed
                 in the discontinuous case to select the correct species solution,
                 optional
+            mesh: the mesh the integral carrying this value is assembled over.
+                Defaults to ``function_space.mesh``. Pass it explicitly when the two
+                differ -- a term coupling a codim-1 subdomain to the bulk is a
+                parent-mesh facet integral although its unknowns live on submeshes --
+                so that ``ufl.SpatialCoordinate`` and any ``fem.Constant`` are built
+                on the integration domain, not on the space of the unknown. Only
+                meaningful with ``up_to_ufl_expr=True``.
         """
+        if mesh is None and function_space is not None:
+            mesh = function_space.mesh
+
         if isinstance(
             self.input_value, fem.Constant | fem.Function | ufl.core.expr.Expr
         ):
@@ -315,7 +331,6 @@ class Value:
 
         elif callable(self.input_value):
             args = self.input_value.__code__.co_varnames
-            # if only t is an argument, create constant object
             if (
                 "t" in args
                 and "x" not in args
@@ -327,15 +342,14 @@ class Value:
                         "self.value should return a float or an int, not "
                         + f"{type(self.input_value(t=float(t)))} "
                     )
-
                 self.fenics_object = as_fenics_constant(
-                    value=self.input_value(t=float(t)), mesh=function_space.mesh
+                    value=self.input_value(t=float(t)), mesh=mesh
                 )
-
             elif up_to_ufl_expr:
                 self.fenics_object = as_mapped_function(
                     value=self.input_value,
                     function_space=function_space,
+                    mesh=mesh,
                     t=t,
                     temperature=temperature,
                     species_dependent_value=self.species_dependent_value,
@@ -343,6 +357,12 @@ class Value:
                 )
 
             else:
+                if mesh is not function_space.mesh:
+                    raise ValueError(
+                        "a value interpolated into `function_space` must be built on "
+                        "that space's mesh; `mesh` may only differ from "
+                        "`function_space.mesh` with `up_to_ufl_expr=True`."
+                    )
                 self.fenics_interpolation_expression, self.fenics_object = (
                     as_fenics_interp_expr_and_function(
                         value=self.input_value,

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -1657,32 +1657,35 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
             name = f"{species.name}_{subdomain.id}"
             species.subdomain_to_post_processing_solution[subdomain].name = name
 
+    def source_integration_mesh(self, source) -> dolfinx.mesh.Mesh:
+        """The mesh the integral carrying ``source`` is assembled over.
+
+        A source involving only fields of a manifold subdomain is integrated over that
+        manifold's submesh (:meth:`subdomain_measure`); one coupling the manifold to
+        the bulk is a facet integral of the parent mesh (:meth:`coupling_measure`).
+        """
+        if self.is_manifold_self_source(source):
+            return source.volume.submesh
+        if source.volume in self.manifold_to_volumes:
+            return self.mesh.mesh
+        return source.species.subdomain_to_function_space[source.volume].mesh
+
     def convert_source_input_values_to_fenics_objects(self):
         """For each source create the value_fenics."""
         for source in self._unpacked_sources:
-            # create value_fenics for all F.ParticleSource objects
             if isinstance(source, _source.ParticleSource):
-                V = source.species.subdomain_to_function_space[source.volume]
-
-                # a self source on a manifold is integrated over its submesh, so its
-                # time and temperature must live there; a coupling source is integrated
-                # on the parent mesh and keeps the parent-mesh ones
                 if self.is_manifold_self_source(source):
                     t = self.subdomain_time(source.volume)
                     temperature = self.subdomain_temperature(source.volume)
                 else:
                     t = self.t
                     temperature = self.temperature_fenics
-                    if source.volume in self.manifold_to_volumes:
-                        # a coupling source is integrated on the parent mesh, so its
-                        # spatial coordinate has to be the parent mesh's as well --
-                        # ufl.SpatialCoordinate of the manifold's submesh is silently
-                        # wrong under the "+"/"-" restriction of an interior manifold.
-                        # only function_space.mesh is read on the up_to_ufl_expr path
-                        V = dolfinx.fem.functionspace(self.mesh.mesh, ("CG", 1))
 
                 source.value.convert_input_value(
-                    function_space=V,
+                    function_space=source.species.subdomain_to_function_space[
+                        source.volume
+                    ],
+                    mesh=self.source_integration_mesh(source),
                     t=t,
                     temperature=temperature,
                     up_to_ufl_expr=True,

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -1673,6 +1673,13 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                 else:
                     t = self.t
                     temperature = self.temperature_fenics
+                    if source.volume in self.manifold_to_volumes:
+                        # a coupling source is integrated on the parent mesh, so its
+                        # spatial coordinate has to be the parent mesh's as well --
+                        # ufl.SpatialCoordinate of the manifold's submesh is silently
+                        # wrong under the "+"/"-" restriction of an interior manifold.
+                        # only function_space.mesh is read on the up_to_ufl_expr path
+                        V = dolfinx.fem.functionspace(self.mesh.mesh, ("CG", 1))
 
                 source.value.convert_input_value(
                     function_space=V,
@@ -2608,9 +2615,8 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         """For each particle flux create the ``value_fenics`` attribute."""
         for bc in self._unpacked_bcs:
             if isinstance(bc, boundary_conditions.ParticleFluxBC):
-                volume_subdomain = self.flux_bc_target(bc)[0]
                 bc.create_value_fenics(
-                    mesh=volume_subdomain.submesh,
+                    mesh=self.mesh.mesh,
                     temperature=self.temperature_fenics,
                     t=self.t,
                 )

--- a/test/system_tests/test_codim1_coupling.py
+++ b/test/system_tests/test_codim1_coupling.py
@@ -191,7 +191,9 @@ def test_codim1_coupling_2d():
 
 @pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only for now")
 def test_coupling_source_internal_subdomain():
-    """Emulate the repository MWE to verify codim-1 coupling terms."""
+    """Create a simple 2D codim-1 problem to verify codim-1 coupling terms are
+    being applied correctly. Compares against a known solution.
+    """
     D_BULK, D_GAMMA = 1.5, 0.7
     PLANE = 0.5
 

--- a/test/system_tests/test_codim1_coupling.py
+++ b/test/system_tests/test_codim1_coupling.py
@@ -190,6 +190,90 @@ def test_codim1_coupling_2d():
 
 
 @pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only for now")
+def test_coupling_source_internal_subdomain():
+    """Emulate the repository MWE to verify codim-1 coupling terms."""
+    D_BULK, D_GAMMA = 1.5, 0.7
+    PLANE = 0.5
+
+    mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 20, 20)
+
+    left = F.VolumeSubdomain(
+        id=1,
+        material=F.Material(D_0=D_BULK, E_D=0.0),
+        locator=lambda x: x[0] <= PLANE + 1e-14,
+    )
+    right = F.VolumeSubdomain(
+        id=2,
+        material=F.Material(D_0=D_BULK, E_D=0.0),
+        locator=lambda x: x[0] >= PLANE - 1e-14,
+    )
+    gamma = F.VolumeSubdomain(
+        id=3,
+        material=F.Material(D_0=D_GAMMA, E_D=0.0),
+        dim=1,
+        locator=lambda x: np.isclose(x[0], PLANE),
+    )
+    outer_l = F.SurfaceSubdomain(id=4, locator=lambda x: np.isclose(x[0], 0.0))
+    outer_r = F.SurfaceSubdomain(id=5, locator=lambda x: np.isclose(x[0], 1.0))
+
+    H_l = F.Species("H_l", subdomains=[left])
+    H_r = F.Species("H_r", subdomains=[right])
+    H_g = F.Species("H_g", subdomains=[gamma])
+
+    sources = [
+        F.ParticleSource(
+            value=lambda x, c_g, c_b: 4.0 * x[0] * (c_b - c_g),
+            species=H_g,
+            volume=gamma,
+            species_dependent_value={"c_b": H_l, "c_g": H_g},
+        ),
+        F.ParticleSource(
+            value=lambda x, c_g, c_b: 6.0 * x[0] * (c_b - c_g),
+            species=H_g,
+            volume=gamma,
+            species_dependent_value={"c_b": H_r, "c_g": H_g},
+        ),
+    ]
+    bcs = [
+        F.ParticleFluxBC(
+            subdomain=gamma,
+            species=H_l,
+            value=lambda x, c_g, c_b: 4.0 * x[0] * (c_g - c_b),
+            species_dependent_value={"c_b": H_l, "c_g": H_g},
+        ),
+        F.ParticleFluxBC(
+            subdomain=gamma,
+            species=H_r,
+            value=lambda x, c_g, c_b: 6.0 * x[0] * (c_g - c_b),
+            species_dependent_value={"c_b": H_r, "c_g": H_g},
+        ),
+        F.FixedConcentrationBC(subdomain=outer_l, value=2.0, species=H_l),
+        F.FixedConcentrationBC(subdomain=outer_r, value=0.0, species=H_r),
+    ]
+
+    model = F.HydrogenTransportProblemDiscontinuous(
+        mesh=F.Mesh(mesh),
+        species=[H_l, H_r, H_g],
+        subdomains=[left, right, gamma, outer_l, outer_r],
+        sources=sources,
+        boundary_conditions=bcs,
+        temperature=500,
+        exports=[],
+    )
+    model.settings = F.Settings(atol=1e-12, rtol=1e-12, transient=False)
+    model.initialise()
+    model.run()
+
+    c_l = H_l.subdomain_to_post_processing_solution[left].x.array
+    c_r = H_r.subdomain_to_post_processing_solution[right].x.array
+    c_g = H_g.subdomain_to_post_processing_solution[gamma].x.array
+
+    assert np.allclose(c_l.min(), 14.0 / 9.0, rtol=1e-6, atol=1e-8)
+    assert np.allclose(c_r.max(), 4.0 / 9.0, rtol=1e-6, atol=1e-8)
+    assert np.allclose(c_g.mean(), 8.0 / 9.0, rtol=1e-6, atol=1e-8)
+
+
+@pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only for now")
 def test_codim1_coupling_3d_tilted():
     """A 2D manifold in a 3D mesh, tilted with respect to every coordinate axis.
 


### PR DESCRIPTION
Migrated from #1227 so the branch lives on `festim-dev/FESTIM` rather than a fork.

Original work and commit authorship by @ee-nn — this PR contains the same commit (`f21898b`), unchanged.

## Description

Fix attempt for the flux conservation bug across internal interfaces in `HydrogenTransportProblemDiscontinuous`:

- Coupling sources on a manifold are integrated on the parent mesh, so their spatial coordinate must come from the parent mesh too — `ufl.SpatialCoordinate` of the manifold's submesh is silently wrong under the `+`/`-` restriction of an interior manifold.
- `ParticleFluxBC.create_value_fenics` now builds its value on the parent mesh instead of the target volume subdomain's submesh.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Testing

- [ ] All existing tests pass locally (`pytest`)
- [ ] I have added new tests that prove my fix is effective or that my feature works

## Additional Notes

Work in progress — carried over as-is from #1227. Based on `rem/codim-fix-for-0.10` (#1221).
