### PR TITLE
Codim: Fix multiple codim subdomains erroring on a single bulk subdomain

### DIFF
--- a/src/festim/helpers.py
+++ b/src/festim/helpers.py
@@ -46,6 +46,7 @@ def as_mapped_function(
     species_dependent_value: dict[str, "Species"] | None = None,
     subdomain: "VolumeSubdomain | None" = None,
     mesh: dolfinx.mesh.Mesh | None = None,
+    foreign_subdomain: "VolumeSubdomain | None" = None,
 ) -> ufl.core.expr.Expr:
     """Maps a user given callable function to the mesh, time, temperature or the
     concentration of other species within festim as needed.
@@ -88,33 +89,43 @@ def as_mapped_function(
         if species.concentration is not None:
             kwargs[name] = species.concentration
         else:  # discontinuous case: the species has one solution per subdomain
-            kwargs[name] = solution_on(species, subdomain)
+            kwargs[name] = solution_on(species, subdomain, foreign_subdomain)
 
     return value(**kwargs)
 
 
-def solution_on(species: "Species", subdomain: "VolumeSubdomain"):
+def solution_on(
+    species: "Species",
+    subdomain: "VolumeSubdomain",
+    foreign_subdomain: "VolumeSubdomain | None" = None,
+):
     """The solution of ``species`` to use in an expression assembled for ``subdomain``.
 
     Usually the species lives on ``subdomain`` and this is just a dictionary lookup.
     In a codimensional coupling the expression deliberately reaches across meshes -- a
     source on a manifold subdomain depending on the bulk concentration, say -- and the
-    species then has a single solution elsewhere, which is the one to use.
+    solution to read is the one on the side of the manifold the term belongs to. The
+    caller knows which side that is and passes it as ``foreign_subdomain``; failing
+    that, a species with a single solution has only one it could mean.
 
     Args:
         species: the species whose solution is needed
         subdomain: the volume subdomain the expression is assembled for
+        foreign_subdomain: where to read a species that does not live on ``subdomain``,
+            optional
 
     Returns:
         The ufl expression of the species solution
 
     Raises:
         ValueError: if the species lives on several subdomains, none of which is
-            ``subdomain``, so the choice would be arbitrary
+            ``subdomain`` or ``foreign_subdomain``, so the choice would be arbitrary
     """
     solutions = species.subdomain_to_solution
     if subdomain in solutions:
         return solutions[subdomain]
+    if foreign_subdomain in solutions:
+        return solutions[foreign_subdomain]
     if len(solutions) == 1:
         return next(iter(solutions.values()))
     others = [s.id for s in solutions]
@@ -315,6 +326,7 @@ class Value:
         up_to_ufl_expr: bool | None = False,
         subdomain: "VolumeSubdomain | None" = None,
         mesh: dolfinx.mesh.Mesh | None = None,
+        foreign_subdomain: "VolumeSubdomain | None" = None,
     ):
         """Converts a user given value to a relevent fenics object depending on the type
         of the value provided.
@@ -335,6 +347,10 @@ class Value:
                 so that ``ufl.SpatialCoordinate`` and any ``fem.Constant`` are built
                 on the integration domain, not on the space of the unknown. Only
                 meaningful with ``up_to_ufl_expr=True``.
+            foreign_subdomain: where to read a species that does not live on
+                ``subdomain``. A term coupling a codim-1 subdomain to the bulk reaches
+                into one particular side of it, and a bulk species defined on several
+                subdomains has a solution on each; see :func:`solution_on`. Optional.
         """
         if mesh is None and function_space is not None:
             mesh = function_space.mesh
@@ -377,6 +393,7 @@ class Value:
                     temperature=temperature,
                     species_dependent_value=self.species_dependent_value,
                     subdomain=subdomain,
+                    foreign_subdomain=foreign_subdomain,
                 )
 
             else:

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -2513,6 +2513,41 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
 
         gas_species.F = form
 
+    def interface_species(self, interface: _subdomain.Interface):
+        """The mobile species whose continuity ``interface`` enforces.
+
+        An interface condition relates the two solutions of one species across the
+        facets, so it applies to a species that has a solution on both of its volume
+        subdomains. In a model with codim-1 subdomains most species do not: a
+        manifold's own species lives on a subdomain that is not a volume of any
+        interface, and a bulk species may be confined to one side of a manifold. Those
+        are simply not part of this interface's condition.
+
+        A species present on exactly one of the two sides is the ambiguous case. It is
+        either deliberately absent from the neighbouring material or a subdomain
+        missing from its ``subdomains``, and only the user can tell which, so it is
+        skipped with a warning rather than silently.
+        """
+        subdomain_0, subdomain_1 = interface.subdomains
+        coupled = []
+        for species in self.species:
+            if not species.mobile:
+                continue
+            present = [s for s in (subdomain_0, subdomain_1) if s in species.subdomains]
+            if len(present) == 2:
+                coupled.append(species)
+            elif present:
+                missing = subdomain_1 if present[0] is subdomain_0 else subdomain_0
+                warnings.warn(
+                    f"species {species.name} lives on volume subdomain "
+                    f"{present[0].id} but not on {missing.id}, the other side of "
+                    f"interface {interface.id}, so the interface condition is not "
+                    "applied to it. Add the missing subdomain to its `subdomains` if "
+                    "it was meant to be continuous across that interface.",
+                    stacklevel=2,
+                )
+        return coupled
+
     def create_formulation(self):
         """Takes all the formulations for each subdomain and adds the interface
         conditions.
@@ -2525,11 +2560,10 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         # bounding the same volume subdomain still agree on their subdomain data
         dInterface = self.interior_facet_measure
 
-        all_mobile_species = [spe for spe in self.species if spe.mobile]
         for interface in self.interfaces:
             F_0, F_1 = interface.get_formulation(
                 dInterface,
-                species=all_mobile_species,
+                species=self.interface_species(interface),
                 temperature=self.temperature_fenics,
             )
             subdomain_0, subdomain_1 = interface.subdomains

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -1715,6 +1715,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                     temperature=temperature,
                     up_to_ufl_expr=True,
                     subdomain=source.volume,
+                    foreign_subdomain=self.source_coupling_side(source),
                 )
 
     def convert_advection_term_to_fenics_objects(self):
@@ -2088,6 +2089,24 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
             return False
         return not self.foreign_species(source, source.volume)
 
+    def source_coupling_side(self, source) -> _subdomain.VolumeSubdomain | None:
+        """The bulk subdomain a coupling source on a manifold reads, or ``None`` if
+        ``source`` is not one half of a codimensional coupling.
+
+        Which side of the manifold the term belongs to is decided by the bulk species
+        the source names (see :meth:`coupling_side`), and the expression has to read
+        that species' solution *there*. It cannot work that out for itself: a bulk
+        species defined on several subdomains -- because it is continuous across an
+        interface, say -- has a solution on each of them.
+        """
+        if source.volume not in self.manifold_to_volumes:
+            return None
+        foreign = self.foreign_species(source, source.volume)
+        if not foreign:
+            return None
+        # foreign_species has already checked that they all resolve to the same side
+        return self.coupling_side(source.volume, foreign[0])
+
     def diffusion_coefficient(self, subdomain: _subdomain.VolumeSubdomain, species):
         """The diffusion coefficient of ``species`` for the gradient terms of
         ``subdomain``, defined on the mesh those terms are integrated over."""
@@ -2196,12 +2215,11 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
             if source.volume != subdomain:
                 continue
             v = source.species.subdomain_to_test_function[subdomain]
-            foreign = self.foreign_species(source, subdomain) if is_manifold else []
-            if foreign:
+            bulk = self.source_coupling_side(source) if is_manifold else None
+            if bulk is not None:
                 # a source on a manifold that reads a bulk concentration: the exchange
                 # half that feeds the manifold. It must be integrated on the parent
                 # mesh, and restricted to the side the bulk species lives on
-                bulk = self.coupling_side(subdomain, foreign[0])
                 restriction = self.restriction_of(subdomain, bulk)
                 form_coupling -= (
                     self.restrict(source.value.fenics_object, restriction)

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -1335,7 +1335,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         facet_to_cell = self.mesh.mesh.topology.connectivity(
             self.mesh.mesh.topology.dim - 1, self.mesh.mesh.topology.dim
         )
-        self._coupling_measures = {}
+        self.interior_facet_measure = None
         self._manifold_is_interior = {}
         self._manifold_export_measures = {}
         self.manifold_to_volumes = _subdomain.map_manifold_to_volume_subdomains(
@@ -1360,8 +1360,15 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
             subdomain.transfer_meshtag(self.mesh.mesh, self.facet_meshtags)
 
         for interface in self.interfaces:
-            interface.mt = self.volume_meshtags
+            # ``mt`` is read as ``mt.find(interface.id)`` to get the facets the
+            # interface occupies, so it is the facet tags
+            interface.mt = self.facet_meshtags
+            interface.mesh = self.mesh.mesh
             interface.parent_mesh = self.mesh.mesh
+
+        # every interior-facet integrand of the parent mesh is known by now, and they
+        # all have to share one measure (see :meth:`build_interior_facet_measure`)
+        self.build_interior_facet_measure()
 
         self.create_species_from_traps()
         self.link_enclosures()
@@ -1680,7 +1687,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
 
         A source involving only fields of a manifold subdomain is integrated over that
         manifold's submesh (:meth:`subdomain_measure`); one coupling the manifold to
-        the bulk is a facet integral of the parent mesh (:meth:`coupling_measure`).
+        the bulk is a facet integral of the parent mesh (:meth:`facet_measure`).
         """
         if self.is_manifold_self_source(source):
             return source.volume.submesh
@@ -1749,7 +1756,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
 
         Terms coupling a manifold to the bulk cannot use this measure -- a bulk field
         cannot be resolved inside a codim-1 integral -- and use
-        :meth:`coupling_measure` instead.
+        :meth:`facet_measure` instead.
         """
         if subdomain.codim(self.mesh.vdim) == 1:
             return ufl.Measure("dx", domain=subdomain.submesh)
@@ -1795,55 +1802,82 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
             self._manifold_is_interior[manifold] = interior > 0
         return self._manifold_is_interior[manifold]
 
-    def coupling_measure(self, manifold: _subdomain.VolumeSubdomain):
-        """The parent-mesh measure the terms coupling ``manifold`` to the bulk are
-        integrated over.
+    def facet_measure(self, manifold: _subdomain.VolumeSubdomain):
+        """The parent-mesh measure the facets of ``manifold`` are integrated in: the
+        terms coupling it to the bulk, and the derived quantities exported on it.
 
-        A manifold on the boundary of the mesh uses ``ds``; one inside the mesh uses
-        ``dS``. When it separates two different volume subdomains the integration
-        entities are ordered so that ``"+"`` is the first of them (see
-        :meth:`restriction_of`); when the same subdomain lies on both sides there is
-        nothing to order, because the bulk field is single-valued across the facet.
-        """
-        return self.unindexed_coupling_measure(manifold)(manifold.id)
+        A manifold on the boundary of the mesh is integrated with ``ds``, one inside
+        the mesh with the shared ``dS`` (see :meth:`build_interior_facet_measure`),
+        whose entities are ordered so that ``"+"`` is the first of the two volume
+        subdomains it separates (see :meth:`restriction_of`).
 
-    def unindexed_coupling_measure(self, manifold: _subdomain.VolumeSubdomain):
-        """As :meth:`coupling_measure`, but not yet restricted to the manifold's id.
-
-        Derived quantities index the measure they are handed by the id of the subdomain
-        they export, exactly as they do with the parent ``ds``, so they need the measure
-        itself rather than an integral over it.
+        The measure is **not** restricted to the manifold: index it with
+        ``manifold.id``, as the derived quantities do with the parent ``ds``. Left
+        unindexed in a form it integrates over everything the measure carries data
+        for -- every tagged facet of the mesh for ``ds``, every interior manifold and
+        interface for the shared ``dS``.
         """
         if not self.manifold_is_interior(manifold):
             return self.ds
+        return self.interior_facet_measure
 
-        # memoised: DOLFINx requires every integral of a compiled form to share the
-        # *same* subdomain_data object, not merely an equal one
-        if manifold not in self._coupling_measures:
-            volumes = self.manifold_to_volumes[manifold]
-            if len(volumes) == 2:
-                integral_data = _subdomain.compute_ordered_interior_facet_data(
-                    self.volume_meshtags,
-                    self.facet_meshtags,
-                    manifold.id,
-                    volumes[0],
-                    volumes[1],
-                )
-            else:
-                # one subdomain on both sides: either restriction reads the same value,
-                # so the entities are taken in whatever order DOLFINx gives them
-                integral_data = (
-                    manifold.id,
-                    compute_integration_domains(
-                        dolfinx.fem.IntegralType.interior_facet,
-                        self.mesh.mesh.topology._cpp_object,
-                        self.facet_meshtags.find(manifold.id),
-                    ),
-                )
-            self._coupling_measures[manifold] = ufl.Measure(
-                "dS", domain=self.mesh.mesh, subdomain_data=[integral_data]
+    def build_interior_facet_measure(self):
+        """Builds the single ``dS`` measure that every interior-facet integral of the
+        parent mesh shares, and stores it in ``interior_facet_measure``.
+
+        The coupling terms of an interior manifold and the continuity terms of an
+        :class:`festim.Interface` are both ``dS`` integrals of the parent mesh, and
+        both need integration data of their own so that ``"+"`` and ``"-"`` land on the
+        sides they are meant to. They cannot each carry their own measure: UFL collects
+        one ``subdomain_data`` entry per integral of a form, and ``dolfinx.fem.form``
+        asserts that they are all the *same* object before using the first of them for
+        every id. A measure per manifold therefore breaks as soon as one volume
+        subdomain touches two interior manifolds, or an interface and an interior
+        manifold -- both integrals end up in that subdomain's ``F``. So the data of
+        every interior-facet integral goes into one list, and the measure built from it
+        is handed to all of them, each indexing it by its own id.
+        """
+        integral_data = [
+            self._manifold_integration_data(manifold)
+            for manifold in self.manifold_subdomains
+            if self.manifold_is_interior(manifold)
+        ]
+        integral_data += [
+            interface.compute_mapped_interior_facet_data(self.volume_meshtags)
+            for interface in self.interfaces
+        ]
+        self.interior_facet_measure = ufl.Measure(
+            "dS", domain=self.mesh.mesh, subdomain_data=integral_data
+        )
+
+    def _manifold_integration_data(self, manifold: _subdomain.VolumeSubdomain):
+        """The ``(id, entities)`` pair putting the coupling terms of an interior
+        ``manifold`` on the facets it occupies.
+
+        When the manifold separates two different volume subdomains the entities are
+        ordered so that ``"+"`` is the first of them (see :meth:`restriction_of`); when
+        the same subdomain lies on both sides there is nothing to order, because the
+        bulk field is single-valued across the facet.
+        """
+        volumes = self.manifold_to_volumes[manifold]
+        if len(volumes) == 2:
+            return _subdomain.compute_ordered_interior_facet_data(
+                self.volume_meshtags,
+                self.facet_meshtags,
+                manifold.id,
+                volumes[0],
+                volumes[1],
             )
-        return self._coupling_measures[manifold]
+        # one subdomain on both sides: either restriction reads the same value, so the
+        # entities are taken in whatever order DOLFINx gives them
+        return (
+            manifold.id,
+            compute_integration_domains(
+                dolfinx.fem.IntegralType.interior_facet,
+                self.mesh.mesh.topology._cpp_object,
+                self.facet_meshtags.find(manifold.id),
+            ),
+        )
 
     def restriction_of(
         self, manifold: _subdomain.VolumeSubdomain, volume: _subdomain.VolumeSubdomain
@@ -1905,7 +1939,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
             target = self.coupling_side(bc.subdomain, bc.species)
             return (
                 target,
-                self.coupling_measure(bc.subdomain),
+                self.facet_measure(bc.subdomain)(bc.subdomain.id),
                 self.restriction_of(bc.subdomain, target),
             )
         return self.surface_to_volume[bc.subdomain], self.ds(bc.subdomain.id), None
@@ -2075,7 +2109,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         ``subdomain`` -- are integrated over :meth:`subdomain_measure`, which for a
         manifold subdomain is its own submesh. *Coupling* terms, which mix a manifold
         field with a bulk field, cannot live there (a bulk function cannot be resolved
-        inside a codim-1 integral) and use :meth:`coupling_measure` on the parent mesh.
+        inside a codim-1 integral) and use :meth:`facet_measure` on the parent mesh.
 
         For a regular volume subdomain both measures are on the parent mesh and the
         whole formulation ends up in ``subdomain.F``. For a manifold subdomain they are
@@ -2172,7 +2206,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                 form_coupling -= (
                     self.restrict(source.value.fenics_object, restriction)
                     * self.restrict(v, restriction)
-                    * self.coupling_measure(subdomain)
+                    * self.facet_measure(subdomain)(subdomain.id)
                 )
             else:
                 self_form -= source.value.fenics_object * v * dx
@@ -2468,18 +2502,10 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         Finally compute the jacobian matrix and store it in the ``J`` attribute,
         adds the ``entity_maps`` to the forms and store them in the ``forms`` attribute
         """
-        mesh = self.mesh.mesh
-        mt = self.facet_meshtags
-
-        for interface in self.interfaces:
-            interface.mesh = mesh
-            interface.mt = mt
-
-        integral_data = [
-            interface.compute_mapped_interior_facet_data(self.volume_meshtags)
-            for interface in self.interfaces
-        ]
-        dInterface = ufl.Measure("dS", domain=mesh, subdomain_data=integral_data)
+        # the interfaces were wired and their integration data folded into the shared
+        # dS measure in initialise(), so that an interface and an interior manifold
+        # bounding the same volume subdomain still agree on their subdomain data
+        dInterface = self.interior_facet_measure
 
         all_mobile_species = [spe for spe in self.species if spe.mobile]
         for interface in self.interfaces:
@@ -2767,7 +2793,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
             return (
                 volume,
                 parent,
-                self.unindexed_coupling_measure(surface),
+                self.facet_measure(surface),
                 self.restriction_of(surface, volume),
                 entity_maps,
             )

--- a/test/system_tests/test_codim1_exports.py
+++ b/test/system_tests/test_codim1_exports.py
@@ -222,7 +222,7 @@ def test_flux_on_an_interior_manifold_is_not_silently_zero():
     # even if the closed form above were ever relaxed
     parent = model.mesh.mesh
     n = ufl.FacetNormal(parent)
-    dS_gamma = model.coupling_measure(gamma)
+    dS_gamma = model.facet_measure(gamma)(gamma.id)
     for species, volume, title in (
         (H_l, left, "H_l flux surface 3"),
         (H_r, right, "H_r flux surface 3"),

--- a/test/system_tests/test_codim1_interface.py
+++ b/test/system_tests/test_codim1_interface.py
@@ -164,7 +164,7 @@ def test_interior_manifold_conserves_particles():
     c_r = H_r.subdomain_to_solution[right]
     c_g = H_g.subdomain_to_solution[gamma]
     entity_maps = [sd.cell_map for sd in model.volume_subdomains]
-    dS = model.coupling_measure(gamma)
+    dS = model.facet_measure(gamma)(gamma.id)
 
     def assemble(form):
         return model.mesh.mesh.comm.allreduce(
@@ -246,7 +246,7 @@ def test_interior_manifold_inside_a_single_subdomain():
     model.initialise()
 
     assert model.manifold_is_interior(gamma)
-    assert model.coupling_measure(gamma).integral_type() == "interior_facet"
+    assert model.facet_measure(gamma)(gamma.id).integral_type() == "interior_facet"
 
     model.run()
 
@@ -515,3 +515,194 @@ def test_interior_manifold_3d_tilted_mms():
             for i in range(len(refinements) - 1)
         ]
         assert all(r > 1.8 for r in rates), (field, rates)
+
+
+# --- several interior-facet integrands in one form -------------------------------
+#
+# An interior manifold's coupling and an Interface's continuity condition are both dS
+# integrals of the parent mesh, and both need integration data of their own. They
+# cannot each carry their own measure: UFL collects one subdomain_data entry per
+# integral of a form, and dolfinx.fem.form asserts they are all the same object before
+# using the first for every id. Any volume subdomain bounded by two of them at once
+# therefore exercises the shared measure.
+
+K1_LEFT, K1_RIGHT, K2_LEFT, K2_RIGHT = 2.0, 3.0, 4.0, 5.0
+MID_ID, GAMMA_1_ID, GAMMA_2_ID, INTERFACE_ID = 6, 7, 8, 9
+
+
+def _exchange(gamma, gamma_species, bulk_species, k):
+    # NOTE perhaps having a small helper like this could be nice to have in the
+    # base code at some point
+    """The two halves of a codimensional coupling: a source feeding the manifold and
+    the matching flux leaving the bulk."""
+    dependencies = {"c_b": bulk_species, "c_g": gamma_species}
+    return (
+        F.ParticleSource(
+            value=lambda c_g, c_b: k * (c_b - c_g),
+            species=gamma_species,
+            volume=gamma,
+            species_dependent_value=dependencies,
+        ),
+        F.ParticleFluxBC(
+            subdomain=gamma,
+            species=bulk_species,
+            value=lambda c_g, c_b: k * (c_g - c_b),
+            species_dependent_value=dependencies,
+        ),
+    )
+
+
+def build_two_junctions(n=12, second_junction="manifold"):
+    """Three vertical strips, joined at ``x = 1/3`` by an interior manifold and at
+    ``x = 2/3`` by either a second manifold or an :class:`festim.Interface`.
+
+    Either way the middle strip is bounded by two interior-facet integrands at once, so
+    both of their ``dS`` integrals land in its form.
+    """
+    mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, n, n)
+    mat = F.Material(D_0=D_BULK, E_D=0.0, K_S_0=1.0, E_K_S=0.0)
+    mat_gamma = F.Material(D_0=D_GAMMA, E_D=0.0)
+
+    left = F.VolumeSubdomain(
+        id=LEFT_ID, material=mat, locator=lambda x: x[0] <= 1 / 3 + 1e-14
+    )
+    middle = F.VolumeSubdomain(
+        id=MID_ID,
+        material=mat,
+        locator=lambda x: np.logical_and(x[0] >= 1 / 3 - 1e-14, x[0] <= 2 / 3 + 1e-14),
+    )
+    right = F.VolumeSubdomain(
+        id=RIGHT_ID, material=mat, locator=lambda x: x[0] >= 2 / 3 - 1e-14
+    )
+    gamma_1 = F.VolumeSubdomain(
+        id=GAMMA_1_ID,
+        material=mat_gamma,
+        dim=1,
+        locator=lambda x: np.isclose(x[0], 1 / 3),
+    )
+    outer_l = F.SurfaceSubdomain(id=OUTER_L_ID, locator=lambda x: np.isclose(x[0], 0.0))
+    outer_r = F.SurfaceSubdomain(id=OUTER_R_ID, locator=lambda x: np.isclose(x[0], 1.0))
+
+    H_l = F.Species("H_l", subdomains=[left])
+    H_g1 = F.Species("H_g1", subdomains=[gamma_1])
+    interfaces, sources, bcs = [], [], []
+
+    if second_junction == "manifold":
+        gamma_2 = F.VolumeSubdomain(
+            id=GAMMA_2_ID,
+            material=mat_gamma,
+            dim=1,
+            locator=lambda x: np.isclose(x[0], 2 / 3),
+        )
+        H_m = F.Species("H_m", subdomains=[middle])
+        H_r = F.Species("H_r", subdomains=[right])
+        H_g2 = F.Species("H_g2", subdomains=[gamma_2])
+        extra = [gamma_2]
+        species = [H_l, H_m, H_r, H_g1, H_g2]
+        for bulk_species, k in ((H_m, K2_LEFT), (H_r, K2_RIGHT)):
+            source, flux = _exchange(gamma_2, H_g2, bulk_species, k)
+            sources.append(source)
+            bcs.append(flux)
+        outflow_species = H_r
+    else:
+        # an Interface needs its species defined on both of its subdomains, so the
+        # middle and right strips share one
+        H_m = F.Species("H_m", subdomains=[middle, right])
+        extra = []
+        species = [H_l, H_m, H_g1]
+        interfaces = [F.Interface(id=INTERFACE_ID, subdomains=[middle, right])]
+        outflow_species = H_m
+
+    for bulk_species, k in ((H_l, K1_LEFT), (H_m, K1_RIGHT)):
+        source, flux = _exchange(gamma_1, H_g1, bulk_species, k)
+        sources.append(source)
+        bcs.append(flux)
+
+    bcs += [
+        F.FixedConcentrationBC(subdomain=outer_l, value=2.0, species=H_l),
+        F.FixedConcentrationBC(subdomain=outer_r, value=0.0, species=outflow_species),
+    ]
+
+    model = F.HydrogenTransportProblemDiscontinuous(
+        mesh=F.Mesh(mesh),
+        species=species,
+        subdomains=[left, middle, right, gamma_1, *extra, outer_l, outer_r],
+        sources=sources,
+        boundary_conditions=bcs,
+        interfaces=interfaces,
+        temperature=500,
+        settings=F.Settings(atol=1e-12, rtol=1e-12, transient=False),
+    )
+    return model, (left, middle, right, gamma_1, *extra), species
+
+
+def assert_subdomain_data_is_shared(form, name):
+    """Check DOLFINx's own invariant, with a message that says what broke.
+
+    ``dolfinx.fem.form`` asserts that all the integrals of a form sharing a domain and
+    an integral type carry the *same* ``subdomain_data`` object, then uses the first of
+    them for every subdomain id. A violation surfaces either as a bare
+    ``AssertionError`` deep inside the compiler or, with assertions disabled, as one
+    manifold silently integrated over another's facets.
+    """
+    if not isinstance(form, ufl.Form):
+        # a manifold carrying no coupling term contributes nothing to the parent mesh
+        return
+    for per_type in form.subdomain_data().values():
+        for integral_type, data in per_type.items():
+            distinct = {id(d) for d in data if d is not None}
+            assert len(distinct) <= 1, (
+                f"the {integral_type} integrals of {name} carry {len(distinct)} "
+                "different subdomain_data objects; they must share one"
+            )
+
+
+@pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only for now")
+def test_two_interior_manifolds_bounding_one_subdomain():
+    """A strip between two grain boundaries couples to both at once.
+
+    At steady state the chain is a series of resistances carrying one flux J::
+
+        2 - 0 = J (1/(3D) + 1/k1L + 1/k1R + 1/(3D) + 1/k2L + 1/k2R + 1/(3D))
+
+    Each manifold is uniform along its length, so its own diffusion term drops out and
+    the concentrations are pinned exactly. All four exchange rates differ, so a swapped
+    restriction -- or one manifold integrated over the other's facets -- moves them.
+    """
+    model, subdomains, species = build_two_junctions(second_junction="manifold")
+    left, middle, right, gamma_1, gamma_2 = subdomains
+    H_l, H_m, H_r, H_g1, H_g2 = species
+    model.initialise()
+
+    for subdomain in subdomains:
+        assert_subdomain_data_is_shared(subdomain.F, f"volume subdomain {subdomain.id}")
+
+    # sharing means the same object, not merely equal data
+    shared = model.interior_facet_measure
+    assert model.facet_measure(gamma_1) is shared
+    assert model.facet_measure(gamma_2) is shared
+    assert {tag for tag, _ in shared.subdomain_data()} == {GAMMA_1_ID, GAMMA_2_ID}
+
+    model.run()
+
+    # walk the resistance chain back from the empty wall on the right
+    bulk_r = 1 / (3 * D_BULK)
+    flux = 2.0 / (3 * bulk_r + 1 / K1_LEFT + 1 / K1_RIGHT + 1 / K2_LEFT + 1 / K2_RIGHT)
+    c_right_max = flux * bulk_r
+    c_gamma_2 = c_right_max + flux / K2_RIGHT
+    c_mid_min = c_gamma_2 + flux / K2_LEFT
+    c_mid_max = c_mid_min + flux * bulk_r
+    c_gamma_1 = c_mid_max + flux / K1_RIGHT
+    c_left_min = c_gamma_1 + flux / K1_LEFT
+
+    def values(spe, subdomain):
+        return spe.subdomain_to_post_processing_solution[subdomain].x.array
+
+    assert np.isclose(values(H_l, left).max(), 2.0, atol=1e-10)
+    assert np.isclose(values(H_l, left).min(), c_left_min, atol=1e-8)
+    assert np.allclose(values(H_g1, gamma_1), c_gamma_1, atol=1e-8)
+    assert np.isclose(values(H_m, middle).max(), c_mid_max, atol=1e-8)
+    assert np.isclose(values(H_m, middle).min(), c_mid_min, atol=1e-8)
+    assert np.allclose(values(H_g2, gamma_2), c_gamma_2, atol=1e-8)
+    assert np.isclose(values(H_r, right).max(), c_right_max, atol=1e-8)
+    assert np.isclose(values(H_r, right).min(), 0.0, atol=1e-10)

--- a/test/system_tests/test_codim1_interface.py
+++ b/test/system_tests/test_codim1_interface.py
@@ -879,8 +879,14 @@ def test_interface_and_interior_manifold_bounding_one_subdomain(recwarn):
     model.initialise()
 
     # neither the left bulk species nor the manifold's own species touches both sides
-    # of the interface, and neither is a mistake, so neither should warn
-    assert [w for w in recwarn if "interface" in str(w.message)] == []
+    # species the interface could not couple. Matched on the phrase unique to that
+    # warning: initialise() emits unrelated ones that also mention interfaces.
+    skipped = [
+        str(w.message)
+        for w in recwarn
+        if "the interface condition is not applied" in str(w.message)
+    ]
+    assert skipped == []
 
     # the middle strip's form now carries a manifold dS and an interface dS
     assert_subdomain_data_is_shared(middle.F, "the middle strip")

--- a/test/system_tests/test_codim1_interface.py
+++ b/test/system_tests/test_codim1_interface.py
@@ -706,3 +706,91 @@ def test_two_interior_manifolds_bounding_one_subdomain():
     assert np.allclose(values(H_g2, gamma_2), c_gamma_2, atol=1e-8)
     assert np.isclose(values(H_r, right).max(), c_right_max, atol=1e-8)
     assert np.isclose(values(H_r, right).min(), 0.0, atol=1e-10)
+
+
+# --- a bulk species that lives on more than one subdomain -------------------------
+
+
+def build_shared_bulk_species(n=12):
+    """Three strips with a manifold between the first two, where the bulk species of
+    the second strip also lives on the third.
+
+    A species spanning several subdomains has a solution on each, so the coupling
+    source on the manifold has to be told which one it reads -- the side of the
+    manifold the term belongs to. Nothing couples the middle and right strips here, so
+    at steady state no flux crosses the manifold and everything upstream of it settles
+    at the fed wall's value.
+    """
+    mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, n, n)
+    mat = F.Material(D_0=D_BULK, E_D=0.0)
+
+    left = F.VolumeSubdomain(
+        id=LEFT_ID, material=mat, locator=lambda x: x[0] <= 1 / 3 + 1e-14
+    )
+    middle = F.VolumeSubdomain(
+        id=MID_ID,
+        material=mat,
+        locator=lambda x: np.logical_and(x[0] >= 1 / 3 - 1e-14, x[0] <= 2 / 3 + 1e-14),
+    )
+    right = F.VolumeSubdomain(
+        id=RIGHT_ID, material=mat, locator=lambda x: x[0] >= 2 / 3 - 1e-14
+    )
+    gamma = F.VolumeSubdomain(
+        id=GAMMA_1_ID,
+        material=F.Material(D_0=D_GAMMA, E_D=0.0),
+        dim=1,
+        locator=lambda x: np.isclose(x[0], 1 / 3),
+    )
+    outer_l = F.SurfaceSubdomain(id=OUTER_L_ID, locator=lambda x: np.isclose(x[0], 0.0))
+    outer_r = F.SurfaceSubdomain(id=OUTER_R_ID, locator=lambda x: np.isclose(x[0], 1.0))
+
+    H_l = F.Species("H_l", subdomains=[left])
+    H_mr = F.Species("H_mr", subdomains=[middle, right])
+    H_g = F.Species("H_g", subdomains=[gamma])
+
+    sources, bcs = [], []
+    for bulk_species, k in ((H_l, K1_LEFT), (H_mr, K1_RIGHT)):
+        source, flux = _exchange(gamma, H_g, bulk_species, k)
+        sources.append(source)
+        bcs.append(flux)
+    bcs += [
+        F.FixedConcentrationBC(subdomain=outer_l, value=2.0, species=H_l),
+        F.FixedConcentrationBC(subdomain=outer_r, value=0.0, species=H_mr),
+    ]
+
+    model = F.HydrogenTransportProblemDiscontinuous(
+        mesh=F.Mesh(mesh),
+        species=[H_l, H_mr, H_g],
+        subdomains=[left, middle, right, gamma, outer_l, outer_r],
+        sources=sources,
+        boundary_conditions=bcs,
+        temperature=500,
+        settings=F.Settings(atol=1e-12, rtol=1e-12, transient=False),
+    )
+    return model, (left, middle, right, gamma), (H_l, H_mr, H_g)
+
+
+@pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only for now")
+def test_coupling_reads_the_species_solution_on_the_manifold_s_own_side():
+    """``H_mr`` has a solution on the middle strip and another on the right one, and
+    the exchange with the manifold reads the middle.
+
+    Reading the right one instead would leave the two halves of the exchange
+    disagreeing -- the source on the manifold pulling towards 0 while the flux out of
+    the middle strip pushes towards its own concentration -- and nothing would
+    equilibrate at the fed wall's value.
+    """
+    model, (left, middle, right, gamma), (H_l, H_mr, H_g) = build_shared_bulk_species()
+    model.initialise()
+    model.run()
+
+    def values(spe, subdomain):
+        return spe.subdomain_to_post_processing_solution[subdomain].x.array
+
+    # no outlet past the manifold, so no flux crosses it and everything upstream sits
+    # at the fed wall's value
+    assert np.allclose(values(H_l, left), 2.0, atol=1e-8)
+    assert np.allclose(values(H_g, gamma), 2.0, atol=1e-8)
+    assert np.allclose(values(H_mr, middle), 2.0, atol=1e-8)
+    # the right strip shares the species but nothing else, and only sees its own wall
+    assert np.allclose(values(H_mr, right), 0.0, atol=1e-8)

--- a/test/system_tests/test_codim1_interface.py
+++ b/test/system_tests/test_codim1_interface.py
@@ -794,3 +794,137 @@ def test_coupling_reads_the_species_solution_on_the_manifold_s_own_side():
     assert np.allclose(values(H_mr, middle), 2.0, atol=1e-8)
     # the right strip shares the species but nothing else, and only sees its own wall
     assert np.allclose(values(H_mr, right), 0.0, atol=1e-8)
+
+
+# --- an interface and an interior manifold in one model ---------------------------
+#
+# The two are independent mechanisms on different facets, but they meet in the form of
+# any volume subdomain bounded by both: an interface condition and a manifold coupling
+# are both dS integrals of the parent mesh, so that form needs the shared measure.
+
+PENALTY = 10.0
+
+
+def build_interface_and_manifold(n=12):
+    """Three strips joined at ``x = 1/3`` by an interior manifold and at ``x = 2/3`` by
+    an :class:`festim.Interface`, so the middle strip is bounded by both."""
+    mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, n, n)
+    # the interface relates u_0/K_0 to u_1/K_1, so the bulks need a solubility
+    mat = F.Material(D_0=D_BULK, E_D=0.0, K_S_0=1.0, E_K_S=0.0)
+
+    left = F.VolumeSubdomain(
+        id=LEFT_ID, material=mat, locator=lambda x: x[0] <= 1 / 3 + 1e-14
+    )
+    middle = F.VolumeSubdomain(
+        id=MID_ID,
+        material=mat,
+        locator=lambda x: np.logical_and(x[0] >= 1 / 3 - 1e-14, x[0] <= 2 / 3 + 1e-14),
+    )
+    right = F.VolumeSubdomain(
+        id=RIGHT_ID, material=mat, locator=lambda x: x[0] >= 2 / 3 - 1e-14
+    )
+    gamma = F.VolumeSubdomain(
+        id=GAMMA_1_ID,
+        material=F.Material(D_0=D_GAMMA, E_D=0.0),
+        dim=1,
+        locator=lambda x: np.isclose(x[0], 1 / 3),
+    )
+    outer_l = F.SurfaceSubdomain(id=OUTER_L_ID, locator=lambda x: np.isclose(x[0], 0.0))
+    outer_r = F.SurfaceSubdomain(id=OUTER_R_ID, locator=lambda x: np.isclose(x[0], 1.0))
+
+    H_l = F.Species("H_l", subdomains=[left])
+    # the interface enforces the continuity of this one across x = 2/3
+    H_mr = F.Species("H_mr", subdomains=[middle, right])
+    H_g = F.Species("H_g", subdomains=[gamma])
+
+    sources, bcs = [], []
+    for bulk_species, k in ((H_l, K1_LEFT), (H_mr, K1_RIGHT)):
+        source, flux = _exchange(gamma, H_g, bulk_species, k)
+        sources.append(source)
+        bcs.append(flux)
+    bcs += [
+        F.FixedConcentrationBC(subdomain=outer_l, value=2.0, species=H_l),
+        F.FixedConcentrationBC(subdomain=outer_r, value=0.0, species=H_mr),
+    ]
+
+    model = F.HydrogenTransportProblemDiscontinuous(
+        mesh=F.Mesh(mesh),
+        species=[H_l, H_mr, H_g],
+        subdomains=[left, middle, right, gamma, outer_l, outer_r],
+        sources=sources,
+        boundary_conditions=bcs,
+        interfaces=[
+            F.Interface(id=9, subdomains=[middle, right], penalty_term=PENALTY)
+        ],
+        temperature=500,
+        settings=F.Settings(atol=1e-12, rtol=1e-12, transient=False),
+    )
+    return model, (left, middle, right, gamma), (H_l, H_mr, H_g)
+
+
+@pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only for now")
+def test_interface_and_interior_manifold_bounding_one_subdomain(recwarn):
+    """A strip may have a manifold on one side and an interface on the other.
+
+    What the two may not do is cover the *same* facets, which is checked separately.
+
+    One flux crosses everything at steady state, so the drop across each element of the
+    chain predicts the same J. That holds whatever the interface's own resistance is,
+    which is what makes it a fair check of the coupling rather than of the penalty
+    constant.
+    """
+    model, (left, middle, right, gamma), (H_l, H_mr, H_g) = (
+        build_interface_and_manifold()
+    )
+    model.initialise()
+
+    # neither the left bulk species nor the manifold's own species touches both sides
+    # of the interface, and neither is a mistake, so neither should warn
+    assert [w for w in recwarn if "interface" in str(w.message)] == []
+
+    # the middle strip's form now carries a manifold dS and an interface dS
+    assert_subdomain_data_is_shared(middle.F, "the middle strip")
+
+    model.run()
+
+    def values(spe, subdomain):
+        return spe.subdomain_to_post_processing_solution[subdomain].x.array
+
+    c_left, c_g = values(H_l, left), values(H_g, gamma)
+    c_middle, c_right = values(H_mr, middle), values(H_mr, right)
+
+    # monotone step down from the fed wall to the empty one
+    assert np.isclose(c_left.max(), 2.0, atol=1e-10)
+    assert c_left.min() > c_g.max()
+    assert c_g.min() > c_middle.max()
+    assert c_middle.min() > c_right.max()
+    assert np.isclose(c_right.min(), 0.0, atol=1e-10)
+
+    # the same flux through both bulk strips and both faces of the manifold
+    bulk_conductance = 3 * D_BULK
+    fluxes = [
+        bulk_conductance * (2.0 - c_left.min()),
+        K1_LEFT * (c_left.min() - c_g.max()),
+        K1_RIGHT * (c_g.min() - c_middle.max()),
+        bulk_conductance * (c_middle.max() - c_middle.min()),
+        bulk_conductance * (c_right.max() - 0.0),
+    ]
+    assert np.allclose(fluxes, fluxes[0], rtol=1e-6)
+
+
+@pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only for now")
+def test_species_on_one_side_of_an_interface_warns():
+    """A species on exactly one of an interface's subdomains cannot be made continuous
+    across it. That is either deliberate -- a species absent from the neighbouring
+    material -- or a subdomain missing from its list, and only the user can tell which,
+    so it is skipped out loud."""
+    model, (_, _, right, _), _ = build_interface_and_manifold()
+    outer_r = next(s for s in model.subdomains if s.id == OUTER_R_ID)
+    confined = F.Species("H_right_only", subdomains=[right])
+    model.species.append(confined)
+    model.boundary_conditions.append(
+        F.FixedConcentrationBC(subdomain=outer_r, value=1.0, species=confined)
+    )
+
+    with pytest.warns(UserWarning, match="the other side of interface 9"):
+        model.initialise()

--- a/test/test_codim1_subdomain.py
+++ b/test/test_codim1_subdomain.py
@@ -529,14 +529,18 @@ def test_export_volume_measure_is_on_the_submesh_for_a_manifold():
     assert model.export_volume_measure(omega) is model.dx
 
 
-def test_unindexed_coupling_measure_agrees_with_the_indexed_one():
-    """Derived quantities need the measure itself, since they index it by the id of the
-    subdomain they export, exactly as they do with the parent ds."""
+def test_facet_measure_is_unindexed():
+    """Derived quantities index the measure they are handed by the id of the subdomain
+    they export, exactly as they do with the parent ds, so it must reach them
+    unrestricted. A manifold on the boundary of the mesh is integrated with that same
+    parent ``ds``."""
     model, _, gamma, _ = build_manifold_model([])
     model.initialise()
 
-    unindexed = model.unindexed_coupling_measure(gamma)
-    assert unindexed(gamma.id) == model.coupling_measure(gamma)
+    measure = model.facet_measure(gamma)
+    assert measure is model.ds
+    assert measure.subdomain_id() == "everywhere"
+    assert measure(gamma.id).subdomain_id() == gamma.id
 
 
 def test_manifold_boundary_measure_is_memoised():


### PR DESCRIPTION
## Description

### Summary
See https://github.com/festim-dev/FESTIM/pull/1216#discussion_r3805332451. Note that this implementation replaces `coupling_measure` and `unindexed_coupling_measure` with a single `facet_measure` method, this means that #1231 will need to be rebased. 

We could keep both methods if rebasing is too much of a headache but they ended up being rather redundant 

### Motivation and Context
Ensure that multiple codimensional couplings can be applied across each subdomain. 

UDPATE: I believe this also applies the fix suggested for the issue in #897 

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Code refactoring (no functional changes, no API changes)
- [ ] 📝 Documentation update
- [ ] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI configuration change

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [X] All existing tests pass locally (`pytest`)
- [X] I have added new tests that prove my fix is effective or that my feature works


## Code Quality Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [X] My code follows the code style of this project (Ruff formatted: `ruff format .`)
- [X] My code passes linting checks (`ruff check .`)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas

## Documentation

<!-- Put an `x` in the boxes that apply -->

- [X] I have updated the documentation accordingly (if applicable)
- [X] I have added docstrings to new functions/classes following the project conventions