### PR TITLE
docs: recommend a conda distribution rather than Anaconda specifically

### DIFF
--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -45,7 +45,7 @@ jobs:
           retry_count: 3
           
           # A comma separated links to exclude during URL checks
-          exclude_urls: https://www.lspm.cnrs.fr/en/home/,https://www.theses.fr/2022PA131054
+          exclude_urls: https://www.lspm.cnrs.fr/en/home/,https://www.theses.fr/2022PA131054,https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$
 
           # A comma separated patterns to exclude during URL checks
           exclude_patterns:

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -20,17 +20,20 @@ Option 1: Conda (Recommended)
 
 The easiest way to install FESTIM with all its dependencies (including dolfinx) is via Conda.
 
-First `install Anaconda <https://docs.continuum.io/anaconda/install>`_,
+First install a conda distribution, e.g.
+`Anaconda <https://docs.anaconda.com/anaconda/install/>`_ or
+`Miniforge <https://github.com/conda-forge/miniforge>`_.
 
 .. tip::
 
-    You can install Anaconda on most Linux distributions by entering::
+    You can install Miniforge on Linux and MacOS by entering::
 
-        curl -O https://repo.anaconda.com/archive/Anaconda3-2024.06-1-Linux-x86_64.sh
-        bash ./Anaconda3-2024.06-1-Linux-x86_64.sh
+        curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+        bash Miniforge3-$(uname)-$(uname -m).sh
 
-    You can install other versions by replacing :code:`Anaconda3-2024.06-1-Linux-x86_64.sh` 
-    with another from `the official repository <https://repo.anaconda.com/archive/>`_.
+    See the `Miniforge <https://github.com/conda-forge/miniforge#install>`_ and
+    `Anaconda <https://docs.anaconda.com/anaconda/install/>`_ documentation for other
+    installation methods.
 
 Then run the following commands to create an environment and install FESTIM::
 

--- a/docs/source/userguide/beginners_guide.rst
+++ b/docs/source/userguide/beginners_guide.rst
@@ -8,7 +8,7 @@ What do I need to know?
 
 Basic knowledge of `Python <https://www.learnpython.org/>`_ is required to make the most out of FESTIM.
 
-New users should familiarise themselves with `Conda <https://anaconda.org/>`_.
+New users should familiarise themselves with `Conda <https://docs.conda.io/>`_ and the `conda-forge <https://conda-forge.org/>`_ channel.
 
 FESTIM is under version control with `git <https://git-scm.com/>`_. Even though users don't need git to install FESTIM, it is convenient to have a basic understanding of how it works. You can find `git tutorials <https://git-scm.com/doc>`_ to help you getting started. The `FESTIM source code <https://github.com/festim-dev/FESTIM>`_ is hosted on GitHub.
 Git knowledge and a GitHub account is required to open issues and :ref:`contribute to the code <developers_guide>`.


### PR DESCRIPTION

## Description

### Summary
The install guide pointed users at Anaconda by name and pinned a specific Anaconda3 installer URL that goes stale. Reword to "install a conda distribution, e.g. Anaconda or Miniforge" and show the version-independent Miniforge installer instead.

Also point the beginner's guide "familiarise yourself with Conda" link at the conda docs rather than anaconda.org, which is a package host.


### Related Issues
no related issues

### Motivation and Context
Miniforge is a nice more open source option

## Type of Change
- [x] 📝 Documentation update


## Testing

- [x] All existing tests pass locally (`pytest`)
~- [ ] I have added new tests that prove my fix is effective or that my feature works~


## Code Quality Checklist
Not really got any code in this PR
- [ ] My code follows the code style of this project (Ruff formatted: `ruff format .`)
- [ ] My code passes linting checks (`ruff check .`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

## Documentation
- [x] I have updated the documentation accordingly (if applicable)
~- [ ] I have added docstrings to new functions/classes following the project conventions~

## Breaking Changes

none
