### PR TITLE
Codim: support for derived quantities

### DIFF
--- a/docs/source/userguide/subdomains.rst
+++ b/docs/source/userguide/subdomains.rst
@@ -255,6 +255,55 @@ a float or as a callable of ``x`` and ``t`` rather than as a ready-made
 subdomain rather than sharing one between a reaction on a manifold and a reaction
 elsewhere. Both are raised rather than silently mis-assembled.
 
+Exports on a manifold
+---------------------
+
+Derived quantities can be asked for in three places once a manifold is in the mesh.
+
+**Over the manifold**, for its own species — a volume quantity, with ``volume`` set to
+the manifold. It is integrated over the manifold itself, so a
+:class:`festim.TotalVolume` on a line in a 2D mesh is a line integral:
+
+.. code-block:: python
+
+    F.TotalVolume(field=c_gamma, volume=gamma)
+    F.AverageVolume(field=c_gamma, volume=gamma)
+
+**On the facets the manifold occupies**, for a *bulk* species — a surface quantity, with
+the manifold passed where a surface subdomain normally goes. This is the exchange
+between the bulk and the manifold:
+
+.. code-block:: python
+
+    F.SurfaceFlux(field=c_bulk, surface=gamma)
+    F.TotalSurface(field=c_bulk, surface=gamma)
+
+On an interior manifold, which side the quantity is read on follows from ``field``,
+exactly as it does for the flux boundary conditions above — declare one export per side,
+each naming that side's species. The sign convention is the ordinary one: a positive
+flux leaves the subdomain the species lives on, so an exchange from the left bulk to the
+right one through the manifold reads positive on the left and negative on the right.
+
+Asking for a manifold's *own* species on its own facets raises: it has no flux across
+the manifold, and the quantity meant is the volume one above.
+
+**On the boundary of the manifold** — a surface quantity whose ``surface`` is the
+codim-2 :class:`festim.SurfaceSubdomain` described in the previous section. This is what
+gives the outlet flux of the pipe example:
+
+.. code-block:: python
+
+    outlet = F.SurfaceSubdomain(id=4, dim=0,
+                                locator=lambda x: np.isclose(x[0], L))
+    ...
+    exports=[F.SurfaceFlux(field=c_fluid, surface=outlet)]
+
+.. note::
+
+    :class:`festim.SurfaceFlux` computes the **diffusive** flux only. On a manifold
+    carrying an :class:`festim.AdvectionTerm` the advective part is not included, and
+    FESTIM warns.
+
 Limitations
 -----------
 
@@ -265,8 +314,12 @@ Limitations
   so the exchange with it would not be well posed.
 * Boundary conditions on the boundary of a manifold are limited to
   :class:`festim.FixedConcentrationBC`.
-* Dedicated exports on a manifold or on its boundary are not available;
-  :class:`festim.VTXSpeciesExport` on a manifold works.
+* Exports on and around a manifold are limited to the integral-based derived quantities
+  (:class:`festim.SurfaceFlux`, :class:`festim.TotalSurface`,
+  :class:`festim.AverageSurface`, :class:`festim.TotalVolume`,
+  :class:`festim.AverageVolume`) and :class:`festim.VTXSpeciesExport`. The minimum and
+  maximum quantities are not available in
+  :class:`festim.HydrogenTransportProblemDiscontinuous` at all, manifold or not.
 * Cartesian coordinates only.
 
 ----------

--- a/docs/source/userguide/subdomains.rst
+++ b/docs/source/userguide/subdomains.rst
@@ -318,7 +318,7 @@ Limitations
   (:class:`festim.SurfaceFlux`, :class:`festim.TotalSurface`,
   :class:`festim.AverageSurface`, :class:`festim.TotalVolume`,
   :class:`festim.AverageVolume`) and :class:`festim.VTXSpeciesExport`. The minimum and
-  maximum quantities are not available in
+  maximum quantities and :class:`festim.CustomQuantity` are not available in
   :class:`festim.HydrogenTransportProblemDiscontinuous` at all, manifold or not.
 * Cartesian coordinates only.
 

--- a/src/festim/exports/average_surface.py
+++ b/src/festim/exports/average_surface.py
@@ -3,6 +3,7 @@ from dolfinx import fem
 from scifem import assemble_scalar
 
 from festim.exports.surface_quantity import SurfaceQuantity
+from festim.helpers import restrict
 
 
 class AverageSurface(SurfaceQuantity):
@@ -23,7 +24,11 @@ class AverageSurface(SurfaceQuantity):
         return f"Average {self.field.name} surface {self.surface.id}"
 
     def compute(
-        self, u: fem.Function | ufl.indexed.Indexed, ds: ufl.Measure, entity_maps=None
+        self,
+        u: fem.Function | ufl.indexed.Indexed,
+        ds: ufl.Measure,
+        entity_maps=None,
+        restriction: str | None = None,
     ):
         """Computes the average value of the field on the defined surface subdomain, and
         appends it to the data list.
@@ -32,9 +37,17 @@ class AverageSurface(SurfaceQuantity):
             u: field for which the average value is computed
             ds: surface measure of the model
             entity_maps: entity maps relating parent mesh and submesh
+            restriction: which side of an interior facet to read the field on, when
+                ``ds`` is an interior facet measure
         """
 
         self.value = assemble_scalar(
-            fem.form(u * ds(self.surface.id), entity_maps=entity_maps)
-        ) / assemble_scalar(fem.form(1 * ds(self.surface.id), entity_maps=entity_maps))
+            fem.form(
+                restrict(u, restriction) * ds(self.surface.id), entity_maps=entity_maps
+            )
+        ) / assemble_scalar(
+            fem.form(
+                restrict(1, restriction) * ds(self.surface.id), entity_maps=entity_maps
+            )
+        )
         self.data.append(self.value)

--- a/src/festim/exports/surface_flux.py
+++ b/src/festim/exports/surface_flux.py
@@ -3,16 +3,22 @@ from dolfinx import fem
 from scifem import assemble_scalar
 
 from festim.exports.surface_quantity import SurfaceQuantity
+from festim.helpers import restrict
 from festim.species import Species
 from festim.subdomain.surface_subdomain import SurfaceSubdomain
+from festim.subdomain.volume_subdomain import VolumeSubdomain
 
 
 class SurfaceFlux(SurfaceQuantity):
     """Computes the flux of a field on a given surface.
 
+    Only the diffusive flux is computed: an advection term on the subdomain is not
+    accounted for, and FESTIM warns when one is present.
+
     Args:
         field: species for which the surface flux is computed
-        surface: surface subdomain
+        surface: surface subdomain. See `festim.SurfaceQuantity` for the codimensional
+            cases -- a manifold, or the boundary of one.
         filename: name of the file to which the surface flux is exported
 
     Attributes:
@@ -20,7 +26,7 @@ class SurfaceFlux(SurfaceQuantity):
     """
 
     field: Species
-    surface: SurfaceSubdomain
+    surface: SurfaceSubdomain | VolumeSubdomain
     filename: str
 
     title: str
@@ -32,12 +38,19 @@ class SurfaceFlux(SurfaceQuantity):
         return f"{self.field.name} flux surface {self.surface.id}"
 
     def __init__(
-        self, field: Species, surface: SurfaceSubdomain, filename: str | None = None
+        self,
+        field: Species,
+        surface: SurfaceSubdomain | VolumeSubdomain,
+        filename: str | None = None,
     ) -> None:
         super().__init__(field=field, surface=surface, filename=filename)
 
     def compute(
-        self, u: fem.Function | ufl.indexed.Indexed, ds: ufl.Measure, entity_maps=None
+        self,
+        u: fem.Function | ufl.indexed.Indexed,
+        ds: ufl.Measure,
+        entity_maps=None,
+        restriction: str | None = None,
     ):
         """Computes the value of the flux at the surface.
 
@@ -45,15 +58,21 @@ class SurfaceFlux(SurfaceQuantity):
             u: field for which the flux is computed
             ds: surface measure of the model
             entity_maps: entity maps relating parent mesh and submesh
+            restriction: which side of an interior facet to evaluate the flux on, when
+                ``ds`` is an interior facet measure. The whole integrand is restricted,
+                so the normal is the one pointing out of that side and the sign
+                convention matches an exterior surface.
         """
 
         # obtain mesh normal from integration domain
         mesh = ds.ufl_domain()
         n = ufl.FacetNormal(mesh)
 
+        integrand = -self.D * ufl.dot(ufl.grad(u), n)
+
         self.value = assemble_scalar(
             fem.form(
-                -self.D * ufl.dot(ufl.grad(u), n) * ds(self.surface.id),
+                restrict(integrand, restriction) * ds(self.surface.id),
                 entity_maps=entity_maps,
             )
         )

--- a/src/festim/exports/surface_quantity.py
+++ b/src/festim/exports/surface_quantity.py
@@ -58,11 +58,10 @@ class SurfaceQuantity(DerivedQuantity):
     @surface.setter
     def surface(self, value):
         # a manifold is a codim-1 VolumeSubdomain and is passed directly wherever a
-        # surface is expected. Whether it really is codim 1 needs the mesh, so it is
-        # checked at initialisation instead: HydrogenTransportProblemDiscontinuous in
-        # export_surface_context, and every other problem class in
-        # HydrogenTransportProblem.initialise_exports, which rejects volume subdomains
-        # outright since only that one class supports manifolds
+        # surface is expected. Checking whether it really is codim 1 needs the mesh, 
+        # so it's checked at initialisation: via export_surface_context in
+        # HydrogenTransportProblemDiscontinuous, and rejected outright in 
+        # HydrogenTransportProblem and its children since they don't support codim
         accepted = int | SurfaceSubdomain | VolumeSubdomain
         if not isinstance(value, accepted) or isinstance(value, bool):
             raise TypeError(

--- a/src/festim/exports/surface_quantity.py
+++ b/src/festim/exports/surface_quantity.py
@@ -3,6 +3,7 @@ from abc import abstractmethod
 from festim.exports.derived_quantity import DerivedQuantity
 from festim.species import Species
 from festim.subdomain.surface_subdomain import SurfaceSubdomain
+from festim.subdomain.volume_subdomain import VolumeSubdomain
 
 
 class SurfaceQuantity(DerivedQuantity):
@@ -10,7 +11,10 @@ class SurfaceQuantity(DerivedQuantity):
 
     Args:
         field: species for which the surface flux is computed
-        surface: surface subdomain
+        surface: surface subdomain. A codim-1 ``VolumeSubdomain`` (a manifold) may be
+            given instead, to compute the quantity on the facets it occupies -- for a
+            *bulk* species, since a manifold's own species has no flux across it. A
+            codim-2 ``SurfaceSubdomain`` computes it on the boundary of a manifold.
         filename: name of the file to which the surface flux is exported
 
     Attributes:
@@ -22,7 +26,7 @@ class SurfaceQuantity(DerivedQuantity):
     """
 
     field: Species
-    surface: SurfaceSubdomain
+    surface: SurfaceSubdomain | VolumeSubdomain
     filename: str | None
 
     t: list[float]
@@ -31,7 +35,7 @@ class SurfaceQuantity(DerivedQuantity):
     def __init__(
         self,
         field: Species | str,
-        surface: SurfaceSubdomain | int,
+        surface: SurfaceSubdomain | VolumeSubdomain | int,
         filename: str | None = None,
     ) -> None:
         super().__init__(filename=filename)
@@ -53,8 +57,18 @@ class SurfaceQuantity(DerivedQuantity):
 
     @surface.setter
     def surface(self, value):
-        if not isinstance(value, int | SurfaceSubdomain) or isinstance(value, bool):
-            raise TypeError("surface should be an int or F.SurfaceSubdomain")
+        # a manifold is a codim-1 VolumeSubdomain and is passed directly wherever a
+        # surface is expected. Whether it really is codim 1 needs the mesh, so it is
+        # checked at initialisation instead: HydrogenTransportProblemDiscontinuous in
+        # export_surface_context, and every other problem class in
+        # HydrogenTransportProblem.initialise_exports, which rejects volume subdomains
+        # outright since only that one class supports manifolds
+        accepted = int | SurfaceSubdomain | VolumeSubdomain
+        if not isinstance(value, accepted) or isinstance(value, bool):
+            raise TypeError(
+                "surface should be an int, F.SurfaceSubdomain or a codim-1 "
+                "F.VolumeSubdomain"
+            )
 
         self._surface = value
 

--- a/src/festim/exports/surface_quantity.py
+++ b/src/festim/exports/surface_quantity.py
@@ -58,9 +58,9 @@ class SurfaceQuantity(DerivedQuantity):
     @surface.setter
     def surface(self, value):
         # a manifold is a codim-1 VolumeSubdomain and is passed directly wherever a
-        # surface is expected. Checking whether it really is codim 1 needs the mesh, 
+        # surface is expected. Checking whether it really is codim 1 needs the mesh,
         # so it's checked at initialisation: via export_surface_context in
-        # HydrogenTransportProblemDiscontinuous, and rejected outright in 
+        # HydrogenTransportProblemDiscontinuous, and rejected outright in
         # HydrogenTransportProblem and its children since they don't support codim
         accepted = int | SurfaceSubdomain | VolumeSubdomain
         if not isinstance(value, accepted) or isinstance(value, bool):

--- a/src/festim/exports/total_surface.py
+++ b/src/festim/exports/total_surface.py
@@ -3,6 +3,7 @@ from dolfinx import fem
 from scifem import assemble_scalar
 
 from festim.exports.surface_quantity import SurfaceQuantity
+from festim.helpers import restrict
 
 
 class TotalSurface(SurfaceQuantity):
@@ -22,7 +23,11 @@ class TotalSurface(SurfaceQuantity):
         return f"Total {self.field.name} surface {self.surface.id}"
 
     def compute(
-        self, u: fem.Function | ufl.indexed.Indexed, ds: ufl.Measure, entity_maps=None
+        self,
+        u: fem.Function | ufl.indexed.Indexed,
+        ds: ufl.Measure,
+        entity_maps=None,
+        restriction: str | None = None,
     ):
         """Computes the total value of the field on the defined surface subdomain, and
         appends it to the data list.
@@ -31,9 +36,13 @@ class TotalSurface(SurfaceQuantity):
             u: field for which the total value is computed
             ds: surface measure of the model
             entity_maps: entity maps relating parent mesh and submesh
+            restriction: which side of an interior facet to read the field on, when
+                ``ds`` is an interior facet measure
         """
 
         self.value = assemble_scalar(
-            fem.form(u * ds(self.surface.id), entity_maps=entity_maps)
+            fem.form(
+                restrict(u, restriction) * ds(self.surface.id), entity_maps=entity_maps
+            )
         )
         self.data.append(self.value)

--- a/src/festim/helpers.py
+++ b/src/festim/helpers.py
@@ -125,6 +125,29 @@ def solution_on(species: "Species", subdomain: "VolumeSubdomain"):
     )
 
 
+def restrict(expression, restriction: str | None):
+    """Apply ``restriction`` to a whole expression.
+
+    Interior facet integrals need every discontinuous terminal restricted to one side
+    of the facet. Restricting the expression as a whole rather than each terminal keeps
+    a compound cross-mesh expression -- ``k * (c_bulk - c_manifold)``, or a flux
+    ``-D * grad(c) . n`` -- on a single side, which also picks the outward normal of
+    that side.
+
+    Args:
+        expression: the ufl expression to restrict
+        restriction: ``"+"``, ``"-"``, or ``None`` for an exterior facet integral, where
+            nothing needs restricting
+
+    Returns:
+        The restricted expression, or ``expression`` unchanged when ``restriction`` is
+        ``None``
+    """
+    if restriction is None:
+        return expression
+    return ufl.as_ufl(expression)(restriction)
+
+
 def as_fenics_interp_expr_and_function(
     value: Callable,
     function_space: dolfinx.fem.function.FunctionSpace,

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -525,10 +525,8 @@ class HydrogenTransportProblem(problem.ProblemBase):
                 ):
                     raise TypeError(
                         f"volume subdomain {export.surface.id} was given as the "
-                        f"surface of a {type(export).__name__}. Only a codim-1 volume "
-                        "subdomain can be, and only in "
-                        "HydrogenTransportProblemDiscontinuous, the sole problem class "
-                        "supporting manifolds."
+                        f"surface of a {type(export).__name__}. Co-dim volume subomains"
+                        "are only supported by HydrogenTransportProblemDiscontinuous"
                     )
 
             # clean data for profile1D export

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -525,8 +525,9 @@ class HydrogenTransportProblem(problem.ProblemBase):
                 ):
                     raise TypeError(
                         f"volume subdomain {export.surface.id} was given as the "
-                        f"surface of a {type(export).__name__}. Co-dim volume subomains"
-                        "are only supported by HydrogenTransportProblemDiscontinuous"
+                        f"surface of a {type(export).__name__}. Co-dim volume "
+                        "subdomains are only supported by "
+                        "HydrogenTransportProblemDiscontinuous"
                     )
 
             # clean data for profile1D export

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -46,6 +46,9 @@ from festim.helpers import (
     is_it_time_to_export,
     nmm_interpolate,
 )
+from festim.helpers import (
+    restrict as _restrict,
+)
 from festim.mixed_dimensional_assembly import (
     custom_assemble_jacobian,
     custom_assemble_residual,
@@ -511,6 +514,21 @@ class HydrogenTransportProblem(problem.ProblemBase):
                     raise NotImplementedError(
                         f"Derived quantity exports are not implemented for "
                         f"{self.mesh.coordinate_system!s} meshes"
+                    )
+
+                # a volume subdomain is accepted as a surface only to let a codim-1
+                # one (a manifold) through, and manifolds exist only in
+                # HydrogenTransportProblemDiscontinuous. Here the id would be looked
+                # up in the facet tags, silently reporting some other surface's value
+                if isinstance(export, exports.SurfaceQuantity) and isinstance(
+                    export.surface, _subdomain.VolumeSubdomain
+                ):
+                    raise TypeError(
+                        f"volume subdomain {export.surface.id} was given as the "
+                        f"surface of a {type(export).__name__}. Only a codim-1 volume "
+                        "subdomain can be, and only in "
+                        "HydrogenTransportProblemDiscontinuous, the sole problem class "
+                        "supporting manifolds."
                     )
 
             # clean data for profile1D export
@@ -1320,6 +1338,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         )
         self._coupling_measures = {}
         self._manifold_is_interior = {}
+        self._manifold_export_measures = {}
         self.manifold_to_volumes = _subdomain.map_manifold_to_volume_subdomains(
             ft=self.facet_meshtags,
             ct=self.volume_meshtags,
@@ -1787,8 +1806,17 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         :meth:`restriction_of`); when the same subdomain lies on both sides there is
         nothing to order, because the bulk field is single-valued across the facet.
         """
+        return self.unindexed_coupling_measure(manifold)(manifold.id)
+
+    def unindexed_coupling_measure(self, manifold: _subdomain.VolumeSubdomain):
+        """As :meth:`coupling_measure`, but not yet restricted to the manifold's id.
+
+        Derived quantities index the measure they are handed by the id of the subdomain
+        they export, exactly as they do with the parent ``ds``, so they need the measure
+        itself rather than an integral over it.
+        """
         if not self.manifold_is_interior(manifold):
-            return self.ds(manifold.id)
+            return self.ds
 
         # memoised: DOLFINx requires every integral of a compiled form to share the
         # *same* subdomain_data object, not merely an equal one
@@ -1816,7 +1844,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
             self._coupling_measures[manifold] = ufl.Measure(
                 "dS", domain=self.mesh.mesh, subdomain_data=[integral_data]
             )
-        return self._coupling_measures[manifold](manifold.id)
+        return self._coupling_measures[manifold]
 
     def restriction_of(
         self, manifold: _subdomain.VolumeSubdomain, volume: _subdomain.VolumeSubdomain
@@ -1838,9 +1866,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
     def restrict(self, expression, restriction: str | None):
         """Apply ``restriction`` to a whole expression, or return it unchanged when the
         coupling is on exterior facets."""
-        if restriction is None:
-            return expression
-        return expression(restriction)
+        return _restrict(expression, restriction)
 
     def coupling_side(
         self, manifold: _subdomain.VolumeSubdomain, species: _species.Species
@@ -2624,6 +2650,142 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                     t=self.t,
                 )
 
+    def export_volume_measure(self, volume: _subdomain.VolumeSubdomain):
+        """The measure a volume quantity over ``volume`` is integrated with.
+
+        A manifold's fields live on its own submesh, so its integrals are taken there --
+        the parent ``dx`` carries no cell tagged with a manifold's id, and assembling a
+        submesh field against a parent measure fails inside FFCx anyway. The measure is
+        given a meshtag covering the whole submesh so that the export can index it by
+        the subdomain id, exactly as it does with the parent ``dx``.
+        """
+        if volume.codim(self.mesh.vdim) != 1:
+            return self.dx
+
+        if volume not in self._manifold_export_measures:
+            submesh = volume.submesh
+            tdim = submesh.topology.dim
+            # owned cells only: a ghost would be counted twice in parallel
+            cells = np.arange(
+                submesh.topology.index_map(tdim).size_local, dtype=np.int32
+            )
+            tags = dolfinx.mesh.meshtags(
+                submesh, tdim, cells, np.full(len(cells), volume.id, dtype=np.int32)
+            )
+            self._manifold_export_measures[volume] = ufl.Measure(
+                "dx", domain=submesh, subdomain_data=tags
+            )
+        return self._manifold_export_measures[volume]
+
+    def _manifold_boundary_measure(
+        self,
+        surface: _subdomain.SurfaceSubdomain,
+        manifold: _subdomain.VolumeSubdomain,
+    ):
+        """The ``ds`` measure on ``manifold``'s submesh selecting ``surface``.
+
+        The boundary of a manifold is codim-1 *relative to the manifold*, so this is an
+        ordinary exterior facet integral on its submesh rather than a codim-2 integral
+        of the parent mesh -- the endpoints of a line in 2D are the facets of a 1D mesh.
+        The same reasoning already locates the dofs of a Dirichlet BC there.
+
+        Raises:
+            ValueError: if the locator matches no boundary entity of the manifold
+        """
+        key = (surface, manifold)
+        if key not in self._manifold_export_measures:
+            submesh = manifold.submesh
+            fdim = submesh.topology.dim - 1
+            submesh.topology.create_connectivity(fdim, submesh.topology.dim)
+            entities = surface.locate_boundary_facet_indices(submesh)
+            # a locator matching nothing, or only points interior to the manifold, would
+            # otherwise leave the export quietly reporting zero
+            if self.mesh.mesh.comm.allreduce(len(entities), op=MPI.SUM) == 0:
+                raise ValueError(
+                    f"the locator of surface subdomain {surface.id} matched no "
+                    f"boundary entity of codim-1 volume subdomain {manifold.id}. It "
+                    "must select a point on the boundary of that subdomain, not one "
+                    "inside it."
+                )
+            entities = np.sort(entities).astype(np.int32)
+            tags = dolfinx.mesh.meshtags(
+                submesh,
+                fdim,
+                entities,
+                np.full(len(entities), surface.id, dtype=np.int32),
+            )
+            self._manifold_export_measures[key] = ufl.Measure(
+                "ds", domain=submesh, subdomain_data=tags
+            )
+        return self._manifold_export_measures[key]
+
+    def export_surface_context(self, export: exports.SurfaceQuantity):
+        """Everything a surface quantity needs to know about where it is computed.
+
+        Three cases, and the ordinary one is unchanged:
+
+        - an ordinary ``SurfaceSubdomain``: the parent ``ds``, and the volume subdomain
+          it bounds;
+        - a **manifold** (codim-1 ``VolumeSubdomain``): the facets it occupies, read
+          from the bulk side that ``export.field`` lives on. Interior manifolds use the
+          ``dS`` coupling measure with that side's restriction -- the parent ``ds``
+          integrates to exactly zero over interior facets, which would be a silent zero
+          rather than an error;
+        - a **codim-2 ``SurfaceSubdomain``**: the boundary of the manifold that
+          ``export.field`` lives on, integrated on that manifold's submesh.
+
+        Returns:
+            ``(volume, mesh, measure, restriction, entity_maps)`` where ``volume`` is
+            the subdomain whose solution and material the quantity reads, and ``mesh``
+            the one the integral is taken on -- the parent mesh except on the boundary
+            of a manifold.
+
+        Raises:
+            ValueError: if the volume subdomain given as a surface is not a manifold, or
+                if a manifold's own species is asked for on that manifold's facets,
+                which is not a flux across anything
+        """
+        surface = export.surface
+        entity_maps = [sd.cell_map for sd in self.volume_subdomains]
+        parent = self.mesh.mesh
+
+        if isinstance(surface, _subdomain.VolumeSubdomain):
+            if surface.codim(self.mesh.vdim) != 1:
+                raise ValueError(
+                    f"volume subdomain {surface.id} is not a manifold, so it cannot be "
+                    "used as the surface of a derived quantity. Only a codim-1 volume "
+                    "subdomain occupies facets; give a surface subdomain, or a volume "
+                    "quantity over this subdomain."
+                )
+            if surface in export.field.subdomains:
+                raise ValueError(
+                    f"species {export.field.name} lives on codim-1 volume subdomain "
+                    f"{surface.id} itself, so it has no flux across it. Export it with "
+                    "a volume quantity over that subdomain instead, or name a bulk "
+                    "species to get the exchange with one side of it."
+                )
+            volume = self.coupling_side(surface, export.field)
+            return (
+                volume,
+                parent,
+                self.unindexed_coupling_measure(surface),
+                self.restriction_of(surface, volume),
+                entity_maps,
+            )
+
+        if surface.codim(self.mesh.vdim) == 2:
+            manifold = self.manifold_of(surface, export.field)
+            # everything lives on the submesh, so no entity map is involved
+            return (
+                manifold,
+                manifold.submesh,
+                self._manifold_boundary_measure(surface, manifold),
+                None,
+                None,
+            )
+
+        return self.surface_to_volume[surface], parent, self.ds, None, entity_maps
+
     def _export_context(
         self, export
     ) -> tuple[list[fem.Function], list[str], dolfinx.mesh.Mesh]:
@@ -2698,9 +2860,17 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         # HydrogenTransportProblem
         for export in self.exports:
             if isinstance(export, exports.SurfaceQuantity):
-                volume = self.surface_to_volume[export.surface]
+                volume, mesh, *_ = self.export_surface_context(export)
+                # on the boundary of a manifold the integral is taken on that manifold's
+                # submesh, and like every other coefficient of a submesh integral D has
+                # to be built there rather than on the parent mesh
+                temperature = (
+                    self.subdomain_temperature(volume)
+                    if mesh is not self.mesh.mesh
+                    else self.temperature_fenics
+                )
                 D = volume.material.get_diffusion_coefficient(
-                    self.mesh.mesh, self.temperature_fenics, export.field
+                    mesh, temperature, export.field
                 )
                 # NOTE: maybe we need to make sure there are no functionspace clashes?
 
@@ -2783,15 +2953,18 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                             "Advection terms are not currently accounted for in the "
                             "evaluation of surface flux values"
                         )
-                    export_surf = export.surface
-                    export_vol = self.surface_to_volume[export_surf]
+                    export_vol, _, measure, restriction, entity_maps = (
+                        self.export_surface_context(export)
+                    )
                     submesh_function = (
                         export.field.subdomain_to_post_processing_solution[export_vol]
                     )
-                    entity_maps = [sd.cell_map for sd in self.volume_subdomains]
 
                     export.compute(
-                        u=submesh_function, ds=self.ds, entity_maps=entity_maps
+                        u=submesh_function,
+                        ds=measure,
+                        entity_maps=entity_maps,
+                        restriction=restriction,
                     )
                 else:
                     export.compute()
@@ -2804,7 +2977,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                         u=export.field.subdomain_to_post_processing_solution[
                             export.volume
                         ],
-                        dx=self.dx,
+                        dx=self.export_volume_measure(export.volume),
                         entity_maps=entity_maps,
                     )
                 else:

--- a/test/system_tests/test_codim1_exports.py
+++ b/test/system_tests/test_codim1_exports.py
@@ -189,14 +189,16 @@ def test_flux_on_an_interior_manifold_is_not_silently_zero():
     sides, so a swapped ``"+"``/``"-"`` would give the wrong number rather than the
     same one twice.
     """
-    from .test_codim1_interface import build
+    from .test_codim1_interface import D_BULK, build
 
-    model, (_left, _right, gamma), (H_l, H_r, H_g) = build(n=20)
+    model, (left, right, gamma), (H_l, H_r, H_g) = build(n=20)
     model.exports = [
         F.SurfaceFlux(field=H_l, surface=gamma),
         F.SurfaceFlux(field=H_r, surface=gamma),
         F.TotalSurface(field=H_l, surface=gamma),
         F.TotalSurface(field=H_r, surface=gamma),
+        F.AverageSurface(field=H_l, surface=gamma),
+        F.AverageSurface(field=H_r, surface=gamma),
         F.TotalVolume(field=H_g, volume=gamma),
     ]
     model.initialise()
@@ -209,6 +211,34 @@ def test_flux_on_an_interior_manifold_is_not_silently_zero():
     assert np.isclose(got["Total H_l surface 3"], 14 / 9, atol=1e-10)
     assert np.isclose(got["Total H_r surface 3"], 4 / 9, atol=1e-10)
     assert np.isclose(got["Total H_g volume 3"], 8 / 9, atol=1e-10)
+    # the solution is uniform along Gamma and Gamma has unit measure, so the averages
+    # are the totals -- which also pins the measure the average divides by
+    assert np.isclose(got["Average H_l surface 3"], 14 / 9, atol=1e-10)
+    assert np.isclose(got["Average H_r surface 3"], 4 / 9, atol=1e-10)
+
+    # the same two fluxes assembled by hand from the solutions, on the coupling measure
+    # and restriction the *formulation* uses, so they go nowhere near the export layer:
+    # a wrong integrand, measure or side in the exports shows up as a disagreement here
+    # even if the closed form above were ever relaxed
+    parent = model.mesh.mesh
+    n = ufl.FacetNormal(parent)
+    dS_gamma = model.coupling_measure(gamma)
+    for species, volume, title in (
+        (H_l, left, "H_l flux surface 3"),
+        (H_r, right, "H_r flux surface 3"),
+    ):
+        c = species.subdomain_to_post_processing_solution[volume]
+        by_hand = dolfinx.fem.assemble_scalar(
+            dolfinx.fem.form(
+                model.restrict(
+                    -D_BULK * ufl.dot(ufl.grad(c), n),
+                    model.restriction_of(gamma, volume),
+                )
+                * dS_gamma,
+                entity_maps=[sd.cell_map for sd in model.volume_subdomains],
+            )
+        )
+        assert np.isclose(by_hand, got[title], atol=1e-10)
 
 
 @pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only for now")
@@ -226,7 +256,8 @@ def test_interior_manifold_flux_balance():
     model.initialise()
     model.run()
 
-    into_gamma, out_of_gamma = (e.data[-1] for e in model.exports)
+    got = by_title(model)
+    into_gamma, out_of_gamma = got["H_l flux surface 3"], got["H_r flux surface 3"]
     assert np.isclose(into_gamma + out_of_gamma, 0.0, atol=1e-10)
 
 
@@ -388,5 +419,5 @@ def test_volume_as_a_surface_raises_in_a_problem_without_manifolds():
         temperature=500,
         settings=F.Settings(atol=1e-10, rtol=1e-10, transient=False),
     )
-    with pytest.raises(TypeError, match="Only a codim-1 volume subdomain"):
+    with pytest.raises(TypeError, match="only supported by .*Discontinuous"):
         model.initialise()

--- a/test/system_tests/test_codim1_exports.py
+++ b/test/system_tests/test_codim1_exports.py
@@ -1,0 +1,392 @@
+"""Derived quantities on and around a codim-1 (manifold) subdomain. See issue #1208.
+
+Three places a quantity can be asked for once a manifold is in the mesh, none of which
+the export layer could reach before:
+
+- the **facets a manifold occupies**, for a *bulk* species -- the exchange between the
+  bulk and the manifold. On an interior manifold this needs the ``dS`` coupling measure
+  and the restriction of the side the species lives on: the parent ``ds`` integrates to
+  exactly zero over interior facets, so getting this wrong is a silent zero rather than
+  an error;
+- the **manifold itself**, for its own species, integrated over its submesh;
+- the **boundary of a manifold**, which is codim-1 *relative to the manifold* and so an
+  ordinary exterior facet integral on its submesh -- the outlet of the pipe of
+  ``test_codim1_boundary.py``.
+
+Every value asserted here is a closed form, and the sign convention is the one an
+ordinary surface flux already has: positive means leaving the subdomain the species
+lives on.
+"""
+
+from itertools import pairwise
+
+from mpi4py import MPI
+
+import dolfinx
+import numpy as np
+import pytest
+import ufl
+
+import festim as F
+
+D_O, D_G, K_EX = 1.5, 0.7, 2.0
+BETA = 1.0 - D_O / K_EX
+OMEGA_ID, GAMMA_ID, RIGHT_ID, END_ID = 1, 2, 3, 4
+
+pi = np.pi
+
+
+def exterior_model(n=32, exports=()):
+    """The manufactured problem of ``test_codim1_coupling.py`` in 2D, with Gamma on the
+    outer boundary ``x=0``::
+
+        c_O = 1 + x^2 + (1 + x) cos(pi y)      c_G = 1 + beta cos(pi y)
+
+    so the quantities below are all known in closed form.
+    """
+    mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, n, n)
+
+    omega = F.VolumeSubdomain(
+        id=OMEGA_ID,
+        material=F.Material(D_0=D_O, E_D=0.0),
+        locator=lambda x: np.full_like(x[0], True, dtype=bool),
+    )
+    gamma = F.VolumeSubdomain(
+        id=GAMMA_ID,
+        material=F.Material(D_0=D_G, E_D=0.0),
+        dim=1,
+        locator=lambda x: np.isclose(x[0], 0.0),
+    )
+    right = F.SurfaceSubdomain(id=RIGHT_ID, locator=lambda x: np.isclose(x[0], 1.0))
+
+    H_om = F.Species("H_om", subdomains=[omega])
+    H_gam = F.Species("H_gam", subdomains=[gamma])
+
+    model = F.HydrogenTransportProblemDiscontinuous(
+        mesh=F.Mesh(mesh),
+        species=[H_om, H_gam],
+        subdomains=[omega, gamma, right],
+        sources=[
+            F.ParticleSource(
+                value=lambda x: -D_O * (2 - pi**2 * (1 + x[0]) * ufl.cos(pi * x[1])),
+                species=H_om,
+                volume=omega,
+            ),
+            F.ParticleSource(
+                value=lambda x: (D_G * pi**2 * BETA - D_O) * ufl.cos(pi * x[1]),
+                species=H_gam,
+                volume=gamma,
+            ),
+            F.ParticleSource(
+                value=lambda c_g, c_o: K_EX * (c_o - c_g),
+                species=H_gam,
+                volume=gamma,
+                species_dependent_value={"c_o": H_om, "c_g": H_gam},
+            ),
+        ],
+        boundary_conditions=[
+            F.ParticleFluxBC(
+                subdomain=gamma,
+                value=lambda c_g, c_o: K_EX * (c_g - c_o),
+                species=H_om,
+                species_dependent_value={"c_o": H_om, "c_g": H_gam},
+            ),
+            F.FixedConcentrationBC(
+                subdomain=right,
+                value=lambda x: 1 + x[0] ** 2 + (1 + x[0]) * ufl.cos(pi * x[1]),
+                species=H_om,
+            ),
+        ],
+        exports=list(exports),
+        temperature=500,
+        settings=F.Settings(atol=1e-12, rtol=1e-12, transient=False),
+    )
+    return model, (omega, gamma, right), (H_om, H_gam)
+
+
+def by_title(model):
+    return {e.title: e.data[-1] for e in model.exports}
+
+
+@pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only for now")
+def test_quantities_on_an_exterior_manifold():
+    """Bulk quantities on the facets of a manifold, and manifold quantities over it.
+
+    Exact values, with Gamma the unit-length segment ``x=0``::
+
+        int_Gamma c_O  = int_0^1 (1 + cos(pi y)) dy = 1
+        int_Gamma c_G  = int_0^1 (1 + beta cos(pi y)) dy = 1
+    """
+    model, (_omega, gamma, _right), (H_om, H_gam) = exterior_model()
+    model.exports = [
+        F.TotalSurface(field=H_om, surface=gamma),
+        F.AverageSurface(field=H_om, surface=gamma),
+        F.TotalVolume(field=H_gam, volume=gamma),
+        F.AverageVolume(field=H_gam, volume=gamma),
+    ]
+    model.initialise()
+    model.run()
+
+    got = by_title(model)
+    assert np.isclose(got["Total H_om surface 2"], 1.0, atol=1e-6)
+    assert np.isclose(got["Average H_om surface 2"], 1.0, atol=1e-6)
+    assert np.isclose(got["Total H_gam volume 2"], 1.0, atol=1e-6)
+    assert np.isclose(got["Average H_gam volume 2"], 1.0, atol=1e-6)
+
+
+@pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only for now")
+def test_flux_on_an_exterior_manifold_matches_the_exchange():
+    """The bulk flux on Gamma's facets is the exchange term that drives the coupling.
+
+    ``-D_O grad(c_O).n = J = K_EX (c_O - c_G) = D_O cos(pi y)`` there, which integrates
+    to zero over Gamma -- so the total alone would pass with almost any sign or measure.
+    The flux is therefore also checked pointwise against ``J``, by comparing it with the
+    exchange assembled independently from the two solutions, and by refining.
+    """
+    errors = []
+    for n in (16, 32, 64):
+        model, (omega, gamma, _right), (H_om, _H_gam) = exterior_model(n=n)
+        model.exports = [F.SurfaceFlux(field=H_om, surface=gamma)]
+        model.initialise()
+        model.run()
+
+        flux = model.exports[0].data[-1]
+        assert np.isclose(flux, 0.0, atol=1e-3)
+
+        # the same quantity weighted by cos(pi y), whose exact value is
+        # int_0^1 D_O cos^2(pi y) dy = D_O / 2, is not degenerate
+        c_om = H_om.subdomain_to_post_processing_solution[omega]
+        parent = model.mesh.mesh
+        y = ufl.SpatialCoordinate(parent)[1]
+        weighted = dolfinx.fem.assemble_scalar(
+            dolfinx.fem.form(
+                -D_O
+                * ufl.dot(ufl.grad(c_om), ufl.FacetNormal(parent))
+                * ufl.cos(pi * y)
+                * model.ds(gamma.id),
+                entity_maps=[sd.cell_map for sd in model.volume_subdomains],
+            )
+        )
+        errors.append(abs(weighted - D_O / 2))
+
+    rates = [np.log(e0 / e1) / np.log(2) for e0, e1 in pairwise(errors)]
+    assert all(r > 1.8 for r in rates), rates
+
+
+@pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only for now")
+def test_flux_on_an_interior_manifold_is_not_silently_zero():
+    """The case the parent ``ds`` gets wrong without failing.
+
+    Steady 1D transport across a manifold at ``x=0.5``, ``c=2`` at ``x=0`` and ``c=0``
+    at ``x=1`` (the configuration of ``test_codim1_interface.py``). Every flux equals
+    the same ``J`` at steady state::
+
+        D/0.5 (2 - c_L) = K_L (c_L - c_G) = K_R (c_G - c_R) = D/0.5 c_R = J
+
+    giving ``J = 4/3``, ``c_L = 14/9``, ``c_G = 8/9``, ``c_R = 4/9``. Gamma has unit
+    length, so the integrated flux is ``J`` itself -- positive leaving the left bulk,
+    negative on the right, which is entering it. The exchange rates differ on the two
+    sides, so a swapped ``"+"``/``"-"`` would give the wrong number rather than the
+    same one twice.
+    """
+    from .test_codim1_interface import build
+
+    model, (_left, _right, gamma), (H_l, H_r, H_g) = build(n=20)
+    model.exports = [
+        F.SurfaceFlux(field=H_l, surface=gamma),
+        F.SurfaceFlux(field=H_r, surface=gamma),
+        F.TotalSurface(field=H_l, surface=gamma),
+        F.TotalSurface(field=H_r, surface=gamma),
+        F.TotalVolume(field=H_g, volume=gamma),
+    ]
+    model.initialise()
+    model.run()
+
+    got = by_title(model)
+    # not merely nonzero: the parent ds would give exactly 0.0 for both
+    assert np.isclose(got["H_l flux surface 3"], 4 / 3, atol=1e-10)
+    assert np.isclose(got["H_r flux surface 3"], -4 / 3, atol=1e-10)
+    assert np.isclose(got["Total H_l surface 3"], 14 / 9, atol=1e-10)
+    assert np.isclose(got["Total H_r surface 3"], 4 / 9, atol=1e-10)
+    assert np.isclose(got["Total H_g volume 3"], 8 / 9, atol=1e-10)
+
+
+@pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only for now")
+def test_interior_manifold_flux_balance():
+    """What the manifold takes from one side it gives to the other, at steady state
+    with no source on it. This is the check that catches a restriction applied to only
+    part of the integrand, which a convergence study can miss."""
+    from .test_codim1_interface import build
+
+    model, (_left, _right, gamma), (H_l, H_r, _H_g) = build(n=20)
+    model.exports = [
+        F.SurfaceFlux(field=H_l, surface=gamma),
+        F.SurfaceFlux(field=H_r, surface=gamma),
+    ]
+    model.initialise()
+    model.run()
+
+    into_gamma, out_of_gamma = (e.data[-1] for e in model.exports)
+    assert np.isclose(into_gamma + out_of_gamma, 0.0, atol=1e-10)
+
+
+@pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only for now")
+def test_quantities_on_the_boundary_of_a_manifold():
+    """Gamma's own endpoint: an exterior facet integral on Gamma's submesh.
+
+    At ``y=1`` the manufactured manifold solution gives ``c_G = 1 + beta cos(pi) =
+    1 - beta = 0.75``, and Gamma's endpoint is a single point of unit measure, so the
+    total is that value. Its natural condition ``dc_G/dy = 0`` holds exactly there, so
+    the flux converges to zero -- at first order, being a derivative recovered at a
+    boundary point.
+    """
+    values, fluxes = [], []
+    for n in (16, 32, 64):
+        model, (_omega, _gamma, _right), (_H_om, H_gam) = exterior_model(n=n)
+        end = F.SurfaceSubdomain(
+            id=END_ID, dim=0, locator=lambda x: np.isclose(x[1], 1.0)
+        )
+        model.exports = [
+            F.TotalSurface(field=H_gam, surface=end),
+            F.SurfaceFlux(field=H_gam, surface=end),
+        ]
+        model.initialise()
+        model.run()
+
+        got = by_title(model)
+        values.append(abs(got[f"Total H_gam surface {END_ID}"] - 0.75))
+        fluxes.append(abs(got[f"H_gam flux surface {END_ID}"]))
+
+    assert values[-1] < 1e-4, values
+    # both converge; the flux only at first order
+    assert all(v1 < v0 for v0, v1 in pairwise(values)), values
+    assert all(f1 < 0.6 * f0 for f0, f1 in pairwise(fluxes)), fluxes
+
+
+@pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only for now")
+def test_outlet_flux_of_a_manifold_carrying_advection():
+    """A manifold's endpoint flux against a closed form that is not zero.
+
+    Gamma alone, uncoupled from the bulk, with advection-diffusion along it and
+    Dirichlet at both ends (the two-point BVP of ``test_codim1_boundary.py``)::
+
+        c = (e^Pe - e^(v y / D)) / (e^Pe - 1),   Pe = v L / D
+
+    so the diffusive flux at the outlet ``y=1`` is
+    ``-D dc/dy = v e^Pe / (e^Pe - 1)``, and the export must reproduce it. This is the
+    quantity a pipe model asks for: what leaves the fluid at the outlet.
+    """
+    v_y, D_gam, n = 2.0, 0.7, 200
+    mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 8, n)
+
+    omega = F.VolumeSubdomain(
+        id=OMEGA_ID,
+        material=F.Material(D_0=1.0, E_D=0.0),
+        locator=lambda x: np.full_like(x[0], True, dtype=bool),
+    )
+    gamma = F.VolumeSubdomain(
+        id=GAMMA_ID,
+        material=F.Material(D_0=D_gam, E_D=0.0),
+        dim=1,
+        locator=lambda x: np.isclose(x[0], 0.0),
+    )
+    inlet = F.SurfaceSubdomain(id=3, dim=0, locator=lambda x: np.isclose(x[1], 0.0))
+    outlet = F.SurfaceSubdomain(id=4, dim=0, locator=lambda x: np.isclose(x[1], 1.0))
+    fixed = F.SurfaceSubdomain(id=5, locator=lambda x: np.isclose(x[0], 1.0))
+
+    H_om = F.Species("H_om", subdomains=[omega])
+    H_gam = F.Species("H_gam", subdomains=[gamma])
+
+    vel = dolfinx.fem.Function(dolfinx.fem.functionspace(mesh, ("Lagrange", 1, (2,))))
+    vel.interpolate(lambda x: np.vstack([np.zeros_like(x[0]), np.full_like(x[0], v_y)]))
+
+    model = F.HydrogenTransportProblemDiscontinuous(
+        mesh=F.Mesh(mesh),
+        species=[H_om, H_gam],
+        subdomains=[omega, gamma, inlet, outlet, fixed],
+        advection_terms=[F.AdvectionTerm(velocity=vel, subdomain=gamma, species=H_gam)],
+        boundary_conditions=[
+            F.FixedConcentrationBC(subdomain=inlet, value=1.0, species=H_gam),
+            F.FixedConcentrationBC(subdomain=outlet, value=0.0, species=H_gam),
+            F.FixedConcentrationBC(subdomain=fixed, value=0.0, species=H_om),
+        ],
+        exports=[F.SurfaceFlux(field=H_gam, surface=outlet)],
+        temperature=500,
+        settings=F.Settings(atol=1e-12, rtol=1e-12, transient=False),
+    )
+    model.initialise()
+    model.run()
+
+    peclet = v_y / D_gam
+    expected = v_y * np.exp(peclet) / (np.exp(peclet) - 1)
+    assert np.isclose(model.exports[0].data[-1], expected, rtol=2e-2), (
+        model.exports[0].data[-1],
+        expected,
+    )
+
+
+@pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only for now")
+def test_manifolds_own_species_on_its_own_facets_raises():
+    """A manifold's species has no flux *across* the manifold -- the quantity the user
+    means is a volume one over it."""
+    model, (_omega, gamma, _right), (_H_om, H_gam) = exterior_model(n=8)
+    model.exports = [F.SurfaceFlux(field=H_gam, surface=gamma)]
+
+    with pytest.raises(ValueError, match="has no flux across it"):
+        model.initialise()
+
+
+@pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only for now")
+def test_export_on_a_manifold_boundary_locator_matching_nothing_raises():
+    """A locator selecting a point interior to Gamma would otherwise report zero."""
+    model, (_omega, _gamma, _right), (_H_om, H_gam) = exterior_model(n=8)
+    inside = F.SurfaceSubdomain(
+        id=END_ID, dim=0, locator=lambda x: np.isclose(x[1], 0.5)
+    )
+    model.exports = [F.TotalSurface(field=H_gam, surface=inside)]
+
+    with pytest.raises(ValueError, match="matched no boundary entity"):
+        model.initialise()
+
+
+@pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only for now")
+def test_ordinary_volume_subdomain_as_a_surface_raises():
+    """Only a codim-1 volume subdomain occupies facets."""
+    model, (omega, _gamma, _right), (H_om, _H_gam) = exterior_model(n=8)
+    model.exports = [F.SurfaceFlux(field=H_om, surface=omega)]
+
+    with pytest.raises(ValueError, match="is not a manifold"):
+        model.initialise()
+
+
+@pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only for now")
+def test_volume_as_a_surface_raises_in_a_problem_without_manifolds():
+    """Only HydrogenTransportProblemDiscontinuous supports manifolds.
+
+    The ``surface`` setter accepts a volume subdomain so a manifold can be passed
+    through, so every other problem class has to reject one at initialisation. It would
+    otherwise look the subdomain's id up in the *facet* tags and silently report some
+    other surface's value -- a plausible number for the wrong surface, not a zero.
+    """
+    mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 8, 8)
+    vol = F.VolumeSubdomain(
+        id=1,
+        material=F.Material(D_0=1.0, E_D=0.0),
+        locator=lambda x: np.full_like(x[0], True, dtype=bool),
+    )
+    left = F.SurfaceSubdomain(id=1, locator=lambda x: np.isclose(x[0], 0.0))
+    H = F.Species("H", subdomains=[vol])
+
+    model = F.HydrogenTransportProblem(
+        mesh=F.Mesh(mesh),
+        species=[H],
+        subdomains=[vol, left],
+        boundary_conditions=[
+            F.FixedConcentrationBC(subdomain=left, value=1.0, species=H)
+        ],
+        exports=[F.SurfaceFlux(field=H, surface=vol)],
+        temperature=500,
+        settings=F.Settings(atol=1e-10, rtol=1e-10, transient=False),
+    )
+    with pytest.raises(TypeError, match="Only a codim-1 volume subdomain"):
+        model.initialise()

--- a/test/test_codim1_subdomain.py
+++ b/test/test_codim1_subdomain.py
@@ -6,6 +6,7 @@ import dolfinx
 import numpy as np
 import pytest
 import ufl
+from scifem import assemble_scalar
 
 import festim as F
 from festim.helpers import solution_on
@@ -492,3 +493,62 @@ def test_ordered_interior_facet_data_rejects_facets_elsewhere():
             F.VolumeSubdomain(id=1, material=material),
             F.VolumeSubdomain(id=2, material=material),
         )
+
+
+def test_surface_quantity_accepts_a_manifold_subdomain():
+    """A manifold is passed directly wherever a surface is expected, exports included.
+
+    Which subdomain object it is cannot tell whether it is really codim 1 -- that needs
+    the mesh -- so the setter accepts any volume subdomain and the problem checks at
+    initialisation.
+    """
+    gamma = F.VolumeSubdomain(id=2, material=F.Material(D_0=1, E_D=0), dim=1)
+    export = F.SurfaceFlux(field=F.Species("H"), surface=gamma)
+    assert export.surface is gamma
+
+
+@pytest.mark.parametrize("bad", [True, "top", 1.0, None])
+def test_surface_quantity_rejects_other_types(bad):
+    with pytest.raises(TypeError, match="surface should be"):
+        F.SurfaceFlux(field=F.Species("H"), surface=bad)
+
+
+def test_export_volume_measure_is_on_the_submesh_for_a_manifold():
+    """A manifold's fields live on its submesh, so a volume quantity over it integrates
+    there. The measure carries a tag over the whole submesh, so indexing it by the
+    subdomain id -- which is what the export does -- selects all of it."""
+    model, omega, gamma, _ = build_manifold_model([])
+    model.initialise()
+
+    dx_gamma = model.export_volume_measure(gamma)
+    assert dx_gamma.ufl_domain() is gamma.submesh.ufl_domain()
+    # the manifold is the full top edge of the unit square
+    assert np.isclose(assemble_scalar(1 * dx_gamma(gamma.id)), 1.0)
+
+    # an ordinary subdomain is untouched
+    assert model.export_volume_measure(omega) is model.dx
+
+
+def test_unindexed_coupling_measure_agrees_with_the_indexed_one():
+    """Derived quantities need the measure itself, since they index it by the id of the
+    subdomain they export, exactly as they do with the parent ds."""
+    model, _, gamma, _ = build_manifold_model([])
+    model.initialise()
+
+    unindexed = model.unindexed_coupling_measure(gamma)
+    assert unindexed(gamma.id) == model.coupling_measure(gamma)
+
+
+def test_manifold_boundary_measure_is_memoised():
+    """DOLFINx requires every integral of a compiled form to share the *same*
+    subdomain_data object, not merely an equal one."""
+    end = F.SurfaceSubdomain(id=7, dim=0, locator=lambda x: np.isclose(x[0], 0.0))
+    model, _, gamma, H_gam = build_manifold_model([end])
+    model.exports = [F.TotalSurface(field=H_gam, surface=end)]
+    model.initialise()
+
+    first = model._manifold_boundary_measure(end, gamma)
+    assert model._manifold_boundary_measure(end, gamma) is first
+    assert first.ufl_domain() is gamma.submesh.ufl_domain()
+    # a single endpoint of a 1D submesh, of unit measure
+    assert np.isclose(assemble_scalar(1 * first(end.id)), 1.0)


### PR DESCRIPTION
## Description

### Summary

Makes FESTIM's derived quantities work with codimensional (manifold) subdomains. Three
places a quantity can be asked for once a codim-1 subdomain is in the mesh, none of
which the export layer could reach before:

| asked for | before | now |
|---|---|---|
| a **bulk** species on the facets Γ occupies, Γ on the domain boundary | `TypeError` at construction | ✅ converges at rate 2 |
| …same, Γ **interior** | **silently `0.0`** | ✅ exact `4/3` on the closed-form case |
| `TotalVolume` / `AverageVolume` over Γ itself | FFCx `UnboundLocalError: 't'` | ✅ exact |
| anything on Γ's **own boundary** (a codim-2 surface) | `KeyError` | ✅ matches the two-point BVP closed form |

Covers `SurfaceFlux`, `TotalSurface`, `AverageSurface`, `TotalVolume` and
`AverageVolume`. `VTXSpeciesExport` on Γ already worked and is unchanged, as is every
export on an ordinary surface — the codim-0 path is untouched.

```python
gamma = F.VolumeSubdomain(id=2, material=mat, dim=1, locator=...)   # a manifold
outlet = F.SurfaceSubdomain(id=4, dim=0, locator=...)               # its endpoint

exports = [
    F.SurfaceFlux(field=c_bulk, surface=gamma),    # exchange between bulk and manifold
    F.TotalVolume(field=c_gamma, volume=gamma),    # integral along the manifold
    F.SurfaceFlux(field=c_gamma, surface=outlet),  # what leaves at the manifold's end
]
```

### Related Issues

Related to #1208. Builds on the codim-1 support in #1216 — this is "dedicated exports on
Γ", which that PR listed as out of scope.

### Motivation and Context

A codim-1 subdomain is not much use if you cannot measure anything on it. The two
questions users actually have are *how much is exchanged between the bulk and the
manifold* and *how much leaves at the end of the manifold* (the outlet of the 1D fluid
in the pipe case), and neither was answerable.

Two findings are worth flagging to reviewers:

**1. The interior case was a silent wrong answer, not a crash.** `ds(Γ.id)` integrates to
exactly zero over interior facets, so a flux across an interior manifold would have
reported `0.0` with no warning had the type check not stopped it first. Interior Γ now
uses the `dS` coupling measure with the restriction of the side `field` lives on,
reusing `coupling_side` / `restriction_of` / `restrict` unchanged from #1216. This is the
behaviour `test_flux_on_an_interior_manifold_is_not_silently_zero` pins.

**2. Γ's boundary is not a codim-2 integral.** #1216 filed it as "a `ridge` / `dr`
integral, a different problem". It isn't: Γ's boundary is codim-1 *relative to Γ*, so it
is an ordinary exterior-facet `ds` on Γ's submesh — the endpoints of a line in 2D are the
facets of a 1D mesh — and `ufl.FacetNormal` works there. This is the same correction #1216
already made for Dirichlet dof location but did not carry over to assembly.

### Implementation

- `exports/surface_quantity.py` — the `surface` setter accepts a `VolumeSubdomain`, since
  a manifold is passed directly wherever a surface is expected.
- `HydrogenTransportProblem.initialise_exports` — and therefore **rejects** one outright,
  because manifolds exist only in `HydrogenTransportProblemDiscontinuous`. Without this,
  widening the setter would let a volume subdomain's id be looked up in the *facet* tags,
  silently reporting some other surface's value. `ChangeVar` delegates here, so one guard
  covers both.
- `helpers.py` — module-level `restrict(expression, restriction)`, so exports can restrict
  without reaching into the problem. `HydrogenTransportProblemDiscontinuous.restrict` now
  delegates to it.
- `SurfaceFlux` / `TotalSurface` / `AverageSurface` — optional `restriction` kwarg on
  `compute`, applied to the **whole** integrand. That is what makes `-D ∇c · n` pick the
  outward normal of its own side, so the sign convention comes out identical to an
  exterior surface: positive means leaving the subdomain the species lives on, and a flux
  through an interface reads `+J` on one side and `-J` on the other.
- `hydrogen_transport_problem.py` — `unindexed_coupling_measure` (factored out of
  `coupling_measure`), `export_volume_measure`, `_manifold_boundary_measure`, and
  `export_surface_context`, the single place the three cases are decided.
  `initialise_exports` now builds `D` on whichever mesh the integral lives on.

Both new measures carry a meshtag so the exports can index them by subdomain id as they
already do, and both are memoised — DOLFINx requires every integral of a compiled form to
share the *same* `subdomain_data` object, not merely an equal one.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Code refactoring (no functional changes, no API changes)
- [x] 📝 Documentation update
- [x] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI configuration change

## Testing

- [x] All existing tests pass locally (`pytest`) — 977 passed, 5 skipped
- [x] I have added new tests that prove my fix is effective or that my feature works

`test/system_tests/test_codim1_exports.py` (10 tests) and five unit tests in
`test/test_codim1_subdomain.py`. **Every one was confirmed to fail with its own fix
reverted**, which for the interior case means reverting to a literal `0.0` against an
exact `4/3`.

Each asserted value is a closed form, not a regression baseline:

- `test_quantities_on_an_exterior_manifold` — totals and averages against the manufactured
  solution of `test_codim1_coupling.py`.
- `test_flux_on_an_exterior_manifold_matches_the_exchange` — the total flux on Γ is exactly
  zero for that MMS, so it is *also* checked weighted by `cos(πy)` against `D_Ω/2`,
  converging at rate > 1.8. A degenerate zero would otherwise pass with almost any sign or
  measure.
- `test_flux_on_an_interior_manifold_is_not_silently_zero` — the important one.
- `test_interior_manifold_flux_balance` — what Γ takes from one side it gives to the other.
  Passes under the naive implementation (`0 + 0 = 0`) but catches a wrong-side restriction,
  so it and the previous test are complementary.
- `test_quantities_on_the_boundary_of_a_manifold` — value and flux at Γ's endpoint,
  converging at rates 2 and 1.
- `test_outlet_flux_of_a_manifold_carrying_advection` — the pipe outlet against
  `-D dc/dy = v e^Pe / (e^Pe − 1)`, i.e. an endpoint flux whose exact value is *not* zero.
- Four raises: a manifold's own species on its own facets, a codim-0 volume as a surface, a
  locator matching nothing on Γ's boundary, and a volume subdomain as a surface in a problem
  class without manifolds.

Serial only for now, consistent with the rest of the codim-1 suite.

## Code Quality Checklist

- [x] My code follows the code style of this project (Ruff formatted: `ruff format .`)
- [x] My code passes linting checks (`ruff check .`) — clean on every file touched
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Documentation

- [x] I have updated the documentation accordingly (if applicable)
- [x] I have added docstrings to new functions/classes following the project conventions

New "Exports on a manifold" section in `docs/source/userguide/subdomains.rst` covering the
three positions, the side-inference rule and the sign convention; the limitations list
corrected accordingly. No new doctests (the additions are `code-block`, not `testcode`), and
I was unable to run `sphinx-build` locally — it is not in my environment — so the RST is
unverified beyond review.

## Breaking Changes

None. The `restriction` kwarg defaults to `None`, so every existing `compute` call is
unchanged, and the codim-0 path is byte-identical.

One behaviour *tightens*: passing a `VolumeSubdomain` as a `SurfaceQuantity`'s `surface`
used to be a `TypeError` at construction and is now a `TypeError` at `initialise()` in
problem classes without manifolds. Same outcome, later and with a clearer message.

## Additional Notes

**Known limitations, all pre-existing and none introduced here:**

- **`CustomQuantity` does not work on a manifold**, and is in fact broken in
  `HydrogenTransportProblemDiscontinuous` independently of codimension: it builds its kwargs
  as `{species.name: species.subdomain_to_post_processing_solution[volume] for species in
  self.species}`, which demands *every* species have a solution on the chosen subdomain, so
  any problem where a species does not live everywhere raises `KeyError`. Reproduced with two
  ordinary bulk subdomains and no manifold anywhere. Beyond that fix it also needs an API
  decision: the other exports separate `field` (which side to read) from `surface` (where to
  integrate), and `CustomQuantity` collapses both into one `subdomain`, so "the bulk flux
  across Γ" is not expressible. Worth its own issue.
- **`MinimumSurface` / `MaximumSurface` / `MinimumVolume` / `MaximumVolume`** read
  `field.post_processing_solution` and `self.facet_meshtags`, neither of which
  `HydrogenTransportProblemDiscontinuous` sets — `AttributeError` on `main` with no manifold
  involved. Also worth its own issue.
- **`SurfaceFlux` is diffusive-only**, as everywhere else in FESTIM; it already warns when
  advection terms are present. The pipe-outlet test asserts against the diffusive term only,
  and the docs say so.
