### PR TITLE
Fix relative SNES step convergence criterion

### DIFF
--- a/src/festim/helpers.py
+++ b/src/festim/helpers.py
@@ -509,7 +509,7 @@ def convergenceTest(snes, it, norms):
         return snes.ConvergedReason.CONVERGED_FNORM_ABS
     elif f / _residual0 < rtol:
         return snes.ConvergedReason.CONVERGED_FNORM_RELATIVE
-    elif gnorm < stol and it > 0:
+    elif gnorm < stol * _xnorm and it > 0:
         return snes.ConvergedReason.CONVERGED_SNORM_RELATIVE
     else:
         return snes.ConvergedReason.ITERATING

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -512,3 +512,34 @@ def test_convert_input_value_time_and_species_dependent():
     species.solution.x.array[:] = 4.0
     result.interpolate(expr)
     assert np.allclose(result.x.array, 5.0 * 4.0)
+
+
+def test_convergence_test_uses_relative_step_norm():
+    """Test that the SNES step criterion scales stol by the solution norm."""
+
+    class MockSNES:
+        class ConvergedReason:
+            DIVERGED_MAX_IT = -5
+            CONVERGED_FNORM_ABS = 2
+            CONVERGED_FNORM_RELATIVE = 3
+            CONVERGED_SNORM_RELATIVE = 4
+            ITERATING = 0
+
+        def getTolerances(self):
+            return 1e-8, 1e-12, 1e-4, 50
+
+    snes = MockSNES()
+
+    initial_reason = F.helpers.convergenceTest(
+        snes,
+        it=0,
+        norms=(100.0, 1.0, 1.0),
+    )
+    assert initial_reason == snes.ConvergedReason.ITERATING
+
+    reason = F.helpers.convergenceTest(
+        snes,
+        it=1,
+        norms=(100.0, 5e-3, 1.0),
+    )
+    assert reason == snes.ConvergedReason.CONVERGED_SNORM_RELATIVE


### PR DESCRIPTION
## Description

### Summary

Fix the relative SNES step-convergence criterion in the custom convergence callback.

The callback returns `CONVERGED_SNORM_RELATIVE`, but previously tested
`gnorm < stol`, effectively applying `stol` as an absolute step-norm
threshold. The condition is changed to `gnorm < stol * _xnorm`, consistent
with the relative step criterion.

A regression test is included to distinguish the absolute and relative
criteria.

### Related Issues

Closes #1253.

### Motivation and Context

The existing convergence callback receives both the solution norm and step
norm, but did not scale the step tolerance by the solution norm when applying
the relative step-convergence criterion. This could therefore give a different
convergence classification from the corresponding relative criterion.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Code refactoring (no functional changes, no API changes)
- [ ] 📝 Documentation update
- [x] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI configuration change

## Testing

- [x] All existing tests pass locally (`pytest`)
- [x] I have added new tests that prove my fix is effective or that my feature works

Local test suite:

`PYTHONPATH="$PWD/src" python -m pytest test/ -q`

Result: **1149 passed, 5 skipped**.

The new regression test was also verified to fail with the original condition
and pass with the corrected relative criterion.

## Code Quality Checklist

- [x] My code follows the code style of this project
- [ ] My code passes linting checks (`ruff check .`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

The two modified files pass:

`ruff format --check src/festim/helpers.py test/test_helpers.py`

`ruff check src/festim/helpers.py test/test_helpers.py`

Repository-wide `ruff check .` currently reports pre-existing issues in
unmodified files.