### PR TITLE
changes to allow for SurfaceFlux exports for spherical and cylindrical coordinates

### DIFF
--- a/src/festim/exports/surface_flux.py
+++ b/src/festim/exports/surface_flux.py
@@ -1,8 +1,11 @@
+import math
+
 import ufl
 from dolfinx import fem
 from scifem import assemble_scalar
 
 from festim.exports.surface_quantity import SurfaceQuantity
+from festim.mesh import CoordinateSystem, Mesh
 from festim.species import Species
 from festim.subdomain.surface_subdomain import SurfaceSubdomain
 
@@ -22,6 +25,7 @@ class SurfaceFlux(SurfaceQuantity):
     field: Species
     surface: SurfaceSubdomain
     filename: str
+    mesh: Mesh
 
     title: str
     value: float
@@ -51,9 +55,31 @@ class SurfaceFlux(SurfaceQuantity):
         mesh = ds.ufl_domain()
         n = ufl.FacetNormal(mesh)
 
+        match self.mesh.coordinate_system:
+            case CoordinateSystem.CARTESIAN:
+                weight = 1
+            case CoordinateSystem.CYLINDRICAL:
+                assert self.mesh.vdim == 1, (
+                    "SurfaceFlux in cylindrical coordinates is only implemented "
+                    "for 1D radial meshes"
+                )
+                r = ufl.SpatialCoordinate(mesh)[0]
+                weight = 2 * math.pi * r
+            case CoordinateSystem.SPHERICAL:
+                assert self.mesh.vdim == 1, (
+                    "SurfaceFlux in spherical coordinates is only implemented "
+                    "for 1D radial meshes"
+                )
+                r = ufl.SpatialCoordinate(mesh)[0]
+                weight = 4 * math.pi * r**2
+            case _:
+                raise NotImplementedError(
+                    f"Unknown coordinate system {self.mesh.coordinate_system!s}"
+                )
+
         self.value = assemble_scalar(
             fem.form(
-                -self.D * ufl.dot(ufl.grad(u), n) * ds(self.surface.id),
+                -weight * self.D * ufl.dot(ufl.grad(u), n) * ds(self.surface.id),
                 entity_maps=entity_maps,
             )
         )

--- a/src/festim/exports/surface_flux.py
+++ b/src/festim/exports/surface_flux.py
@@ -5,8 +5,8 @@ from dolfinx import fem
 from scifem import assemble_scalar
 
 from festim.exports.surface_quantity import SurfaceQuantity
-from festim.mesh import CoordinateSystem
 from festim.helpers import restrict
+from festim.mesh import CoordinateSystem
 from festim.species import Species
 from festim.subdomain.surface_subdomain import SurfaceSubdomain
 from festim.subdomain.volume_subdomain import VolumeSubdomain
@@ -100,12 +100,16 @@ class SurfaceFlux(SurfaceQuantity):
                     f"Unknown coordinate system {self.coordinate_system!s}"
                 )
 
-        integrand = -weight * self.D * ufl.dot(ufl.grad(u), n)
+        integrand = -self.D * ufl.dot(ufl.grad(u), n)
         if subdomain_id is None:
             subdomain_id = self.surface.id
 
         if self.drift_velocity is not None:
             integrand += u * ufl.dot(self.drift_velocity, n)
+
+        # the weight carries the metric of the coordinate system, so it multiplies the
+        # whole flux density, drift included
+        integrand *= weight
 
         self.value = assemble_scalar(
             fem.form(

--- a/src/festim/exports/surface_flux.py
+++ b/src/festim/exports/surface_flux.py
@@ -5,7 +5,7 @@ from dolfinx import fem
 from scifem import assemble_scalar
 
 from festim.exports.surface_quantity import SurfaceQuantity
-from festim.mesh import CoordinateSystem, Mesh
+from festim.mesh import CoordinateSystem
 from festim.species import Species
 from festim.subdomain.surface_subdomain import SurfaceSubdomain
 
@@ -25,7 +25,7 @@ class SurfaceFlux(SurfaceQuantity):
     field: Species
     surface: SurfaceSubdomain
     filename: str
-    mesh: Mesh
+    coordinate_system: CoordinateSystem
 
     title: str
     value: float
@@ -55,26 +55,24 @@ class SurfaceFlux(SurfaceQuantity):
         mesh = ds.ufl_domain()
         n = ufl.FacetNormal(mesh)
 
-        match self.mesh.coordinate_system:
+        match self.coordinate_system:
             case CoordinateSystem.CARTESIAN:
                 weight = 1
             case CoordinateSystem.CYLINDRICAL:
-                assert self.mesh.vdim == 1, (
-                    "SurfaceFlux in cylindrical coordinates is only implemented "
-                    "for 1D radial meshes"
-                )
                 r = ufl.SpatialCoordinate(mesh)[0]
-                weight = 2 * math.pi * r
+                # TODO: full coverage assumed; expose as a constructor parameter
+                # (e.g. azimuth_range) to support partial coverage
+                coverage = 2 * math.pi  # radians
+                weight = coverage * r
             case CoordinateSystem.SPHERICAL:
-                assert self.mesh.vdim == 1, (
-                    "SurfaceFlux in spherical coordinates is only implemented "
-                    "for 1D radial meshes"
-                )
                 r = ufl.SpatialCoordinate(mesh)[0]
-                weight = 4 * math.pi * r**2
+                # TODO: full coverage assumed; expose as constructor parameters
+                # (e.g. azimuth_range, polar_range) to support partial coverage
+                coverage = 4 * math.pi  # steradians
+                weight = coverage * r**2
             case _:
                 raise NotImplementedError(
-                    f"Unknown coordinate system {self.mesh.coordinate_system!s}"
+                    f"Unknown coordinate system {self.coordinate_system!s}"
                 )
 
         self.value = assemble_scalar(

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -489,8 +489,12 @@ class HydrogenTransportProblem(problem.ProblemBase):
 
             elif isinstance(export, exports.DerivedQuantity):
                 # raise not implemented error if the derived quantity don't match the
-                # type of mesh eg. SurfaceFlux is used with cylindrical mesh
-                if self.mesh.coordinate_system != CoordinateSystem.CARTESIAN:
+                # type of mesh eg. TotalVolume is not implemented for cylindrical
+                # or spherical meshes. SurfaceFlux supports all coordinate systems.
+                if (
+                    self.mesh.coordinate_system != CoordinateSystem.CARTESIAN
+                    and not isinstance(export, exports.SurfaceFlux)
+                ):
                     raise NotImplementedError(
                         f"Derived quantity exports are not implemented for "
                         f"{self.mesh.coordinate_system!s} meshes"
@@ -536,6 +540,7 @@ class HydrogenTransportProblem(problem.ProblemBase):
                 # add the global D to the export
                 export.D = self._species_to_D_global.get(export.field)
                 export.D_expr = self._species_to_D_global_expr.get(export.field)
+                export.mesh = self.mesh
             if isinstance(export, exports.MaximumVolume | exports.MinimumVolume):
                 export.volume_meshtags = self.volume_meshtags
             if isinstance(export, exports.MaximumSurface | exports.MinimumSurface):
@@ -2130,6 +2135,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                 # NOTE: maybe we need to make sure there are no functionspace clashes?
 
                 export.D = D
+                export.mesh = self.mesh
 
             # reset the data and time for SurfaceQuantity and VolumeQuantity
             if isinstance(export, exports.DerivedQuantity):

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -540,7 +540,7 @@ class HydrogenTransportProblem(problem.ProblemBase):
                 # add the global D to the export
                 export.D = self._species_to_D_global.get(export.field)
                 export.D_expr = self._species_to_D_global_expr.get(export.field)
-                export.mesh = self.mesh
+                export.coordinate_system = self.mesh.coordinate_system
             if isinstance(export, exports.MaximumVolume | exports.MinimumVolume):
                 export.volume_meshtags = self.volume_meshtags
             if isinstance(export, exports.MaximumSurface | exports.MinimumSurface):
@@ -2135,7 +2135,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                 # NOTE: maybe we need to make sure there are no functionspace clashes?
 
                 export.D = D
-                export.mesh = self.mesh
+                export.coordinate_system = self.mesh.coordinate_system
 
             # reset the data and time for SurfaceQuantity and VolumeQuantity
             if isinstance(export, exports.DerivedQuantity):

--- a/test/system_tests/test_cylindrical_coordinates.py
+++ b/test/system_tests/test_cylindrical_coordinates.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 
 import festim as F
@@ -63,6 +65,72 @@ def test_run_MMS_cylindrical():
     L2_error = error_L2(computed_solution, u_exact)
 
     assert L2_error < 1e-6
+
+
+def test_surface_flux_cylindrical():
+    """Tests that SurfaceFlux computes the correct flux in cylindrical coordinates,
+    on a 1D radial mesh.
+
+    Uses the analytical solution for steady-state diffusion through a cylindrical
+    shell with no source: u(r) = (C1/D) * ln(r) + C2, solved for fixed
+    concentrations c1, c2 at the inner and outer radii r1, r2. The total flux
+    (per unit axial length) through any cylindrical shell, Q = -2 * pi * C1, is
+    constant in r (steady-state conservation with no source), so the inner and
+    outer surface fluxes should be equal and opposite.
+
+    TODO: add a 2D (r, z) axisymmetric version of this test, including a case
+    where the tagged surface isn't aligned with the mesh axes.
+    """
+
+    r1, r2 = 1.0, 2.0
+    c1, c2 = 10.0, 2.0
+    D = 2.0
+
+    my_mesh = F.Mesh1D(
+        vertices=np.linspace(r1, r2, 1000), coordinate_system="cylindrical"
+    )
+
+    my_mat = F.Material(D_0=D, E_D=0)
+
+    left = F.SurfaceSubdomain1D(id=1, x=r1)
+    right = F.SurfaceSubdomain1D(id=2, x=r2)
+    my_vol = F.VolumeSubdomain1D(id=3, borders=[r1, r2], material=my_mat)
+
+    H = F.Species("H")
+
+    my_bcs = [
+        F.FixedConcentrationBC(subdomain=left, value=c1, species=H),
+        F.FixedConcentrationBC(subdomain=right, value=c2, species=H),
+    ]
+
+    flux_left = F.SurfaceFlux(field=H, surface=left)
+    flux_right = F.SurfaceFlux(field=H, surface=right)
+
+    my_settings = F.Settings(
+        atol=1e-10,
+        rtol=1e-9,
+        max_iterations=50,
+        transient=False,
+    )
+
+    my_sim = F.HydrogenTransportProblem(
+        mesh=my_mesh,
+        species=[H],
+        subdomains=[my_vol, left, right],
+        boundary_conditions=my_bcs,
+        temperature=500,
+        exports=[flux_left, flux_right],
+        settings=my_settings,
+    )
+
+    my_sim.initialise()
+    my_sim.run()
+
+    C1 = D * (c1 - c2) / math.log(r1 / r2)
+    expected_flux_magnitude = abs(2 * math.pi * C1)
+
+    assert np.isclose(flux_left.value, -expected_flux_magnitude, rtol=1e-2)
+    assert np.isclose(flux_right.value, expected_flux_magnitude, rtol=1e-2)
 
 
 def test_run_MMS_cylindrical_mixed_domain():

--- a/test/system_tests/test_cylindrical_coordinates.py
+++ b/test/system_tests/test_cylindrical_coordinates.py
@@ -1,6 +1,10 @@
 import math
 
+from mpi4py import MPI
+
+import dolfinx
 import numpy as np
+import ufl
 
 import festim as F
 
@@ -77,9 +81,6 @@ def test_surface_flux_cylindrical():
     (per unit axial length) through any cylindrical shell, Q = -2 * pi * C1, is
     constant in r (steady-state conservation with no source), so the inner and
     outer surface fluxes should be equal and opposite.
-
-    TODO: add a 2D (r, z) axisymmetric version of this test, including a case
-    where the tagged surface isn't aligned with the mesh axes.
     """
 
     r1, r2 = 1.0, 2.0
@@ -218,3 +219,115 @@ def test_run_MMS_cylindrical_mixed_domain():
 
     assert L2_error_l < 1e-06
     assert L2_error_r < 1e-06
+
+
+def test_surface_flux_cylindrical_2d_oblique_surface():
+    """Tests that SurfaceFlux is correct in cylindrical coordinates on a 2D (r, z)
+    mesh whose boundary is not aligned with the mesh axes.
+
+    The domain is the meridian section of a truncated cone: r goes from ``r1`` to
+    ``r2`` and z from 0 to the sloped line ``h(r) = z0 + slope * (r - r1)``. The
+    sloped boundary is the lateral surface of the cone, so its normal has both an r
+    and a z component -- unlike the inner, outer and bottom surfaces, which are
+    axis-aligned and are checked here too.
+
+    The concentration is fixed to the manufactured solution ``c = 1 + r**2 + z**2``
+    on every boundary, with the matching source term, so the flux density is
+    ``q = -D grad(c) = -2 D (r, z)``. Integrating ``q . n`` over a surface of
+    revolution uses ``dA = 2 pi r dl``, which on the sloped boundary gives
+
+        Q_cone = 2 pi D (slope * r1 - z0) * (r2**2 - r1**2)
+
+    since the integrand ``r * (slope * r - h(r))`` collapses to the constant
+    ``r * (slope * r1 - z0)``. The axis-aligned surfaces integrate to
+    ``4 pi D r1**2 z0`` (inner) and ``-4 pi D r2**2 h(r2)`` (outer), and the bottom
+    carries no flux because ``q . n = -q_z`` vanishes at z = 0. The four fluxes are
+    also checked against the divergence theorem, which ties the weight used on the
+    sloped surface to the one used on the axis-aligned ones.
+    """
+
+    r1, r2 = 1.0, 2.0
+    z0, slope = 1.0, 0.5
+    D = 2.0
+
+    def h(r):
+        """z of the sloped boundary at radius r."""
+        return z0 + slope * (r - r1)
+
+    # deform a unit square into the (r, z) meridian section of the truncated cone.
+    # The mapping is affine in r, so the sloped boundary stays a straight line and the
+    # straight-sided cells represent the geometry exactly
+    square = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 24, 24)
+    nodes = square.geometry.x
+    r = r1 + (r2 - r1) * nodes[:, 0].copy()
+    nodes[:, 0] = r
+    nodes[:, 1] = nodes[:, 1].copy() * h(r)
+
+    my_mesh = F.Mesh(mesh=square, coordinate_system="cylindrical")
+
+    def c_exact(x):
+        return 1 + x[0] ** 2 + x[1] ** 2
+
+    my_mat = F.Material(D_0=D, E_D=0)
+
+    my_vol = F.VolumeSubdomain(
+        id=1,
+        material=my_mat,
+        locator=lambda x: np.full_like(x[0], True, dtype=bool),
+    )
+    cone = F.SurfaceSubdomain(id=2, locator=lambda x: np.isclose(x[1], h(x[0])))
+    bottom = F.SurfaceSubdomain(id=3, locator=lambda x: np.isclose(x[1], 0.0))
+    inner = F.SurfaceSubdomain(id=4, locator=lambda x: np.isclose(x[0], r1))
+    outer = F.SurfaceSubdomain(id=5, locator=lambda x: np.isclose(x[0], r2))
+    surfaces = [cone, bottom, inner, outer]
+
+    H = F.Species("H")
+
+    # the cylindrical divergence of the flux, ie. the source that makes c_exact the
+    # solution: (1 / r) d/dr (r q_r) + d q_z / dz
+    x = ufl.SpatialCoordinate(my_mesh.mesh)
+    f = -(1 / x[0]) * ufl.div(x[0] * D * ufl.grad(c_exact(x)))
+
+    fluxes = {surf.id: F.SurfaceFlux(field=H, surface=surf) for surf in surfaces}
+
+    my_sim = F.HydrogenTransportProblem(
+        mesh=my_mesh,
+        species=[H],
+        subdomains=[my_vol, *surfaces],
+        boundary_conditions=[
+            F.FixedConcentrationBC(subdomain=surf, value=c_exact, species=H)
+            for surf in surfaces
+        ],
+        temperature=500,
+        sources=[F.ParticleSource(value=f, volume=my_vol, species=H)],
+        exports=list(fluxes.values()),
+        # c_exact is quadratic and the cells are straight-sided, so P2 reproduces it
+        # exactly and the fluxes come out to solver precision
+        settings=F.Settings(
+            atol=1e-12, rtol=1e-12, max_iterations=50, transient=False, element_degree=2
+        ),
+    )
+
+    my_sim.initialise()
+    my_sim.run()
+
+    expected_cone = 2 * math.pi * D * (slope * r1 - z0) * (r2**2 - r1**2)
+    expected_inner = 4 * math.pi * D * r1**2 * z0
+    expected_outer = -4 * math.pi * D * r2**2 * h(r2)
+
+    assert np.isclose(fluxes[cone.id].value, expected_cone, rtol=1e-6)
+    assert np.isclose(fluxes[inner.id].value, expected_inner, rtol=1e-6)
+    assert np.isclose(fluxes[outer.id].value, expected_outer, rtol=1e-6)
+    assert np.isclose(fluxes[bottom.id].value, 0.0, atol=1e-6)
+
+    # divergence theorem: the net flux out of the closed boundary is the integral of
+    # div(q) = f = -6 D over the volume of revolution, 2 pi times the integral of
+    # r h(r) dr
+    volume = (
+        2
+        * math.pi
+        * ((z0 - slope * r1) * (r2**2 - r1**2) / 2 + slope * (r2**3 - r1**3) / 3)
+    )
+    net_flux = sum(flux.value for flux in fluxes.values())
+
+    assert np.isclose(net_flux, -6 * D * volume, rtol=1e-6)

--- a/test/system_tests/test_spherical_coordinates.py
+++ b/test/system_tests/test_spherical_coordinates.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 from dolfinx import fem
 
@@ -64,6 +66,67 @@ def test_run_MMS_spherical():
     L2_error = error_L2(computed_solution, u_exact)
 
     assert L2_error < 1e-6
+
+
+def test_surface_flux_spherical():
+    """Tests that SurfaceFlux computes the correct flux in spherical coordinates.
+
+    Uses the analytical solution for steady-state diffusion through a spherical
+    shell with no source: u(r) = A/r + B, solved for fixed concentrations u1, u2
+    at the inner and outer radii r1, r2. The total flux through any spherical
+    shell, Q = 4 * pi * D * A, is constant in r (steady-state conservation with no
+    source), so the inner and outer surface fluxes should be equal and opposite.
+    """
+
+    r1, r2 = 1.0, 2.0
+    c1, c2 = 10.0, 2.0
+    D = 2.0
+
+    my_mesh = F.Mesh1D(
+        vertices=np.linspace(r1, r2, 1000), coordinate_system="spherical"
+    )
+
+    my_mat = F.Material(D_0=D, E_D=0)
+
+    left = F.SurfaceSubdomain1D(id=1, x=r1)
+    right = F.SurfaceSubdomain1D(id=2, x=r2)
+    my_vol = F.VolumeSubdomain1D(id=3, borders=[r1, r2], material=my_mat)
+
+    H = F.Species("H")
+
+    my_bcs = [
+        F.FixedConcentrationBC(subdomain=left, value=c1, species=H),
+        F.FixedConcentrationBC(subdomain=right, value=c2, species=H),
+    ]
+
+    flux_left = F.SurfaceFlux(field=H, surface=left)
+    flux_right = F.SurfaceFlux(field=H, surface=right)
+
+    my_settings = F.Settings(
+        atol=1e-10,
+        rtol=1e-9,
+        max_iterations=50,
+        transient=False,
+    )
+
+    my_sim = F.HydrogenTransportProblem(
+        mesh=my_mesh,
+        species=[H],
+        subdomains=[my_vol, left, right],
+        boundary_conditions=my_bcs,
+        temperature=500,
+        exports=[flux_left, flux_right],
+        settings=my_settings,
+    )
+
+    my_sim.initialise()
+    my_sim.run()
+
+    A = (c1 - c2) * r1 * r2 / (r2 - r1)
+    expected_flux_magnitude = 4 * math.pi * D * A
+
+    assert np.isclose(flux_left.value, -expected_flux_magnitude, rtol=1e-2)
+    assert np.isclose(flux_right.value, expected_flux_magnitude, rtol=1e-2)
 
 
 def test_run_MMS_spherical_mixed_domain():

--- a/test/test_surface_quantity.py
+++ b/test/test_surface_quantity.py
@@ -43,6 +43,7 @@ def test_surface_flux_export_compute():
         surface=dummy_surface,
     )
     my_export.D = D
+    my_export.mesh = my_mesh
 
     # RUN
     my_export.compute(my_species.solution, ds=ds)

--- a/test/test_surface_quantity.py
+++ b/test/test_surface_quantity.py
@@ -43,7 +43,7 @@ def test_surface_flux_export_compute():
         surface=dummy_surface,
     )
     my_export.D = D
-    my_export.mesh = my_mesh
+    my_export.coordinate_system = my_mesh.coordinate_system
 
     # RUN
     my_export.compute(my_species.solution, ds=ds)


### PR DESCRIPTION
## Description

### Summary
This is only a small change but it allows SurfaceFlux to take cylindrical and spherical coordinates. SurfaceFlux for spherical is just atom/m2 while the cylindrical (I think) is per unit length). Currently a NotImplementedError is raised so this support these computed properties for these other coordinate systems. This does not cover partial solid angles, only full. Some support from Claude Sonnet 4.8 was utilised.

### Related Issues
PR #689 and #688 -- these were found after the write up, and it looks like such changes were rejected (maybe this change will also be the same)

### Motivation and Context
Useful for some spherical pebble modelling! I was doing this anyway in postprocessing. It also coudl be useful to extend it to help the GasEnclosure stuff.

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Code refactoring (no functional changes, no API changes)
- [ ] 📝 Documentation update
- [ ] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI configuration change

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] All existing tests pass locally (`pytest`)
- [x] I have added new tests that prove my fix is effective or that my feature works



## Code Quality Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [ ] My code follows the code style of this project (Ruff formatted: `ruff format .`)
- [ ] My code passes linting checks (`ruff check .`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Documentation

<!-- Put an `x` in the boxes that apply -->

- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added docstrings to new functions/classes following the project conventions

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here -->
<!-- What will users need to change in their code? -->
<!-- Delete this section if not applicable -->

## Screenshots/Examples

<!-- If applicable, add screenshots or code examples to help explain your changes -->
<!-- This is especially useful for new features or bug fixes with visual components -->

## Additional Notes

The surface flux export for the cylindrical I think is per unit axial length. a review on my maths would be appreciated! I also do not have a good test for the cylindrical yet.
