### PR TITLE
Add support for non-cartesian manifolds in codim problems

### DIFF
--- a/docs/source/userguide/subdomains.rst
+++ b/docs/source/userguide/subdomains.rst
@@ -317,9 +317,53 @@ gives the outlet flux of the pipe example:
 
 .. note::
 
-    :class:`festim.SurfaceFlux` computes the **diffusive** flux only. On a manifold
-    carrying an :class:`festim.AdvectionTerm` the advective part is not included, and
-    FESTIM warns.
+    :class:`festim.SurfaceFlux` computes the total flux, including diffusion and
+    any drift acting on the species, such as :class:`festim.AdvectionTerm`.
+
+Coordinate systems
+------------------
+
+Codimensional coupling supports the same coordinate systems as
+:class:`festim.HydrogenTransportProblemDiscontinuous`:
+
+* Cartesian: points in 1D, lines in 2D, and surfaces in 3D.
+* Cylindrical: points in a 1D radial mesh or lines in a 2D axisymmetric
+  :math:`(r,z)` mesh. The first coordinate is the radius.
+* Spherical: points in a 1D radial mesh, representing concentric spherical surfaces.
+
+Set ``coordinate_system`` on the mesh as usual. For a radial model, declare a
+surface carrying its own concentration with ``dim=0``:
+
+.. code-block:: python
+
+    mesh = F.Mesh1D(np.linspace(1.0, 2.0, 101), coordinate_system="spherical")
+    bulk = F.VolumeSubdomain1D(id=1, borders=[1.0, 2.0], material=material)
+    gamma = F.VolumeSubdomain(
+        id=2, dim=0, material=material,
+        locator=lambda x: np.isclose(x[0], 2.0),
+    )
+
+A point subdomain has one concentration degree of freedom per point. It supports
+transient storage, sources, reactions and exchange with the adjacent bulk, but has
+no tangential diffusion or drift and no boundary of its own. A line in an
+axisymmetric mesh supports tangential transport, including the radial metric.
+
+Exchange laws remain flux densities: use the same equal-and-opposite
+``ParticleFluxBC`` and ``ParticleSource`` pair as above, without multiplying either
+value by an area. The radial metric cancels against the rescaled test function in
+these terms, just as it does in the storage and local source terms.
+
+Integral exports in the discontinuous problem include the physical measure:
+:math:`2\pi r` in cylindrical coordinates and :math:`4\pi r^2` in spherical
+coordinates. These factors apply to both totals and the numerator and denominator
+of averages, on bulk subdomains, manifolds and their boundaries. Cylindrical 1D
+totals are per unit axial length; full angular coverage is assumed. For example,
+``TotalVolume(field=c_gamma, volume=gamma)`` on the spherical point at radius
+:math:`R` reports :math:`4\pi R^2 c_\Gamma`.
+
+As in the standard radial formulation, the rescaled gradient terms contain
+``1/r`` or ``1/r**2``. An isolated manifold at ``r=0`` has zero physical measure
+and cannot represent a finite-area exchange surface.
 
 Limitations
 -----------
@@ -331,14 +375,13 @@ Limitations
 * A manifold must lie wholly inside the mesh or wholly on its boundary, and a manifold
   on the boundary of the mesh is adjacent to a single volume subdomain.
 * Boundary conditions on the boundary of a manifold are limited to
-  :class:`festim.FixedConcentrationBC`.
+  :class:`festim.FixedConcentrationBC` and :class:`festim.OutflowBC`.
 * Exports on and around a manifold are limited to the integral-based derived quantities
   (:class:`festim.SurfaceFlux`, :class:`festim.TotalSurface`,
   :class:`festim.AverageSurface`, :class:`festim.TotalVolume`,
   :class:`festim.AverageVolume`) and :class:`festim.VTXSpeciesExport`. The minimum and
   maximum quantities and :class:`festim.CustomQuantity` are not available in
   :class:`festim.HydrogenTransportProblemDiscontinuous` at all, manifold or not.
-* Cartesian coordinates only.
 
 ----------
 Materials

--- a/src/festim/advection.py
+++ b/src/festim/advection.py
@@ -141,7 +141,7 @@ class VelocityField(Value):
         v_cg = basix.ufl.element(
             "Lagrange",
             function_space.mesh.topology.cell_name(),
-            1,
+            0 if function_space.mesh.topology.dim == 0 else 1,
             shape=(function_space.mesh.geometry.dim,),
         )
         self.vector_function_space = fem.functionspace(function_space.mesh, v_cg)

--- a/src/festim/exports/average_surface.py
+++ b/src/festim/exports/average_surface.py
@@ -47,13 +47,16 @@ class AverageSurface(SurfaceQuantity):
         if subdomain_id is None:
             subdomain_id = self.surface.id
 
+        weight = self.coordinate_system.integration_weight(ds.ufl_domain())
         self.value = assemble_scalar(
             fem.form(
-                restrict(u, restriction) * ds(subdomain_id), entity_maps=entity_maps
+                restrict(weight * u, restriction) * ds(subdomain_id),
+                entity_maps=entity_maps,
             )
         ) / assemble_scalar(
             fem.form(
-                restrict(1, restriction) * ds(subdomain_id), entity_maps=entity_maps
+                restrict(weight, restriction) * ds(subdomain_id),
+                entity_maps=entity_maps,
             )
         )
         self.data.append(self.value)

--- a/src/festim/exports/average_volume.py
+++ b/src/festim/exports/average_volume.py
@@ -23,7 +23,8 @@ class AverageVolume(VolumeQuantity):
     def compute(self, u, dx, entity_maps=None):
         """Computes the average value of solution function within the defined volume
         subdomain, and appends it to the data list."""
+        weight = self.coordinate_system.integration_weight(dx.ufl_domain())
         self.value = assemble_scalar(
-            u * dx(self.volume.id), entity_maps=entity_maps
-        ) / assemble_scalar(1 * dx(self.volume.id))
+            weight * u * dx(self.volume.id), entity_maps=entity_maps
+        ) / assemble_scalar(weight * dx(self.volume.id))
         self.data.append(self.value)

--- a/src/festim/exports/surface_flux.py
+++ b/src/festim/exports/surface_flux.py
@@ -1,5 +1,3 @@
-import math
-
 import ufl
 from dolfinx import fem
 from scifem import assemble_scalar
@@ -80,25 +78,7 @@ class SurfaceFlux(SurfaceQuantity):
         mesh = ds.ufl_domain()
         n = ufl.FacetNormal(mesh)
 
-        match self.coordinate_system:
-            case CoordinateSystem.CARTESIAN:
-                weight = 1
-            case CoordinateSystem.CYLINDRICAL:
-                r = ufl.SpatialCoordinate(mesh)[0]
-                # TODO: full coverage assumed; expose as a constructor parameter
-                # (e.g. azimuth_range) to support partial coverage
-                coverage = 2 * math.pi  # radians
-                weight = coverage * r
-            case CoordinateSystem.SPHERICAL:
-                r = ufl.SpatialCoordinate(mesh)[0]
-                # TODO: full coverage assumed; expose as constructor parameters
-                # (e.g. azimuth_range, polar_range) to support partial coverage
-                coverage = 4 * math.pi  # steradians
-                weight = coverage * r**2
-            case _:
-                raise NotImplementedError(
-                    f"Unknown coordinate system {self.coordinate_system!s}"
-                )
+        weight = self.coordinate_system.integration_weight(mesh)
 
         integrand = -self.D * ufl.dot(ufl.grad(u), n)
         if subdomain_id is None:

--- a/src/festim/exports/surface_quantity.py
+++ b/src/festim/exports/surface_quantity.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 
 from festim.exports.derived_quantity import DerivedQuantity
+from festim.mesh import CoordinateSystem
 from festim.species import Species
 from festim.subdomain.surface_subdomain import SurfaceSubdomain
 from festim.subdomain.volume_subdomain import VolumeSubdomain
@@ -31,6 +32,7 @@ class SurfaceQuantity(DerivedQuantity):
 
     t: list[float]
     data: list[float]
+    coordinate_system = CoordinateSystem.CARTESIAN
 
     def __init__(
         self,

--- a/src/festim/exports/total_surface.py
+++ b/src/festim/exports/total_surface.py
@@ -46,9 +46,11 @@ class TotalSurface(SurfaceQuantity):
         if subdomain_id is None:
             subdomain_id = self.surface.id
 
+        weight = self.coordinate_system.integration_weight(ds.ufl_domain())
         self.value = assemble_scalar(
             fem.form(
-                restrict(u, restriction) * ds(subdomain_id), entity_maps=entity_maps
+                restrict(weight * u, restriction) * ds(subdomain_id),
+                entity_maps=entity_maps,
             )
         )
         self.data.append(self.value)

--- a/src/festim/exports/total_volume.py
+++ b/src/festim/exports/total_volume.py
@@ -29,5 +29,8 @@ class TotalVolume(VolumeQuantity):
             dx: volume measure of the model
             entity_maps: entity maps relating parent mesh and submesh
         """
-        self.value = assemble_scalar(u * dx(self.volume.id), entity_maps=entity_maps)
+        weight = self.coordinate_system.integration_weight(dx.ufl_domain())
+        self.value = assemble_scalar(
+            weight * u * dx(self.volume.id), entity_maps=entity_maps
+        )
         self.data.append(self.value)

--- a/src/festim/exports/volume_quantity.py
+++ b/src/festim/exports/volume_quantity.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 
 from festim.exports.derived_quantity import DerivedQuantity
+from festim.mesh import CoordinateSystem
 from festim.species import Species
 from festim.subdomain.volume_subdomain import VolumeSubdomain
 
@@ -27,6 +28,7 @@ class VolumeQuantity(DerivedQuantity):
 
     t: list[float]
     data: list[float]
+    coordinate_system = CoordinateSystem.CARTESIAN
 
     def __init__(
         self,

--- a/src/festim/helpers.py
+++ b/src/festim/helpers.py
@@ -13,6 +13,30 @@ if TYPE_CHECKING:
     from festim.subdomain.volume_subdomain import VolumeSubdomain
 
 
+def spatial_coordinate(mesh):
+    """Coordinates on an integration mesh, including a zero-dimensional submesh.
+
+    FFCx 0.11 cannot compile SpatialCoordinate on a vertex cell (its coordinate
+    table is identically one). A P0 coefficient stores the exact coordinates at
+    each point, also when a point subdomain contains several disconnected points.
+    """
+    domain = mesh if isinstance(mesh, ufl.Mesh) else mesh.ufl_domain()
+    # UFL exposed this as a method before the release bundled with DOLFINx 0.11.
+    tdim = domain.topological_dimension
+    if callable(tdim):
+        tdim = tdim()
+    if tdim > 0:
+        return ufl.SpatialCoordinate(domain)
+    if isinstance(mesh, ufl.Mesh):
+        mesh = dolfinx.mesh.Mesh(domain.ufl_cargo(), domain)
+    gdim = mesh.geometry.dim
+    V = fem.functionspace(mesh, ("P", 0, (gdim,)))
+    coordinate = fem.Function(V)
+    coordinate.interpolate(lambda x: x[:gdim])
+    coordinate.x.scatter_forward()
+    return coordinate
+
+
 def as_fenics_constant(
     value: float | int | fem.Constant, mesh: dolfinx.mesh.Mesh
 ) -> fem.Constant:
@@ -71,15 +95,12 @@ def as_mapped_function(
     kwargs = {}
     if "t" in arguments:
         kwargs["t"] = t
-    if "x" in arguments:
-        x = ufl.SpatialCoordinate(function_space.mesh)
-        kwargs["x"] = x
     if "T" in arguments:
         kwargs["T"] = temperature
     if "x" in arguments:
         # the spatial coordinate must come from the mesh the integral is assembled
         # over, which is not always the mesh the unknown lives on
-        kwargs["x"] = ufl.SpatialCoordinate(mesh or function_space.mesh)
+        kwargs["x"] = spatial_coordinate(mesh or function_space.mesh)
 
     for name, species in (species_dependent_value or {}).items():
         # only pass the species the callable actually declares, as done above for

--- a/src/festim/hydrogen_transport_problem.py
+++ b/src/festim/hydrogen_transport_problem.py
@@ -1567,7 +1567,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                 element_CG = basix.ufl.element(
                     basix.ElementFamily.P,
                     subdomain.submesh.basix_cell(),
-                    1,  # could expose?
+                    0 if subdomain.submesh.topology.dim == 0 else 1,
                     basix.LagrangeVariant.equispaced,
                 )
                 V = dolfinx.fem.functionspace(subdomain.submesh, element_CG)
@@ -1718,7 +1718,9 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
             else:
                 V = condition.species.subdomain_to_function_space[condition.volume]
 
-                if isinstance(self.temperature_fenics, fem.Function):
+                if condition.volume in self.manifold_subdomains or isinstance(
+                    self.temperature_fenics, fem.Function
+                ):
                     temperature = condition.volume.sub_T
                 else:
                     temperature = self.temperature_fenics
@@ -1768,6 +1770,9 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                 unique_species.append(species)
         nb_species = len(unique_species)
 
+        # A radial surface is a point in a 1D mesh. Basix only supports P0 there.
+        if subdomain.submesh.topology.dim == 0:
+            element_degree = 0
         element_CG = basix.ufl.element(
             basix.ElementFamily.P,
             subdomain.submesh.basix_cell(),
@@ -1780,7 +1785,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         u_n = dolfinx.fem.Function(V)
 
         self.subdomain_to_V_CG1[subdomain] = dolfinx.fem.functionspace(
-            subdomain.submesh, ("CG", 1)
+            subdomain.submesh, ("CG", 0 if subdomain.submesh.topology.dim == 0 else 1)
         )
 
         # store attributes in the subdomain object
@@ -1859,7 +1864,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                 V = spe.subdomain_to_function_space[drift_term.subdomain]
                 drift_term.convert_inputs(
                     function_space=V,
-                    t=self.t,
+                    t=self.subdomain_time(drift_term.subdomain),
                     temperature=self.subdomain_temperature(drift_term.subdomain),
                 )
 
@@ -2281,11 +2286,16 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         cannot tabulate a parent-mesh coefficient on submesh cells.
         """
         for reaction in self.reactions:
+            manifold = reaction.volume in self.manifold_subdomains
             for rate in reaction.rate_coefficients:
                 if rate.input_value is not None:
                     rate.convert_input_value(
-                        function_space=getattr(self, "function_space", None),
-                        t=self.t,
+                        function_space=(
+                            reaction.volume.u.function_space
+                            if manifold
+                            else getattr(self, "function_space", None)
+                        ),
+                        t=self.subdomain_time(reaction.volume),
                         temperature=self.subdomain_temperature(reaction.volume),
                         subdomain=reaction.volume,
                         up_to_ufl_expr=True,
@@ -2396,12 +2406,8 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
             subdomain (F.VolumeSubdomain): a subdomain of the geometry
         """
         is_manifold = subdomain.codim(self.mesh.vdim) == 1
-        if is_manifold and self.mesh.coordinate_system != CoordinateSystem.CARTESIAN:
-            raise NotImplementedError(
-                "codimensional subdomains are only supported in cartesian coordinates, "
-                f"not {self.mesh.coordinate_system}"
-            )
         dx = self.subdomain_measure(subdomain)
+        integration_mesh = subdomain.submesh if is_manifold else self.mesh.mesh
         # the self terms are integrated over subdomain's own mesh, so their coefficients
         # must live there too -- for a manifold that is its submesh, not the parent mesh
         dt = self.subdomain_dt(subdomain) if self.settings.transient else None
@@ -2419,16 +2425,16 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
             if self.settings.transient:
                 self_form += ((u - u_n) / dt) * v * dx
 
-            if spe.mobile:
+            if spe.mobile and subdomain.submesh.topology.dim > 0:
                 D = self.diffusion_coefficient(subdomain, spe)
                 match self.mesh.coordinate_system:
                     case CoordinateSystem.CARTESIAN:
                         self_form += ufl.dot(D * ufl.grad(u), ufl.grad(v)) * dx
                     case CoordinateSystem.CYLINDRICAL:
-                        r = ufl.SpatialCoordinate(self.mesh.mesh)[0]
+                        r = ufl.SpatialCoordinate(integration_mesh)[0]
                         self_form += r * ufl.dot(D * ufl.grad(u), ufl.grad(v / r)) * dx
                     case CoordinateSystem.SPHERICAL:
-                        r = ufl.SpatialCoordinate(self.mesh.mesh)[0]
+                        r = ufl.SpatialCoordinate(integration_mesh)[0]
                         self_form += (
                             r**2 * ufl.dot(D * ufl.grad(u), ufl.grad(v / r**2)) * dx
                         )
@@ -2440,6 +2446,9 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         # add drift (advection, Soret, electromigration)
         for drift_term in self.drift_terms:
             if drift_term.subdomain != subdomain:
+                continue
+            if subdomain.submesh.topology.dim == 0:
+                # A point has no tangential direction in which a species can drift.
                 continue
 
             for spe in drift_term.species:
@@ -2461,7 +2470,7 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                     velocity=velocity,
                     dx=dx,
                     coordinate_system=self.mesh.coordinate_system,
-                    mesh=self.mesh.mesh,
+                    mesh=integration_mesh,
                 )
 
         # add fluxes. These are always parent-mesh integrals: a flux on a manifold
@@ -2522,7 +2531,11 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
             subdomain.F = form_coupling
             # self_form is still the integer 0 if the manifold carries no equation of
             # its own, in which case there is nothing to assemble over the submesh
-            subdomain.F_submesh = self_form if isinstance(self_form, ufl.Form) else None
+            subdomain.F_submesh = (
+                self_form
+                if isinstance(self_form, ufl.Form) and self_form.arguments()
+                else None
+            )
         else:
             subdomain.F = self_form + form_coupling
             subdomain.F_submesh = None
@@ -2888,12 +2901,14 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                     continue
                 J.append([ufl.derivative(form, unknown) for unknown in all_unknowns])
             J_groups.append(J)
-        if len(groups) > 1:
+        if self.manifold_subdomains:
             # a block differentiated with respect to an unknown it does not depend on
             # would otherwise send DOLFINx looking for an entity map between two
-            # sibling submeshes, which does not exist
+            # sibling submeshes, which does not exist. A steady point manifold can
+            # have only coupling terms, so this also applies to a single group.
             J_groups = [prune_empty_blocks(J) for J in J_groups]
 
+        if len(groups) > 1:
             # the padded rows must still carry their function spaces: the blocked
             # matrix and the PETSc index sets are both built from this group alone, and
             # an all-None row leaves them with nothing to deduce the block from
@@ -3201,6 +3216,8 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
         # filename: the first one to claim it truncates, the rest append as new blocks
         initialised_files = set()
         for export in self.exports:
+            if isinstance(export, exports.VolumeQuantity | exports.SurfaceQuantity):
+                export.coordinate_system = self.mesh.coordinate_system
             if isinstance(export, exports.FieldExportBase):
                 self._register_export_milestones(export)
                 functions, names, mesh = self._export_context(export)
@@ -3442,8 +3459,6 @@ class HydrogenTransportProblemDiscontinuous(HydrogenTransportProblem):
                 # a manifold mirrors a constant temperature onto its own submesh, and
                 # that mirror has to follow the parent constant
                 for subdomain in self.manifold_subdomains:
-                    # NOTE: current limitation for manifolds, temperature on the manifold
-                    # has to be homogeneous (ie. fem.Constant)
                     subdomain.sub_T.value = float(self.temperature_fenics)
 
     def iterate(self):

--- a/src/festim/initial_condition.py
+++ b/src/festim/initial_condition.py
@@ -9,6 +9,7 @@ import numpy as np
 import ufl
 from dolfinx import fem
 
+from festim.helpers import spatial_coordinate
 from festim.species import Species
 from festim.subdomain.volume_subdomain import VolumeSubdomain
 
@@ -146,7 +147,7 @@ class InitialConcentration(InitialConditionBase):
             temperature: the temperature
             function_space: the function space of the species
         """
-        x = ufl.SpatialCoordinate(mesh)
+        x = spatial_coordinate(mesh)
 
         if isinstance(self.value, int | float):
             self.expr_fenics = lambda x: np.full(x.shape[1], self.value)

--- a/src/festim/mesh/mesh.py
+++ b/src/festim/mesh/mesh.py
@@ -1,3 +1,4 @@
+import math
 from enum import Enum
 
 import dolfinx
@@ -6,6 +7,8 @@ import ufl
 from dolfinx.mesh import Mesh as dolfinx_Mesh
 from dolfinx.mesh import meshtags
 
+from festim.helpers import spatial_coordinate
+
 __all__ = ["CoordinateSystem", "Mesh"]
 
 
@@ -13,6 +16,19 @@ class CoordinateSystem(Enum):
     CARTESIAN = 10
     CYLINDRICAL = 20
     SPHERICAL = 30
+
+    def integration_weight(self, mesh):
+        """Physical measure per unit mesh measure, assuming full angular coverage.
+
+        Use the integration domain's coordinates, including when it is a manifold
+        submesh. Cylindrical 1D quantities are per unit axial length.
+        """
+        if self == CoordinateSystem.CARTESIAN:
+            return 1
+        r = spatial_coordinate(mesh)[0]
+        if self == CoordinateSystem.CYLINDRICAL:
+            return 2 * math.pi * r
+        return 4 * math.pi * r**2
 
     @classmethod
     def from_string(cls, s: str):

--- a/src/festim/mesh/mesh_1d.py
+++ b/src/festim/mesh/mesh_1d.py
@@ -152,7 +152,7 @@ class Mesh1D(Mesh):
 
     def define_meshtags(self, surface_subdomains, volume_subdomains, interfaces=None):
         # check if all borders are defined
-        self.check_borders(volume_subdomains)
+        self.check_borders([v for v in volume_subdomains if v.codim(self.vdim) == 0])
         return super().define_meshtags(
             surface_subdomains, volume_subdomains, interfaces
         )

--- a/src/festim/species.py
+++ b/src/festim/species.py
@@ -3,7 +3,7 @@ from typing import Union
 import ufl
 from dolfinx import fem
 
-from festim.helpers import as_fenics_constant
+from festim.helpers import as_fenics_constant, spatial_coordinate
 from festim.subdomain.volume_subdomain import (
     VolumeSubdomain as _VolumeSubdomain,
 )
@@ -199,7 +199,7 @@ class ImplicitSpecies:
             mesh (dolfinx.mesh.Mesh) : the mesh
             t (dolfinx.fem.Constant): the time
         """
-        x = ufl.SpatialCoordinate(mesh)
+        x = spatial_coordinate(mesh)
 
         if isinstance(self.n, int | float):
             self.value_fenics = as_fenics_constant(mesh=mesh, value=self.n)

--- a/src/festim/subdomain/volume_subdomain.py
+++ b/src/festim/subdomain/volume_subdomain.py
@@ -39,9 +39,10 @@ class VolumeSubdomain:
             its submesh. ``None`` for a codim-0 subdomain
         dim: the topological dimension of the subdomain. Defaults to ``None``, meaning
             the dimension of the mesh. Set it to ``mesh_dim - 1`` to solve a transport
-            equation on a manifold embedded in the mesh (a line in a 2D mesh, a surface
-            in a 3D mesh). Such a subdomain is tagged in the *facet* meshtags, and can
-            be used wherever a surface is expected (eg. ``ParticleFluxBC``).
+            equation on a manifold embedded in the mesh (a point in a 1D mesh, a line
+            in a 2D mesh, a surface in a 3D mesh). A point carries storage and reactions
+            but no tangential transport. Such a subdomain is tagged in *facet* meshtags,
+            and can be used wherever a surface is expected (eg. ``ParticleFluxBC``).
     """
 
     id: int
@@ -83,8 +84,8 @@ class VolumeSubdomain:
     def dim(self, value):
         if value is not None and not isinstance(value, int | np.integer):
             raise TypeError(f"dim must be an integer or None, not {type(value)}")
-        if value is not None and value < 1:
-            raise ValueError(f"dim must be strictly positive, got {value}")
+        if value is not None and value < 0:
+            raise ValueError(f"dim must be non-negative, got {value}")
         self._dim = None if value is None else int(value)
 
     def codim(self, mesh_dim: int) -> int:

--- a/test/system_tests/test_codim1_coordinates.py
+++ b/test/system_tests/test_codim1_coordinates.py
@@ -1,0 +1,303 @@
+"""Radial transport coupled to manifolds, including point surfaces in 1D."""
+
+from mpi4py import MPI
+
+import dolfinx
+import numpy as np
+import pytest
+import ufl
+
+import festim as F
+
+from .tools import error_L2
+
+
+@pytest.mark.parametrize(
+    "coordinates,power", [("cartesian", 0), ("cylindrical", 1), ("spherical", 2)]
+)
+@pytest.mark.parametrize("interior", [False, True])
+@pytest.mark.parametrize("transient", [False, True])
+def test_radial_point_coupling(coordinates, power, interior, transient):
+    """c_left=r+t, c_gamma=3+t, c_right=r+2+t exchange -1 and +1.
+
+    The point at r=2 represents a cylindrical/spherical surface. Its storage and
+    source must balance the bulk flux density, independently of physical area.
+    """
+    material = F.Material(D_0=1, E_D=0)
+    left = F.VolumeSubdomain1D(id=1, borders=[1, 2], material=material)
+    gamma = F.VolumeSubdomain(
+        id=3, dim=0, material=material, locator=lambda x: np.isclose(x[0], 2)
+    )
+    inner = F.SurfaceSubdomain(id=4, locator=lambda x: np.isclose(x[0], 1))
+    bulk = F.Species("left", subdomains=[left])
+    surface = F.Species("surface", subdomains=[gamma])
+    subdomains = [left, gamma, inner]
+    species = [bulk, surface]
+    bcs = [F.FixedConcentrationBC(inner, value=lambda t: 1 + t, species=bulk)]
+    sources = [
+        F.ParticleSource(
+            volume=left, value=lambda x: int(transient) - power / x[0], species=bulk
+        ),
+        F.ParticleSource(
+            volume=gamma,
+            value=lambda x: x[0] / 2 * (float(transient) + (0 if interior else 1)),
+            species=surface,
+        ),
+    ]
+    initial = []
+    if transient:
+        initial = [
+            F.InitialConcentration(value=lambda x: x[0], volume=left, species=bulk),
+            F.InitialConcentration(
+                value=lambda x, T: (T - 499 + x[0] + 1) / 2,
+                volume=gamma,
+                species=surface,
+            ),
+        ]
+    fluxes = [F.SurfaceFlux(field=bulk, surface=gamma)]
+    if interior:
+        right = F.VolumeSubdomain1D(id=2, borders=[2, 3], material=material)
+        outer = F.SurfaceSubdomain(id=5, locator=lambda x: np.isclose(x[0], 3))
+        other = F.Species("right", subdomains=[right])
+        species.append(other)
+        subdomains += [right, outer]
+        bcs.append(F.FixedConcentrationBC(outer, value=lambda t: 5 + t, species=other))
+        sources.append(
+            F.ParticleSource(
+                volume=right,
+                value=lambda x: int(transient) - power / x[0],
+                species=other,
+            )
+        )
+        fluxes.append(F.SurfaceFlux(field=other, surface=gamma))
+        if transient:
+            initial.append(
+                F.InitialConcentration(
+                    value=lambda x: x[0] + 2, volume=right, species=other
+                )
+            )
+
+    for sp in species:
+        if sp is surface:
+            continue
+        dependencies = {"c_b": sp, "c_g": surface}
+        bcs.append(
+            F.ParticleFluxBC(
+                gamma,
+                species=sp,
+                value=lambda c_b, c_g: c_g - c_b,
+                species_dependent_value=dependencies,
+            )
+        )
+        sources.append(
+            F.ParticleSource(
+                volume=gamma,
+                species=surface,
+                value=lambda c_b, c_g: c_b - c_g,
+                species_dependent_value=dependencies,
+            )
+        )
+
+    total = F.TotalVolume(field=surface, volume=gamma)
+    average = F.AverageVolume(field=surface, volume=gamma)
+    surface_total = F.TotalSurface(field=bulk, surface=gamma)
+    model = F.HydrogenTransportProblemDiscontinuous(
+        mesh=F.Mesh1D(
+            np.linspace(1, 3 if interior else 2, 129), coordinate_system=coordinates
+        ),
+        subdomains=subdomains,
+        species=species,
+        sources=sources,
+        boundary_conditions=bcs,
+        initial_conditions=initial,
+        temperature=lambda x: 500 + x[0],
+        exports=[total, average, surface_total, *fluxes],
+        settings=F.Settings(
+            transient=transient,
+            stepsize=F.Stepsize(0.1),
+            final_time=0.2,
+            atol=1e-11,
+            rtol=1e-11,
+        ),
+    )
+    model.show_progress_bar = False
+    model.initialise()
+    model.run()
+    time = 0.2 if transient else 0
+    area = {0: 1, 1: 4 * np.pi, 2: 16 * np.pi}[power]
+    assert average.value == pytest.approx(3 + time, rel=2e-5)
+    assert total.value == pytest.approx(area * (3 + time), rel=2e-5)
+    assert surface_total.value == pytest.approx(area * (2 + time), rel=2e-5)
+    assert fluxes[0].value == pytest.approx(-area, rel=2e-4)
+    if interior:
+        assert fluxes[1].value == pytest.approx(area, rel=2e-4)
+    c = bulk.subdomain_to_post_processing_solution[left]
+    assert error_L2(c, ufl.SpatialCoordinate(left.submesh)[0] + time) < 2e-5
+
+
+@pytest.mark.parametrize("speed", [0.0, 0.6])
+def test_cylindrical_manifold_radial_transport(speed):
+    """A radial manifold: c_bulk=r²(1+z)+z², c_gamma=r²/2, J=r².
+
+    The radius varies along Gamma, exposing a missing metric derivative in both
+    tangential diffusion and drift. The ambient velocity's normal part is ignored.
+    """
+    mesh = dolfinx.mesh.create_rectangle(
+        MPI.COMM_WORLD, [np.array([1.0, 0.0]), np.array([2.0, 1.0])], [32, 32]
+    )
+    bulk = F.VolumeSubdomain(id=1, material=F.Material(D_0=1, E_D=0))
+    gamma = F.VolumeSubdomain(
+        id=2,
+        dim=1,
+        material=F.Material(D_0=0.7, E_D=0),
+        locator=lambda x: np.isclose(x[1], 0),
+    )
+    walls = F.SurfaceSubdomain(
+        id=3,
+        locator=lambda x: (
+            np.isclose(x[0], 1) | np.isclose(x[0], 2) | np.isclose(x[1], 1)
+        ),
+    )
+    ends = F.SurfaceSubdomain(
+        id=4, dim=0, locator=lambda x: np.isclose(x[0], 1) | np.isclose(x[0], 2)
+    )
+    outlet = F.SurfaceSubdomain(id=5, dim=0, locator=lambda x: np.isclose(x[0], 2))
+    c_b = F.Species("bulk", subdomains=[bulk])
+    c_g = F.Species("manifold", subdomains=[gamma])
+    dependencies = {"c_b": c_b, "c_g": c_g}
+    total = F.TotalVolume(c_g, gamma)
+    average = F.AverageVolume(c_g, gamma)
+    surface_total = F.TotalSurface(c_b, gamma)
+    surface_average = F.AverageSurface(c_b, gamma)
+    exchange = F.SurfaceFlux(c_b, gamma)
+    outlet_flux = F.SurfaceFlux(c_g, outlet)
+    velocity = dolfinx.fem.Function(dolfinx.fem.functionspace(mesh, ("P", 1, (2,))))
+    velocity.interpolate(lambda x: np.tile([speed, 0.8], (x.shape[1], 1)).T)
+    model = F.HydrogenTransportProblemDiscontinuous(
+        mesh=F.Mesh(mesh, coordinate_system="cylindrical"),
+        subdomains=[bulk, gamma, walls, ends, outlet],
+        species=[c_b, c_g],
+        temperature=500,
+        settings=F.Settings(transient=False, atol=1e-11, rtol=1e-11),
+        boundary_conditions=[
+            F.FixedConcentrationBC(
+                walls, value=lambda x: x[0] ** 2 * (1 + x[1]) + x[1] ** 2, species=c_b
+            ),
+            F.FixedConcentrationBC(ends, value=lambda x: 0.5 * x[0] ** 2, species=c_g),
+            F.ParticleFluxBC(
+                gamma,
+                value=lambda c_b, c_g: 2 * (c_g - c_b),
+                species=c_b,
+                species_dependent_value=dependencies,
+            ),
+        ],
+        sources=[
+            F.ParticleSource(volume=bulk, species=c_b, value=lambda x: -6 - 4 * x[1]),
+            F.ParticleSource(
+                volume=gamma,
+                species=c_g,
+                value=lambda x: -1.4 - x[0] ** 2 + 1.5 * speed * x[0],
+            ),
+            F.ParticleSource(
+                volume=gamma,
+                species=c_g,
+                value=lambda c_b, c_g: 2 * (c_b - c_g),
+                species_dependent_value=dependencies,
+            ),
+        ],
+        drift_terms=[
+            F.AdvectionTerm(
+                velocity=velocity,
+                subdomain=gamma,
+                species=c_g,
+            )
+        ]
+        if speed
+        else [],
+        exports=[total, average, surface_total, surface_average, exchange, outlet_flux],
+    )
+    model.initialise()
+    model.run()
+    x_b = ufl.SpatialCoordinate(bulk.submesh)
+    x_g = ufl.SpatialCoordinate(gamma.submesh)
+    assert (
+        error_L2(
+            c_b.subdomain_to_post_processing_solution[bulk],
+            x_b[0] ** 2 * (1 + x_b[1]) + x_b[1] ** 2,
+        )
+        < 1e-3
+    )
+    assert (
+        error_L2(c_g.subdomain_to_post_processing_solution[gamma], 0.5 * x_g[0] ** 2)
+        < 1e-3
+    )
+    assert total.value == pytest.approx(15 * np.pi / 4, rel=1e-3)
+    assert average.value == pytest.approx(1.25, rel=1e-3)
+    assert surface_total.value == pytest.approx(15 * np.pi / 2, rel=1e-3)
+    assert surface_average.value == pytest.approx(2.5, rel=1e-3)
+    # Fluxes use the P1 gradient, which is only first-order accurate.
+    assert exchange.value == pytest.approx(15 * np.pi / 2, rel=0.04)
+    assert outlet_flux.value == pytest.approx(4 * np.pi * (2 * speed - 1.4), abs=0.2)
+
+
+def test_spherical_point_trapping():
+    """Two independent point surfaces retain their own coordinates and inventories.
+
+    With n_traps=c_initial=r and irreversible trapping, c_mobile'=-k*c_mobile².
+    Compare each backward-Euler step with the positive root of that quadratic.
+    """
+    material = F.Material(D_0=1, E_D=0)
+    bulk = F.VolumeSubdomain1D(id=1, borders=[1, 3], material=material)
+    gamma = F.VolumeSubdomain(
+        id=2,
+        dim=0,
+        material=material,
+        locator=lambda x: np.isclose(x[0], 1.5) | np.isclose(x[0], 2.5),
+    )
+    bulk_species = F.Species("bulk", subdomains=[bulk])
+    mobile = F.Species("mobile", subdomains=[gamma])
+    trapped = F.Species("trapped", mobile=False, subdomains=[gamma])
+    empty = F.ImplicitSpecies(n=lambda x: x[0], others=[trapped])
+    total_mobile = F.TotalVolume(mobile, gamma)
+    total_trapped = F.TotalVolume(trapped, gamma)
+    model = F.HydrogenTransportProblemDiscontinuous(
+        mesh=F.Mesh1D(np.linspace(1, 3, 17), coordinate_system="spherical"),
+        subdomains=[bulk, gamma],
+        species=[bulk_species, mobile, trapped],
+        initial_conditions=[
+            F.InitialConcentration(value=lambda x: x[0], volume=gamma, species=mobile)
+        ],
+        reactions=[
+            F.GenericReaction(
+                reactant=[mobile, empty],
+                product=trapped,
+                volume=gamma,
+                forward_rate=lambda x, t, T: x[0] * (1 + t) / T,
+            )
+        ],
+        temperature=lambda x, t: 500 + x[0] + t,
+        settings=F.Settings(
+            transient=True,
+            stepsize=F.Stepsize(0.1),
+            final_time=0.2,
+            atol=1e-12,
+            rtol=1e-12,
+        ),
+        exports=[total_mobile, total_trapped],
+    )
+    model.show_progress_bar = False
+    model.initialise()
+    model.run()
+    radii = np.array([1.5, 2.5])
+    expected = radii.copy()
+    for time in (0.1, 0.2):
+        coefficient = 0.1 * radii * (1 + time) / (500 + radii + time)
+        expected = 2 * expected / (1 + np.sqrt(1 + 4 * coefficient * expected))
+    weights = 4 * np.pi * radii**2
+    assert total_mobile.value == pytest.approx(np.dot(weights, expected), rel=1e-10)
+    assert total_trapped.value == pytest.approx(
+        np.dot(weights, radii - expected), rel=1e-9
+    )
+    assert total_mobile.value + total_trapped.value == pytest.approx(
+        np.dot(weights, radii), rel=1e-12
+    )

--- a/test/test_codim1_subdomain.py
+++ b/test/test_codim1_subdomain.py
@@ -18,14 +18,14 @@ def unit_square(n=8):
 
 @pytest.mark.parametrize(
     "dim, mesh_dim, expected",
-    [(None, 2, 0), (2, 2, 0), (1, 2, 1), (2, 3, 1), (3, 3, 0)],
+    [(None, 2, 0), (2, 2, 0), (1, 2, 1), (2, 3, 1), (3, 3, 0), (0, 1, 1)],
 )
 def test_codim(dim, mesh_dim, expected):
     subdomain = F.VolumeSubdomain(id=1, material=F.Material(D_0=1, E_D=0), dim=dim)
     assert subdomain.codim(mesh_dim) == expected
 
 
-@pytest.mark.parametrize("dim, mesh_dim", [(1, 3), (1, 4), (3, 2)])
+@pytest.mark.parametrize("dim, mesh_dim", [(1, 3), (1, 4), (3, 2), (0, 2)])
 def test_codim_out_of_range_raises(dim, mesh_dim):
     """Only codimensions 0 and 1 are supported."""
     subdomain = F.VolumeSubdomain(id=1, material=F.Material(D_0=1, E_D=0), dim=dim)
@@ -39,9 +39,9 @@ def test_dim_type_validation(dim):
         F.VolumeSubdomain(id=1, material=F.Material(D_0=1, E_D=0), dim=dim)
 
 
-@pytest.mark.parametrize("dim", [0, -1])
-def test_dim_must_be_positive(dim):
-    with pytest.raises(ValueError, match="strictly positive"):
+@pytest.mark.parametrize("dim", [-1, -2])
+def test_dim_must_be_non_negative(dim):
+    with pytest.raises(ValueError, match="non-negative"):
         F.VolumeSubdomain(id=1, material=F.Material(D_0=1, E_D=0), dim=dim)
 
 


### PR DESCRIPTION
## Description

`v2.2-rc.2` released co-dimensional subdomains but only for cartesian coordinates. This adds functionality for cylindrical and cartesian coordinates. 

### Related Issues
Fixes  #1263 

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Code refactoring (no functional changes, no API changes)
- [ ] 📝 Documentation update
- [ ] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI configuration change

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [X] All existing tests pass locally (`pytest`)
- [X] I have added new tests that prove my fix is effective or that my feature works


## Code Quality Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [X] My code follows the code style of this project (Ruff formatted: `ruff format .`)
- [X] My code passes linting checks (`ruff check .`)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas

## Documentation

<!-- Put an `x` in the boxes that apply -->

- [X] I have updated the documentation accordingly (if applicable)
- [X] I have added docstrings to new functions/classes following the project conventions

## Screenshots/Examples
Here is a small mwe: 

```python

from mpi4py import MPI

import dolfinx
import numpy as np

import festim as F


def run(name, mesh):
    bulk = F.VolumeSubdomain(id=1, material=F.Material(D_0=1, E_D=0))
    surface = F.VolumeSubdomain(  # the co-dim part 
        id=2,
        dim=mesh.vdim - 1,
        locator=lambda x: np.isclose(x[0], 1.0),
        material=F.Material(D_0=0.1, E_D=0),
    )
    c_bulk = F.Species("bulk", subdomains=[bulk])
    c_surface = F.Species("surface", subdomains=[surface])
    dependencies = {"cb": c_bulk, "cs": c_surface}

    # Hydrogen initially in the bulk transfers to the initially empty surface.
    # The pipe starts with an axial gradient so its surface profile is nonuniform.
    model = F.HydrogenTransportProblemDiscontinuous(
        mesh=mesh,
        subdomains=[bulk, surface],
        species=[c_bulk, c_surface],
        temperature=500,
        initial_conditions=[
            F.InitialConcentration(
                value=(lambda x: 1 + x[1]) if name == "pipe" else 1.0,
                species=c_bulk,
                volume=bulk,
            ),
        ],
        boundary_conditions=[
            F.ParticleFluxBC(
                subdomain=surface,
                species=c_bulk,
                value=lambda cb, cs: cs - cb,  # assume k = 1
                species_dependent_value=dependencies,
            ),
        ],
        sources=[
            F.ParticleSource(
                volume=surface,
                species=c_surface,
                value=lambda cb, cs: cb - cs,
                species_dependent_value=dependencies,
            ),
        ],
        # A codim manifold carries its own equation, so use a volume quantity.
        exports=[
            F.AverageVolume(
                field=c_surface,
                volume=surface,
                filename=f"{name}_surface.csv",
            ),
        ],
        settings=F.Settings(
            transient=True,
            stepsize=0.01,
            final_time=0.2,
            atol=1e-10,
            rtol=1e-10,
        ),
    )
    model.initialise()
    model.run()


# Pipe: inner radius 0.5, outer radius 1, length 2; outer wall has dim=1.
pipe = dolfinx.mesh.create_rectangle(
    MPI.COMM_WORLD, [np.array([0.5, 0.0]), np.array([1.0, 2.0])], [8, 24]
)
run("pipe", F.Mesh(pipe, coordinate_system="cylindrical"))

# Ball: radius 1; outer spherical surface has dim=0 in the radial mesh.
ball = dolfinx.mesh.create_interval(MPI.COMM_WORLD, 32, [0.0, 1.0])
run("ball", F.Mesh(ball, coordinate_system="spherical"))

```
