### PR TITLE
docs: attribute the Windows limitation to scifem, not dolfinx

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,7 +3,7 @@ Installation
 ============
 
 
-Because the main dependency FEniCSx (dolfinx) cannot be installed natively on Windows, Windows users must use the `Windows Subsystem for Linux <https://learn.microsoft.com/en-us/windows/wsl/install>`_ (WSL). FEniCSx can be installed natively on MacOs and Linux.
+Windows users must use the `Windows Subsystem for Linux <https://learn.microsoft.com/en-us/windows/wsl/install>`_ (WSL), because one of FESTIM's dependencies, `scifem <https://github.com/scientificcomputing/scifem>`_, is not built for Windows on conda-forge. FESTIM can be installed natively on MacOS and Linux.
 
 .. tip::
     You can install `WSL <https://learn.microsoft.com/en-us/windows/wsl/install>`_ by running


### PR DESCRIPTION


## Description

### Summary
conda-forge now ships win-64 builds of fenics-dolfinx (0.9.0, 0.10.0 and 0.11.0), so dolfinx is no longer the reason FESTIM cannot be installed natively on Windows. scifem has no win-64 build, so WSL is still required but the actual blocker has changed.

https://anaconda.org/channels/conda-forge/packages/fenics-dolfinx/files?version=0.11.0

### Related Issues
none

### Motivation and Context
dolfinx is good here and perhaps not to be blamed for the lack of windows support

## Type of Change


- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Code refactoring (no functional changes, no API changes)
- [x] 📝 Documentation update
- [ ] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI configuration change

## Testing

- [x] All existing tests pass locally (`pytest`)
~- [ ] I have added new tests that prove my fix is effective or that my feature works~

## Code Quality Checklist
No code here

## Documentation

- [x] I have updated the documentation accordingly (if applicable)
~- [ ] I have added docstrings to new functions/classes following the project conventions~

## Breaking Changes

none
